### PR TITLE
fix(feishu): register no-op handlers for common WS events

### DIFF
--- a/src/channel/monitor.ts
+++ b/src/channel/monitor.ts
@@ -94,6 +94,11 @@ async function monitorSingleAccount(params: {
       'im.message.receive_v1': (data) => handleMessageEvent(ctx, data),
       'im.message.message_read_v1': async () => {},
       'im.message.reaction.created_v1': (data) => handleReactionEvent(ctx, data),
+      // These events are expected in normal usage but do not affect the
+      // plugin's current behavior. Register no-op handlers to avoid SDK
+      // warnings about missing handlers.
+      'im.message.reaction.deleted_v1': async () => {},
+      'im.chat.access_event.bot_p2p_chat_entered_v1': async () => {},
       'im.chat.member.bot.added_v1': (data) => handleBotMembershipEvent(ctx, data, 'added'),
       'im.chat.member.bot.deleted_v1': (data) => handleBotMembershipEvent(ctx, data, 'removed'),
       // 飞书 SDK EventDispatcher.register 不支持带返回值的处理器，此处 as any 是 SDK 类型限制的变通


### PR DESCRIPTION
## Summary
- register no-op handlers for `im.message.reaction.deleted_v1` and `im.chat.access_event.bot_p2p_chat_entered_v1`
- suppress avoidable Lark SDK warning noise for events that are expected in normal usage but currently do not affect plugin behavior

## Why
I observed these warnings on a live OpenClaw deployment using this plugin after the Feishu WebSocket connection was already healthy and processing messages normally:

```text
2026-03-11T18:18:26.832+08:00 [warn]: [ 'no im.chat.access_event.bot_p2p_chat_entered_v1 handle' ]\n2026-03-11T18:18:28.916+08:00 [feishu] feishu[default]: received message from ...\n2026-03-11T18:18:32.482+08:00 [feishu] feishu[default]: reaction event on message ...\n2026-03-11T18:18:45.155+08:00 [warn]: [ 'no im.message.reaction.deleted_v1 handle' ]\n```\n\nThese warnings come from the Lark SDK event dispatcher when an event type arrives without a registered handler. In this plugin, both events are currently safe to ignore, so registering explicit no-op handlers removes log noise without changing behavior.\n\n## Notes\n- no functional behavior is added for these event types yet\n- this change keeps the current behavior explicit and makes production logs easier to inspect\n\n## Validation\n- `./node_modules/.bin/tsc --noEmit`\n- `./node_modules/.bin/eslint src/channel/monitor.ts index.ts` (existing unrelated warning remains in `index.ts`, no new lint errors from this change)\n