### PR TITLE
fix: refresh config on each event to pick up secrets reload 

### DIFF
--- a/src/channel/monitor.ts
+++ b/src/channel/monitor.ts
@@ -45,7 +45,7 @@ async function monitorSingleAccount(params: {
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
 }): Promise<void> {
-  const { cfg, account, runtime, abortSignal } = params;
+  const { account, runtime, abortSignal } = params;
   const { accountId } = account;
   const log = runtime?.log ?? ((...args: unknown[]) => mlog.info(args.map(String).join(' ')));
   const error = runtime?.error ?? ((...args: unknown[]) => mlog.error(args.map(String).join(' ')));
@@ -79,7 +79,9 @@ async function monitorSingleAccount(params: {
   const chatHistories = new Map<string, HistoryEntry[]>();
 
   const ctx: MonitorContext = {
-    cfg,
+    get cfg() {
+      return LarkClient.runtime.config.loadConfig();
+    },
     lark,
     accountId,
     chatHistories,


### PR DESCRIPTION
Fixes #3

The monitor captured `cfg` at startup and stored it in MonitorContext. After `secrets reload`, the runtime config snapshot is replaced with a new object, but the monitor closure still held the stale reference, causing the Feishu channel to keep using expired API keys.

Replace the static `cfg` field with a getter that calls `loadConfig()` on every access, ensuring event handlers always read the latest resolved config.