### PR TITLE
feat: add ownerOnly configuration to UAT and update access checks

### DIFF
--- a/src/core/config-schema.ts
+++ b/src/core/config-schema.ts
@@ -117,6 +117,7 @@ const ReactionNotificationModeSchema = z.enum(['off', 'own', 'all']).optional();
 export const UATConfigSchema = z
   .object({
     enabled: z.boolean().optional(),
+    ownerOnly: z.boolean().optional(),
     allowedScopes: z.array(z.string()).optional(),
     blockedScopes: z.array(z.string()).optional(),
   })

--- a/src/core/tool-client.ts
+++ b/src/core/tool-client.ts
@@ -330,8 +330,11 @@ export class ToolClient {
       });
     }
 
-    // Owner 检查：非 owner 用户直接拒绝（从 uat-client.ts 迁移至此）
-    await assertOwnerAccessStrict(this.account, this.sdk, userOpenId);
+    // Owner 检查：仅在 ownerOnly 模式下执行（默认 true）
+    const ownerOnly = this.account.config?.uat?.ownerOnly ?? true;
+    if (ownerOnly) {
+      await assertOwnerAccessStrict(this.account, this.sdk, userOpenId);
+    }
 
     // 预检：是否有已存储的 token
     const stored = await getStoredToken(this.account.appId, userOpenId);

--- a/src/tools/oauth.ts
+++ b/src/tools/oauth.ts
@@ -276,18 +276,21 @@ export async function executeAuthorize(
   const { appId, appSecret, brand, accountId } = account;
 
   // 0. Check if the user is the app owner (fail-close: 安全优先).
-  const sdk = LarkClient.fromAccount(account).sdk;
-  try {
-    await assertOwnerAccessStrict(account, sdk, senderOpenId);
-  } catch (err) {
-    if (err instanceof OwnerAccessDeniedError) {
-      log.warn(`non-owner user ${senderOpenId} attempted to authorize`);
-      return json({
-        error: 'permission_denied',
-        message: '当前应用仅限所有者（App Owner）使用。您没有权限发起授权，无法使用相关功能。',
-      });
+  const ownerOnly = account.config?.uat?.ownerOnly ?? true;
+  if (ownerOnly) {
+    const sdk = LarkClient.fromAccount(account).sdk;
+    try {
+      await assertOwnerAccessStrict(account, sdk, senderOpenId);
+    } catch (err) {
+      if (err instanceof OwnerAccessDeniedError) {
+        log.warn(`non-owner user ${senderOpenId} attempted to authorize`);
+        return json({
+          error: 'permission_denied',
+          message: '当前应用仅限所有者（App Owner）使用。您没有权限发起授权，无法使用相关功能。',
+        });
+      }
+      throw err;
     }
-    throw err;
   }
 
   // effectiveScope：可变 scope 变量，后续可能因 pendingFlow 合并而扩大


### PR DESCRIPTION
增加了ownerOnly ,用于检查是否仅owner可以操作.

```
{
    "channels": {
        "feishu": {
            "uat": {
                "uat": {
                    "ownerOnly": false
                }
            }
        }
    }
}

```