### PR TITLE
fix(im): use tenant access token for message.list API calls

### DIFF
--- a/src/tools/oapi/im/message-read.ts
+++ b/src/tools/oapi/im/message-read.ts
@@ -2,7 +2,9 @@
  * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
  * SPDX-License-Identifier: MIT
  *
- * 消息读取工具集 -- 以用户身份获取/搜索飞书消息
+ * 消息读取工具集
+ * - list（会话/话题历史）走 TAT（应用身份），因 im.v1.message.list 仅支持 TAT
+ * - search（跨会话搜索）走 UAT（用户身份）
  *
  * 包含：
  *   - feishu_im_user_get_messages       (chat_id / open_id → 会话消息)
@@ -207,7 +209,7 @@ function registerGetMessages(api: OpenClawPluginApi): boolean {
                 opts,
               ),
             {
-              as: 'user',
+              as: 'tenant',
             },
           );
           assertLarkOk(res);
@@ -287,7 +289,7 @@ function registerGetThreadMessages(api: OpenClawPluginApi): boolean {
                 opts,
               ),
             {
-              as: 'user',
+              as: 'tenant',
             },
           );
           assertLarkOk(res);

--- a/src/tools/oapi/im/message-read.ts
+++ b/src/tools/oapi/im/message-read.ts
@@ -152,7 +152,7 @@ function registerGetMessages(api: OpenClawPluginApi): boolean {
       name: 'feishu_im_user_get_messages',
       label: 'Feishu: Get IM Messages',
       description:
-        '【以用户身份】获取群聊或单聊的历史消息。' +
+        '获取群聊或单聊的历史消息。' +
         '\n\n用法：' +
         '\n- 通过 chat_id 获取群聊/单聊消息' +
         '\n- 通过 open_id 获取与指定用户的单聊消息（自动解析 chat_id）' +
@@ -257,7 +257,7 @@ function registerGetThreadMessages(api: OpenClawPluginApi): boolean {
       name: 'feishu_im_user_get_thread_messages',
       label: 'Feishu: Get Thread Messages',
       description:
-        '【以用户身份】获取话题（thread）内的消息列表。' +
+        '获取话题（thread）内的消息列表。' +
         '\n\n用法：' +
         '\n- 通过 thread_id（omt_xxx）获取话题内的所有消息' +
         '\n- 支持分页：page_size + page_token' +


### PR DESCRIPTION
## Summary

Closes #36

`im.v1.message.list` only supports `tenant_access_token` (TAT). The previous `as: 'user'` (UAT) caused error: "The app type is not supported".

- Switch `as: 'user'` → `as: 'tenant'` for both `feishu_im_user_get_messages` and `feishu_im_user_get_thread_messages`
- Update file header comment to document TAT/UAT split (list uses TAT, search uses UAT)

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` — no new errors (36 pre-existing warnings only)
- [ ] Manual: verify chat history retrieval no longer returns "The app type is not supported"
- [ ] Manual: verify thread history retrieval works