### PR TITLE
fix: 修复插件 ID 不匹配导致启动告警 (fixes #25)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@larksuite/openclaw-lark",
+  "name": "@larksuite/feishu-openclaw-plugin",
   "version": "2026.3.10",
   "description": "OpenClaw Lark/Feishu channel plugin",
   "type": "module",


### PR DESCRIPTION
## 问题

OpenClaw 插件加载器在启动时会将 `package.json` 的 `name` 字段去掉 npm scope 后，与 `openclaw.plugin.json` 中的 `id` 进行比对：

- `package.json` name：`@larksuite/openclaw-lark` → 去 scope 后：**`openclaw-lark`**
- `openclaw.plugin.json` id：**`feishu-openclaw-plugin`**

二者不一致，导致每次启动都会产生告警：

```
plugin feishu-openclaw-plugin: plugin id mismatch
(manifest uses "feishu-openclaw-plugin", entry hints "openclaw-lark")
```

作为对照，OpenClaw 内置的飞书扩展使用 `@openclaw/feishu`（去 scope 后 = `feishu`），manifest id 也是 `feishu`，完全一致。其他所有内置插件（discord、zalo 等）均遵循 `@openclaw/<id>` → `<id>` 的命名规范。

## 修复

将 `package.json` name 从 `@larksuite/openclaw-lark` 改为 `@larksuite/feishu-openclaw-plugin`。

去 scope 后：`feishu-openclaw-plugin` = manifest id ✅

## 改动范围

仅修改 `package.json` 一个文件的一行，无其他文件变动。

## 验证

修改后启动告警消失。
