### PR TITLE
fix(plugin): align package metadata with plugin id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@larksuite/openclaw-lark",
+  "name": "@larksuiteoapi/feishu-openclaw-plugin",
   "version": "2026.3.10",
   "description": "OpenClaw Lark/Feishu channel plugin",
   "type": "module",
@@ -55,7 +55,7 @@
       "quickstartAllowFrom": true
     },
     "install": {
-      "npmSpec": "@larksuite/openclaw-lark",
+      "npmSpec": "@larksuiteoapi/feishu-openclaw-plugin",
       "localPath": "extensions/feishu",
       "defaultChoice": "npm"
     }


### PR DESCRIPTION
Fixes #10

## Summary
- change the published package name back to `@larksuiteoapi/feishu-openclaw-plugin`
- align `openclaw.install.npmSpec` with the same package name

## Why
This repository currently publishes package metadata as `@larksuite/openclaw-lark`, while the plugin manifest and exported plugin id are both `feishu-openclaw-plugin`.

On a live OpenClaw deployment this produces the warning below during startup:

```text
Config warnings:
- plugins.entries.feishu-openclaw-plugin: plugin feishu-openclaw-plugin: plugin id mismatch (manifest uses "feishu-openclaw-plugin", entry hints "openclaw-lark")
```

I considered changing the plugin id instead, but that would be riskier because existing installations already use `plugins.entries.feishu-openclaw-plugin` as the config key. Keeping the plugin id stable and aligning the package metadata is the safer compatibility path.

## Validation
- verified that OpenClaw derives the package id hint from the unscoped package name, so after this change `idHint === manifest.id === "feishu-openclaw-plugin"`
- `npm pack --dry-run`

## Compatibility note
This keeps the runtime/plugin config identity unchanged and only fixes the package/install metadata that currently causes the warning.
