### PR TITLE
fix: change openclaw version to ^2026.2.26 for version compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "execa": "^9.6.0",
     "fs-extra": "^11.3.2",
     "minimist": "^1.2.8",
-    "openclaw": "2026.2.26",
+    "openclaw": "^2026.2.26",
     "prettier": "^3.8.1",
     "typescript": "^5.9.3"
   },


### PR DESCRIPTION
## 问题描述

按照 README 说明运行 `feishu-plugin-onboard install` 安装插件时，提示 OpenClaw 版本需要升级，但当前安装的版本 `2026.3.8` 已高于 README 中要求的最低版本 `2026.2.26`。

## 根本原因

`package.json` 中 `devDependencies` 里的 `openclaw` 版本被精确 pin 为 `"2026.2.26"`（无 `^` 或 `>=` 前缀），而 OpenClaw 安装器在做版本兼容性检查时将其解读为**精确版本匹配**，导致 `2026.3.8` 被误判为不符合要求。

## 修复方案

将版本改为 `^2026.2.26`，允许 >= 2026.2.26 的版本通过。

## 测试

修复后，2026.3.8 版本可以正常安装插件，不再出现版本升级提示。

---

## 相关 Issue

N/A 