### PR TITLE
fix: declare preferOver feishu to prevent doctor from auto-enabling built-in channel

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
         "lark"
       ],
       "order": 35,
-      "quickstartAllowFrom": true
+      "quickstartAllowFrom": true,
+      "preferOver": ["feishu"]
     },
     "install": {
       "npmSpec": "@larksuite/openclaw-lark",


### PR DESCRIPTION
## Problem

When `feishu-openclaw-plugin` is installed and active, OpenClaw's doctor/auto-enable logic still adds the built-in `feishu` plugin to `plugins.allow` and `plugins.entries`. After every restart, users see two feishu entries in `openclaw plugins list`:

```
feishu-openclaw-plugin   loaded   ...
feishu                   loaded   ...
```

This causes:
- **Duplicate plugin entries** in `openclaw plugins list`
- **Potential message routing conflicts** (both plugins registering for the `feishu` channel)
- **User confusion** — it's unclear which plugin is active, and the config looks broken

## Root Cause

OpenClaw's `shouldSkipPreferredPluginAutoEnable` logic skips auto-enabling a built-in channel plugin **only if** some other configured plugin declares `preferOver: ["feishu"]` in its channel metadata. Since `feishu-openclaw-plugin` did not declare this, the logic never suppressed the built-in `feishu` auto-enable, resulting in both being loaded simultaneously.

Relevant logic in OpenClaw core (`plugin-auto-enable`):

```js
function shouldSkipPreferredPluginAutoEnable(cfg, entry, configured) {
  for (const other of configured) {
    if (other.pluginId === entry.pluginId) continue;
    if (isPluginDenied(cfg, other.pluginId)) continue;
    if (isPluginExplicitlyDisabled(cfg, other.pluginId)) continue;
    if (resolvePreferredOverIds(other.pluginId).includes(entry.pluginId)) return true;  // <-- needs preferOver
  }
  return false;
}
```

## Fix

Add `"preferOver": ["feishu"]` to the `channel` metadata in `package.json`. This signals to OpenClaw's auto-enable logic that `feishu-openclaw-plugin` is the authoritative handler for the `feishu` channel, and the built-in should be suppressed when this plugin is active.

```json
"channel": {
  ...
  "preferOver": ["feishu"]
}
```

## Before / After

**Before:** `openclaw plugins list` shows two feishu entries; `openclaw.json` has `plugins.allow` and `plugins.entries` containing both `feishu-openclaw-plugin` and `feishu` after doctor runs.

**After:** Only `feishu-openclaw-plugin` appears; the built-in `feishu` is not auto-added.

## Related Issues

- #40 (plugin id mismatch warnings on startup)
- #32 (plugin id mismatch due to naming inconsistency)