### PR TITLE
Trust inbound Feishu thread IDs for session isolation

### DIFF
--- a/src/messaging/inbound/dispatch-context.ts
+++ b/src/messaging/inbound/dispatch-context.ts
@@ -15,7 +15,6 @@ import type { MessageContext } from '../types';
 import type { LarkAccount } from '../../core/types';
 import { LarkClient } from '../../core/lark-client';
 import { larkLogger } from '../../core/lark-logger';
-import { isThreadCapableGroup } from '../../core/chat-info-cache';
 
 const log = larkLogger('inbound/dispatch-context');
 
@@ -147,36 +146,26 @@ export function buildDispatchContext(params: {
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve thread session key for thread-capable groups.
+ * Resolve a thread-scoped session key for any inbound Feishu message that
+ * already carries a concrete thread ID.
  *
- * Returns a thread-scoped session key when ALL conditions are met:
- *   1. `threadSession` config is enabled on the account
- *   2. The group is a topic group (chat_mode=topic) or uses thread
- *      message mode (group_message_type=thread)
+ * Some Feishu groups surface reply threads in message events even when
+ * `im.chat.get` still reports `chat_mode=group` and
+ * `group_message_type=chat`. In that case, gating thread isolation on
+ * chat metadata causes distinct topics to collapse into the shared group
+ * session, which can leak prior topic context into a fresh request.
  *
- * The group info is fetched via `im.chat.get` with a 1-hour LRU cache
- * to minimise OAPI calls.
+ * Once the inbound event already provides `threadId`, we should trust the
+ * event payload and isolate the session by that thread ID directly.
  */
 export async function resolveThreadSessionKey(params: {
-  accountScopedCfg: ClawdbotConfig;
   account: LarkAccount;
-  chatId: string;
   threadId: string;
   baseSessionKey: string;
 }): Promise<string | undefined> {
-  const { accountScopedCfg, account, chatId, threadId, baseSessionKey } = params;
+  const { account, threadId, baseSessionKey } = params;
 
   if (account.config?.threadSession !== true) return undefined;
-
-  const threadCapable = await isThreadCapableGroup({
-    cfg: accountScopedCfg,
-    chatId,
-    accountId: account.accountId,
-  });
-  if (!threadCapable) {
-    log.info(`thread session skipped: group ${chatId} is not topic/thread mode`);
-    return undefined;
-  }
 
   // 使用 SDK 标准函数，保证分隔符格式与 resolveThreadParentSessionKey 兼容
   const { sessionKey } = resolveThreadSessionKeys({

--- a/src/messaging/inbound/dispatch.ts
+++ b/src/messaging/inbound/dispatch.ts
@@ -175,9 +175,7 @@ export async function dispatchToAgent(params: {
   // 1b. Resolve thread session isolation (async: may query group info API)
   if (dc.isThread && dc.ctx.threadId) {
     dc.threadSessionKey = await resolveThreadSessionKey({
-      accountScopedCfg: dc.accountScopedCfg,
       account: dc.account,
-      chatId: dc.ctx.chatId,
       threadId: dc.ctx.threadId,
       baseSessionKey: dc.route.sessionKey,
     });


### PR DESCRIPTION
## 概述
修复飞书群话题回复场景下的 session 串线问题。

## 问题
部分群消息事件已经带有真实 `thread_id`，但 `im.chat.get` 仍返回普通群元数据。现有逻辑会退回群级 session，导致不同 topic 共享上下文，出现串历史或沿用旧话题上下文的问题。

## 改动
- 入站事件带有 `thread_id` 时，直接按 thread 做 session 隔离
- 不再依赖 `im.chat.get` 判断是否为 topic/thread 群

## 验证
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`