### PR TITLE
feat(tools): add a minimal preset for lower context overhead

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,26 @@ Before you start, make sure you have the following:
 
 [How to Use the Official Lark/Feishu Plugin for OpenClaw](https://bytedance.larkoffice.com/docx/MFK7dDFLFoVlOGxWCv5cTXKmnMh)
 
+## Reducing Tool Overhead
+
+If you want a smaller default tool surface and lower prompt/context overhead, use the `minimal` preset and then opt specific capability groups back in:
+
+```json
+{
+  "channels": {
+    "feishu": {
+      "tools": {
+        "preset": "minimal",
+        "calendar": true,
+        "task": true
+      }
+    }
+  }
+}
+```
+
+The `minimal` preset keeps the core messaging/auth/doc path available while disabling heavier capability groups such as calendar, tasks, bitable, wiki, drive, and sheets unless you explicitly re-enable them.
+
 ## Contributing
 
 Community contributions are welcome! If you find a bug or have feature suggestions, please submit an [Issue](https://github.com/larksuite/openclaw-larksuite/issues) or a [Pull Request](https://github.com/larksuite/openclaw-larksuite/pulls).

--- a/README.zh.md
+++ b/README.zh.md
@@ -69,6 +69,26 @@
 ## 使用说明
 [OpenClaw  Lark/飞书官方插件使用指南](https://bytedance.larkoffice.com/docx/MFK7dDFLFoVlOGxWCv5cTXKmnMh)
 
+## 降低工具上下文开销
+
+如果你希望默认注册的工具更少、prompt/context 开销更低，可以使用 `minimal` 预设，再按需打开具体能力组：
+
+```json
+{
+  "channels": {
+    "feishu": {
+      "tools": {
+        "preset": "minimal",
+        "calendar": true,
+        "task": true
+      }
+    }
+  }
+}
+```
+
+`minimal` 预设会保留消息交互 / 授权 / 文档这条核心链路，同时默认关闭日历、任务、多维表格、知识库、云空间、电子表格等较重的能力组，只有在你显式打开时才会注册。
+
 ## 贡献
 
 我们欢迎社区的贡献！如果你发现 Bug 或有功能建议，请随时提交 [Issue](https://github.com/larksuite/openclaw-larksuite/issues) 或 [Pull Request](https://github.com/larksuite/openclaw-larksuite/pulls)。

--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,9 @@
 import type { OpenClawPluginApi } from 'openclaw/plugin-sdk';
 import { emptyPluginConfigSchema } from 'openclaw/plugin-sdk';
 import { feishuPlugin } from './src/channel/plugin';
+import { getEnabledLarkAccounts } from './src/core/accounts';
 import { LarkClient } from './src/core/lark-client';
+import { resolveAnyEnabledToolsConfig } from './src/core/tools-config';
 import { registerOapiTools } from './src/tools/oapi/index';
 import { registerFeishuMcpDocTools } from './src/tools/mcp/doc/index';
 import { registerFeishuOAuthTool } from './src/tools/oauth';
@@ -103,7 +105,7 @@ const plugin = {
   name: 'Feishu',
   description: 'Lark/Feishu channel plugin with im/doc/wiki/drive/task/calendar tools',
   configSchema: emptyPluginConfigSchema(),
-  register(api: OpenClawPluginApi) {
+  register(api: OpenClawPluginApi): void {
     LarkClient.setRuntime(api.runtime);
     api.registerChannel({ plugin: feishuPlugin });
 
@@ -115,11 +117,18 @@ const plugin = {
     // Register MCP doc tools (using Model Context Protocol)
     registerFeishuMcpDocTools(api);
 
-    // Register OAuth tool (UAT device flow authorization)
-    registerFeishuOAuthTool(api);
-
-    // Register OAuth batch auth tool (batch authorization for all app scopes)
-    registerFeishuOAuthBatchAuthTool(api);
+    // Register OAuth tools only when at least one enabled account keeps the
+    // auth capability group enabled.
+    if (api.config) {
+      const accounts = getEnabledLarkAccounts(api.config);
+      const toolsCfg = resolveAnyEnabledToolsConfig(accounts);
+      if (toolsCfg.auth) {
+        registerFeishuOAuthTool(api);
+        registerFeishuOAuthBatchAuthTool(api);
+      } else {
+        api.logger.info?.('feishu_oauth: auth tool group disabled in all accounts');
+      }
+    }
 
     // ---- Tool call hooks (auto-trace AI tool invocations) ----
 

--- a/src/commands/diagnose.ts
+++ b/src/commands/diagnose.ts
@@ -153,16 +153,37 @@ function detectRegisteredTools(config: OpenClawConfig): string[] {
   if (toolsCfg.wiki) tools.push('feishu_wiki');
   if (toolsCfg.drive) tools.push('feishu_drive');
   if (toolsCfg.perm) tools.push('feishu_perm');
-  tools.push(
-    'feishu_bitable_get_meta',
-    'feishu_bitable_list_fields',
-    'feishu_bitable_list_records',
-    'feishu_bitable_get_record',
-    'feishu_bitable_create_record',
-    'feishu_bitable_update_record',
-  );
-  tools.push('feishu_task');
-  tools.push('feishu_calendar');
+  if (toolsCfg.chat) tools.push('feishu_chat', 'feishu_chat_members');
+  if (toolsCfg.im) {
+    tools.push(
+      'feishu_im_user_message',
+      'feishu_im_user_fetch_resource',
+      'feishu_im_user_get_messages',
+      'feishu_im_user_get_thread_messages',
+      'feishu_im_user_search_messages',
+      'feishu_im_bot_image',
+    );
+  }
+  if (toolsCfg.bitable) {
+    tools.push(
+      'feishu_bitable_app',
+      'feishu_bitable_app_table',
+      'feishu_bitable_app_table_record',
+      'feishu_bitable_app_table_field',
+      'feishu_bitable_app_table_view',
+    );
+  }
+  if (toolsCfg.task) tools.push('feishu_task', 'feishu_task_tasklist', 'feishu_task_comment', 'feishu_task_subtask');
+  if (toolsCfg.calendar) {
+    tools.push(
+      'feishu_calendar',
+      'feishu_calendar_event',
+      'feishu_calendar_event_attendee',
+      'feishu_calendar_freebusy',
+    );
+  }
+  if (toolsCfg.sheets) tools.push('feishu_sheet');
+  if (toolsCfg.auth) tools.push('feishu_oauth', 'feishu_oauth_batch_auth');
 
   return tools;
 }

--- a/src/core/config-schema.ts
+++ b/src/core/config-schema.ts
@@ -51,11 +51,21 @@ const ToolPolicySchema = z
 
 const FeishuToolsFlagSchema = z
   .object({
+    preset: z.enum(['full', 'minimal']).optional(),
     doc: z.boolean().optional(),
     wiki: z.boolean().optional(),
     drive: z.boolean().optional(),
     perm: z.boolean().optional(),
     scopes: z.boolean().optional(),
+    chat: z.boolean().optional(),
+    im: z.boolean().optional(),
+    calendar: z.boolean().optional(),
+    task: z.boolean().optional(),
+    bitable: z.boolean().optional(),
+    auth: z.boolean().optional(),
+    mail: z.boolean().optional(),
+    sheets: z.boolean().optional(),
+    okr: z.boolean().optional(),
   })
   .optional();
 

--- a/src/core/tools-config.ts
+++ b/src/core/tools-config.ts
@@ -23,16 +23,48 @@ import type { FeishuToolsConfig, LarkAccount } from './types';
  * permissions is a privileged operation that admins should opt into
  * explicitly.
  */
-export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
+export const FULL_TOOLS_CONFIG: Required<Omit<FeishuToolsConfig, 'preset'>> = {
   doc: true,
   wiki: true,
   drive: true,
   scopes: true,
   perm: false,
+  chat: true,
+  im: true,
+  calendar: true,
+  task: true,
+  bitable: true,
+  auth: true,
   mail: true,
   sheets: true,
   okr: false,
 };
+
+/**
+ * A smaller default tool surface for users who want lower prompt overhead.
+ *
+ * Keeps the core messaging/auth/doc path available while disabling the
+ * heaviest capability groups unless they are explicitly re-enabled.
+ */
+export const MINIMAL_TOOLS_CONFIG: Required<Omit<FeishuToolsConfig, 'preset'>> = {
+  doc: true,
+  wiki: false,
+  drive: false,
+  scopes: false,
+  perm: false,
+  chat: true,
+  im: true,
+  calendar: false,
+  task: false,
+  bitable: false,
+  auth: true,
+  mail: false,
+  sheets: false,
+  okr: false,
+};
+
+/** Backward-compatible alias for the full/default preset. */
+export const DEFAULT_TOOLS_CONFIG = FULL_TOOLS_CONFIG;
 
 // ---------------------------------------------------------------------------
 // Resolver
@@ -45,17 +77,25 @@ export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
  * to the default value.
  */
 export function resolveToolsConfig(cfg?: FeishuToolsConfig): Required<FeishuToolsConfig> {
-  if (!cfg) return { ...DEFAULT_TOOLS_CONFIG };
+  const preset = cfg?.preset ?? 'full';
+  const base = preset === 'minimal' ? MINIMAL_TOOLS_CONFIG : FULL_TOOLS_CONFIG;
 
   return {
-    doc: cfg.doc ?? DEFAULT_TOOLS_CONFIG.doc,
-    wiki: cfg.wiki ?? DEFAULT_TOOLS_CONFIG.wiki,
-    drive: cfg.drive ?? DEFAULT_TOOLS_CONFIG.drive,
-    perm: cfg.perm ?? DEFAULT_TOOLS_CONFIG.perm,
-    scopes: cfg.scopes ?? DEFAULT_TOOLS_CONFIG.scopes,
-    mail: cfg.mail ?? DEFAULT_TOOLS_CONFIG.mail,
-    sheets: cfg.sheets ?? DEFAULT_TOOLS_CONFIG.sheets,
-    okr: cfg.okr ?? DEFAULT_TOOLS_CONFIG.okr,
+    preset,
+    doc: cfg?.doc ?? base.doc,
+    wiki: cfg?.wiki ?? base.wiki,
+    drive: cfg?.drive ?? base.drive,
+    perm: cfg?.perm ?? base.perm,
+    scopes: cfg?.scopes ?? base.scopes,
+    chat: cfg?.chat ?? base.chat,
+    im: cfg?.im ?? base.im,
+    calendar: cfg?.calendar ?? base.calendar,
+    task: cfg?.task ?? base.task,
+    bitable: cfg?.bitable ?? base.bitable,
+    auth: cfg?.auth ?? base.auth,
+    mail: cfg?.mail ?? base.mail,
+    sheets: cfg?.sheets ?? base.sheets,
+    okr: cfg?.okr ?? base.okr,
   };
 }
 
@@ -71,11 +111,18 @@ export function resolveToolsConfig(cfg?: FeishuToolsConfig): Required<FeishuTool
  */
 export function resolveAnyEnabledToolsConfig(accounts: LarkAccount[]): Required<FeishuToolsConfig> {
   const merged: Required<FeishuToolsConfig> = {
+    preset: 'full',
     doc: false,
     wiki: false,
     drive: false,
     perm: false,
     scopes: false,
+    chat: false,
+    im: false,
+    calendar: false,
+    task: false,
+    bitable: false,
+    auth: false,
     mail: false,
     sheets: false,
     okr: false,
@@ -87,6 +134,12 @@ export function resolveAnyEnabledToolsConfig(accounts: LarkAccount[]): Required<
     merged.drive = merged.drive || cfg.drive;
     merged.perm = merged.perm || cfg.perm;
     merged.scopes = merged.scopes || cfg.scopes;
+    merged.chat = merged.chat || cfg.chat;
+    merged.im = merged.im || cfg.im;
+    merged.calendar = merged.calendar || cfg.calendar;
+    merged.task = merged.task || cfg.task;
+    merged.bitable = merged.bitable || cfg.bitable;
+    merged.auth = merged.auth || cfg.auth;
     merged.mail = merged.mail || cfg.mail;
     merged.sheets = merged.sheets || cfg.sheets;
     merged.okr = merged.okr || cfg.okr;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -58,11 +58,18 @@ export type FeishuIdType = 'open_id' | 'user_id' | 'union_id' | 'chat_id';
 
 /** Per-feature toggles for the Feishu-specific tool capabilities. */
 export interface FeishuToolsConfig {
+  preset?: 'full' | 'minimal';
   doc?: boolean;
   wiki?: boolean;
   drive?: boolean;
   perm?: boolean;
   scopes?: boolean;
+  chat?: boolean;
+  im?: boolean;
+  calendar?: boolean;
+  task?: boolean;
+  bitable?: boolean;
+  auth?: boolean;
   mail?: boolean;
   sheets?: boolean;
   okr?: boolean;

--- a/src/tools/oapi/index.ts
+++ b/src/tools/oapi/index.ts
@@ -9,6 +9,8 @@
  */
 
 import type { OpenClawPluginApi } from 'openclaw/plugin-sdk';
+import { getEnabledLarkAccounts } from '../../core/accounts';
+import { resolveAnyEnabledToolsConfig } from '../../core/tools-config';
 import {
   registerFeishuCalendarCalendarTool,
   registerFeishuCalendarEventTool,
@@ -40,50 +42,98 @@ import { registerFeishuSheetsTools } from './sheets/index';
 import { registerFeishuChatTools } from './chat/index';
 import { registerFeishuImTools as registerFeishuImUserTools } from './im/index';
 
-export function registerOapiTools(api: OpenClawPluginApi) {
+export function registerOapiTools(api: OpenClawPluginApi): void {
+  if (!api.config) {
+    api.logger.debug?.('feishu_oapi: No config available, skipping');
+    return;
+  }
+
+  const accounts = getEnabledLarkAccounts(api.config);
+  if (accounts.length === 0) {
+    api.logger.debug?.('feishu_oapi: No Feishu accounts configured, skipping');
+    return;
+  }
+
+  const toolsCfg = resolveAnyEnabledToolsConfig(accounts);
+  const enabledGroups: string[] = [];
+
   // Common tools
-  registerGetUserTool(api);
-  registerSearchUserTool(api);
+  if (toolsCfg.chat || toolsCfg.im || toolsCfg.calendar || toolsCfg.task) {
+    registerGetUserTool(api);
+    registerSearchUserTool(api);
+    enabledGroups.push('common');
+  }
 
   // Chat tools
-  registerFeishuChatTools(api);
+  if (toolsCfg.chat) {
+    registerFeishuChatTools(api);
+    enabledGroups.push('chat');
+  }
 
   // IM tools (user identity)
-  registerFeishuImUserTools(api);
+  if (toolsCfg.im) {
+    registerFeishuImUserTools(api);
+    enabledGroups.push('im');
+  }
 
   // Calendar tools
-  registerFeishuCalendarCalendarTool(api);
-  registerFeishuCalendarEventTool(api);
-  registerFeishuCalendarEventAttendeeTool(api);
-  registerFeishuCalendarFreebusyTool(api);
+  if (toolsCfg.calendar) {
+    registerFeishuCalendarCalendarTool(api);
+    registerFeishuCalendarEventTool(api);
+    registerFeishuCalendarEventAttendeeTool(api);
+    registerFeishuCalendarFreebusyTool(api);
+    enabledGroups.push('calendar');
+  }
 
   // Task tools
-  registerFeishuTaskTaskTool(api);
-  registerFeishuTaskTasklistTool(api);
-  registerFeishuTaskCommentTool(api);
-  registerFeishuTaskSubtaskTool(api);
+  if (toolsCfg.task) {
+    registerFeishuTaskTaskTool(api);
+    registerFeishuTaskTasklistTool(api);
+    registerFeishuTaskCommentTool(api);
+    registerFeishuTaskSubtaskTool(api);
+    enabledGroups.push('task');
+  }
 
   // Bitable tools
-  registerFeishuBitableAppTool(api);
-  registerFeishuBitableAppTableTool(api);
-  registerFeishuBitableAppTableRecordTool(api);
-  registerFeishuBitableAppTableFieldTool(api);
-  registerFeishuBitableAppTableViewTool(api);
+  if (toolsCfg.bitable) {
+    registerFeishuBitableAppTool(api);
+    registerFeishuBitableAppTableTool(api);
+    registerFeishuBitableAppTableRecordTool(api);
+    registerFeishuBitableAppTableFieldTool(api);
+    registerFeishuBitableAppTableViewTool(api);
+    enabledGroups.push('bitable');
+  }
 
   // Search tools
-  registerFeishuSearchTools(api);
+  if (toolsCfg.doc) {
+    registerFeishuSearchTools(api);
+    enabledGroups.push('search');
+  }
 
   // Drive tools
-  registerFeishuDriveTools(api);
+  if (toolsCfg.drive) {
+    registerFeishuDriveTools(api);
+    enabledGroups.push('drive');
+  }
 
   // Wiki tools
-  registerFeishuWikiTools(api);
+  if (toolsCfg.wiki) {
+    registerFeishuWikiTools(api);
+    enabledGroups.push('wiki');
+  }
 
   // Sheets tools
-  registerFeishuSheetsTools(api);
+  if (toolsCfg.sheets) {
+    registerFeishuSheetsTools(api);
+    enabledGroups.push('sheets');
+  }
 
   // IM tools (bot identity)
-  registerFeishuImBotTools(api);
+  if (toolsCfg.im) {
+    registerFeishuImBotTools(api);
+  }
 
-  api.logger.info?.('Registered all OAPI tools (calendar, task, bitable, search, drive, wiki, sheets, im)');
+  api.logger.info?.(
+    `Registered OAPI tool groups: ${enabledGroups.length > 0 ? enabledGroups.join(', ') : 'none'}`,
+  );
 }


### PR DESCRIPTION
Partially addresses #17

## Summary
- add `channels.feishu.tools.preset` with `full` and `minimal` modes
- expand the tools config schema/types so major capability groups can be toggled explicitly (`chat`, `im`, `calendar`, `task`, `bitable`, `auth`, plus the existing groups)
- register OAPI/OAuth tool families conditionally instead of always registering the full surface
- document the new `minimal` preset in both READMEs
- update diagnose output so it reflects the capability groups that are actually enabled

## Why
Issue #17 points out that the plugin currently exposes a very large tool surface by default, which increases prompt/context overhead even for simple sessions.

I saw the same pattern on a live OpenClaw deployment using this plugin: during startup, the gateway emitted **31 tool-registration lines** in a very small window before normal traffic handling continued. A representative excerpt:

```text
2026-03-11T18:06:34.024+08:00 [gateway] feishu_get_user: Registered feishu_get_user tool
2026-03-11T18:06:34.114+08:00 [gateway] feishu_calendar_calendar: Registered feishu_calendar_calendar tool
2026-03-11T18:06:34.147+08:00 [gateway] feishu_task_task: Registered feishu_task_task tool
2026-03-11T18:06:34.182+08:00 [gateway] feishu_bitable_app: Registered feishu_bitable_app tool
2026-03-11T18:06:34.298+08:00 [gateway] Registered all OAPI tools (calendar, task, bitable, search, drive, wiki, sheets, im)
2026-03-11T18:06:34.310+08:00 [gateway] feishu_oauth: Registered feishu_oauth tool
2026-03-11T18:06:34.314+08:00 [gateway] feishu_oauth_batch_auth: Registered feishu_oauth_batch_auth tool
```

This PR does not implement full lazy loading or a CLI bridge, but it gives users a practical way to shrink the default tool surface today:
- choose `preset: "minimal"` for a smaller baseline
- opt specific capability groups back in only when needed

## Design notes
- I intentionally kept the default behavior unchanged: `full` remains the implicit default for backward compatibility
- `minimal` keeps the core messaging/auth/doc path, while disabling heavier groups such as calendar, task, bitable, wiki, drive, and sheets unless explicitly re-enabled
- I also avoided claiming this fully solves #17; it is a compatibility-safe step toward lower overhead without redesigning the entire registration model

## Validation
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `./node_modules/.bin/eslint index.ts src/core/config-schema.ts src/core/types.ts src/core/tools-config.ts src/tools/oapi/index.ts src/commands/diagnose.ts`
