### PR TITLE
fix: 修复 feishu_im_user_message 发送 markdown 表格不渲染

### DIFF
--- a/src/card/reply-dispatcher.ts
+++ b/src/card/reply-dispatcher.ts
@@ -17,7 +17,7 @@ import {
   logTypingFailure,
   type ReplyPayload,
 } from 'openclaw/plugin-sdk';
-import { getLarkAccount } from '../core/accounts';
+import { createAccountScopedConfig, getLarkAccount } from '../core/accounts';
 import { resolveFooterConfig } from '../core/footer-config';
 import { LarkClient } from '../core/lark-client';
 import { larkLogger } from '../core/lark-logger';
@@ -44,6 +44,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   // Resolve account so we can read per-account config (e.g. replyMode)
   const account = getLarkAccount(cfg, accountId);
   const feishuCfg = account.config;
+  const accountScopedCfg = createAccountScopedConfig(cfg, account.accountId);
 
   const prefixContext = createReplyPrefixContext({ cfg, agentId });
 
@@ -72,7 +73,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const textChunkLimit = core.channel.text.resolveTextChunkLimit(cfg, 'feishu', accountId, { fallbackLimit: 4000 });
   const chunkMode = core.channel.text.resolveChunkMode(cfg, 'feishu');
   const tableMode = core.channel.text.resolveMarkdownTableMode({
-    cfg,
+    cfg: accountScopedCfg,
     channel: 'feishu',
   });
 

--- a/src/core/accounts.ts
+++ b/src/core/accounts.ts
@@ -156,6 +156,31 @@ export function getLarkAccount(cfg: ClawdbotConfig, accountId?: string | null): 
   };
 }
 
+/**
+ * Build an account-scoped config view for downstream helpers that read from
+ * `cfg.channels.feishu`.
+ *
+ * In multi-account mode, many runtime helpers expect the merged account config
+ * to already be exposed at `cfg.channels.feishu`. This mirrors the inbound
+ * path behavior so outbound/tooling code resolves per-account settings
+ * consistently.
+ *
+ * @param cfg - Original top-level plugin config
+ * @param accountId - Optional target account ID
+ * @returns Config with `channels.feishu` replaced by the merged account config
+ */
+export function createAccountScopedConfig(cfg: ClawdbotConfig, accountId?: string | null): ClawdbotConfig {
+  const account = getLarkAccount(cfg, accountId);
+
+  return {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      feishu: account.config,
+    },
+  };
+}
+
 /** Return all accounts that are both configured and enabled. */
 export function getEnabledLarkAccounts(cfg: ClawdbotConfig): LarkAccount[] {
   const ids = getLarkAccountIds(cfg);

--- a/src/messaging/outbound/deliver.ts
+++ b/src/messaging/outbound/deliver.ts
@@ -10,6 +10,7 @@
 
 import type { ClawdbotConfig } from 'openclaw/plugin-sdk';
 import type { FeishuSendResult } from '../types';
+import { createAccountScopedConfig } from '../../core/accounts';
 import { LarkClient } from '../../core/lark-client';
 import { normalizeFeishuTarget, resolveReceiveIdType } from '../../core/targets';
 import { optimizeMarkdownStyle } from '../../card/markdown-style';
@@ -55,15 +56,20 @@ function normalizeAtMentions(text: string): string {
  * Pre-process text for Lark rendering:
  * mention normalisation + table conversion + style optimization.
  */
-function prepareTextForLark(text: string): string {
+function prepareTextForLark(cfg: ClawdbotConfig, text: string, accountId?: string): string {
   let processed = normalizeAtMentions(text);
 
-  // Convert markdown tables to Feishu-compatible format if the runtime
-  // provides a converter.
+  // Convert markdown tables to Feishu-compatible format using per-account
+  // tableMode setting.
   try {
+    const accountScopedCfg = createAccountScopedConfig(cfg, accountId);
     const runtime = LarkClient.runtime;
-    if (runtime?.channel?.text?.convertMarkdownTables) {
-      processed = runtime.channel.text.convertMarkdownTables(processed, 'bullets');
+    if (runtime?.channel?.text?.convertMarkdownTables && runtime.channel.text.resolveMarkdownTableMode) {
+      const tableMode = runtime.channel.text.resolveMarkdownTableMode({
+        cfg: accountScopedCfg,
+        channel: 'feishu',
+      });
+      processed = runtime.channel.text.convertMarkdownTables(processed, tableMode);
     }
   } catch {
     // Runtime not available -- use the text as-is.
@@ -245,7 +251,7 @@ export async function sendTextLark(params: SendTextLarkParams): Promise<FeishuSe
 
   log.info(`sendTextLark: target=${to}, textLength=${text.length}`);
   const client = LarkClient.fromCfg(cfg, accountId).sdk;
-  const processedText = prepareTextForLark(text);
+  const processedText = prepareTextForLark(cfg, text, accountId);
   const content = buildPostContent(processedText);
 
   return sendImMessage({ client, to, content, msgType: 'post', replyToMessageId, replyInThread });

--- a/src/messaging/outbound/send.ts
+++ b/src/messaging/outbound/send.ts
@@ -7,6 +7,7 @@
 
 import type { ClawdbotConfig } from 'openclaw/plugin-sdk';
 import type { FeishuSendResult } from '../types';
+import { createAccountScopedConfig } from '../../core/accounts';
 import { LarkClient } from '../../core/lark-client';
 import { normalizeFeishuTarget, normalizeMessageId, resolveReceiveIdType } from '../../core/targets';
 import { runWithMessageUnavailableGuard } from '../../core/message-unavailable';
@@ -65,6 +66,33 @@ export interface SendFeishuCardParams {
 // ---------------------------------------------------------------------------
 
 /**
+ * Resolve the configured markdown table mode for Feishu and convert tables if
+ * the runtime converter is available.
+ *
+ * @param cfg - Plugin configuration
+ * @param text - Raw markdown text
+ * @param accountId - Optional account identifier for multi-account setups
+ * @returns Converted text, or the original text when runtime helpers are unavailable
+ */
+function convertMarkdownTablesForFeishu(cfg: ClawdbotConfig, text: string, accountId?: string): string {
+  try {
+    const accountScopedCfg = createAccountScopedConfig(cfg, accountId);
+    const runtime = LarkClient.runtime;
+    if (runtime?.channel?.text?.convertMarkdownTables && runtime.channel.text.resolveMarkdownTableMode) {
+      const tableMode = runtime.channel.text.resolveMarkdownTableMode({
+        cfg: accountScopedCfg,
+        channel: 'feishu',
+      });
+      return runtime.channel.text.convertMarkdownTables(text, tableMode);
+    }
+  } catch {
+    // Runtime not available -- use the text as-is.
+  }
+
+  return text;
+}
+
+/**
  * Send a text message (rendered as a Feishu "post" with markdown support)
  * to a chat or user.
  *
@@ -99,14 +127,7 @@ export async function sendMessageFeishu(params: SendFeishuMessageParams): Promis
       }
 
       // Convert markdown tables to Feishu-compatible format.
-      try {
-        const runtime = LarkClient.runtime;
-        if (runtime?.channel?.text?.convertMarkdownTables) {
-          processed = runtime.channel.text.convertMarkdownTables(processed, 'bullets');
-        }
-      } catch {
-        // Runtime not available -- use the text as-is.
-      }
+      processed = convertMarkdownTablesForFeishu(cfg, processed, accountId);
 
       // Apply Markdown style optimization.
       processed = optimizeMarkdownStyle(processed, 1);
@@ -125,16 +146,8 @@ export async function sendMessageFeishu(params: SendFeishuMessageParams): Promis
       messageText = buildMentionedMessage(mentions, messageText);
     }
 
-    // Convert markdown tables to Feishu-compatible format if the runtime
-    // provides a converter.
-    try {
-      const runtime = LarkClient.runtime;
-      if (runtime?.channel?.text?.convertMarkdownTables) {
-        messageText = runtime.channel.text.convertMarkdownTables(messageText, 'bullets');
-      }
-    } catch {
-      // Runtime not available -- use the text as-is.
-    }
+    // Convert markdown tables to Feishu-compatible format.
+    messageText = convertMarkdownTablesForFeishu(cfg, messageText, accountId);
 
     // Apply Markdown style optimization.
     messageText = optimizeMarkdownStyle(messageText, 1);
@@ -450,7 +463,9 @@ export async function editMessageFeishu(params: {
 
   const client = LarkClient.fromCfg(cfg, accountId).sdk;
 
-  const optimizedText = optimizeMarkdownStyle(text);
+  const convertedText = convertMarkdownTablesForFeishu(cfg, text, accountId);
+  // Use cardVersion=1 consistent with sendMessageFeishu post path.
+  const optimizedText = optimizeMarkdownStyle(convertedText, 1);
 
   const contentPayload = JSON.stringify({
     zh_cn: {

--- a/src/tools/oapi/im/message.ts
+++ b/src/tools/oapi/im/message.ts
@@ -13,9 +13,171 @@
  * 全部以用户身份（user_access_token）调用，scope 来自 real-scope.json。
  */
 
-import type { OpenClawPluginApi } from 'openclaw/plugin-sdk';
+import type { ClawdbotConfig, OpenClawPluginApi } from 'openclaw/plugin-sdk';
 import { Type } from '@sinclair/typebox';
-import { json, createToolContext, assertLarkOk, handleInvokeErrorWithAutoAuth, registerTool, StringEnum } from '../helpers';
+import { createAccountScopedConfig } from '../../../core/accounts';
+import { LarkClient } from '../../../core/lark-client';
+import {
+  json,
+  createToolContext,
+  assertLarkOk,
+  handleInvokeErrorWithAutoAuth,
+  registerTool,
+  StringEnum,
+} from '../helpers';
+
+interface FeishuPostContentBlock {
+  tag?: string;
+  text?: string;
+  [key: string]: unknown;
+}
+
+interface FeishuPostLocaleContent {
+  title?: string;
+  content?: FeishuPostContentBlock[][];
+  [key: string]: unknown;
+}
+
+const FEISHU_POST_LOCALE_PRIORITY = ['zh_cn', 'en_us', 'ja_jp'] as const;
+
+/**
+ * Check whether a value is a non-null object whose properties can be read.
+ *
+ * @param value - The value to check
+ * @returns Whether the value is a non-null object
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object';
+}
+
+/**
+ * Collect post content bodies from a parsed Feishu post payload.
+ * Handles both flat (title/content at root) and multi-locale wrapper structures.
+ *
+ * @param parsed - The parsed JSON object
+ * @returns List of post content bodies to process
+ */
+function collectPostContents(parsed: Record<string, unknown>): FeishuPostLocaleContent[] {
+  if ('title' in parsed || 'content' in parsed) {
+    return [parsed as FeishuPostLocaleContent];
+  }
+
+  const bodies: FeishuPostLocaleContent[] = [];
+  const seen = new Set<FeishuPostLocaleContent>();
+
+  // Process well-known locales first
+  for (const locale of FEISHU_POST_LOCALE_PRIORITY) {
+    const localeContent = parsed[locale];
+    if (!isRecord(localeContent)) {
+      continue;
+    }
+
+    const body = localeContent as FeishuPostLocaleContent;
+    if (!seen.has(body)) {
+      bodies.push(body);
+      seen.add(body);
+    }
+  }
+
+  // Process remaining locales
+  for (const value of Object.values(parsed)) {
+    if (!isRecord(value)) {
+      continue;
+    }
+
+    const body = value as FeishuPostLocaleContent;
+    if (!seen.has(body)) {
+      bodies.push(body);
+      seen.add(body);
+    }
+  }
+
+  return bodies;
+}
+
+/**
+ * Convert markdown tables to the Feishu-compatible list format.
+ *
+ * Reuses the channel runtime's existing converter so the tool send path
+ * behaves identically to the main reply path.
+ *
+ * @param cfg - Current tool configuration
+ * @param text - Raw markdown text
+ * @returns Converted text, or the original text when runtime is unavailable
+ */
+function convertMarkdownTablesForLark(cfg: ClawdbotConfig, text: string): string {
+  try {
+    const runtime = LarkClient.runtime;
+    if (runtime?.channel?.text?.convertMarkdownTables && runtime.channel.text.resolveMarkdownTableMode) {
+      const tableMode = runtime.channel.text.resolveMarkdownTableMode({
+        cfg,
+        channel: 'feishu',
+      });
+      return runtime.channel.text.convertMarkdownTables(text, tableMode);
+    }
+  } catch {
+    // Runtime converter unavailable -- keep text as-is.
+  }
+
+  return text;
+}
+
+/**
+ * Pre-process `tag="md"` text nodes inside `post` messages so the tool send
+ * path also renders markdown tables correctly.
+ *
+ * @param cfg - Current tool configuration
+ * @param msgType - Feishu message type
+ * @param content - The JSON string from tool parameters
+ * @returns Pre-processed JSON string
+ */
+function preprocessPostContent(cfg: ClawdbotConfig, msgType: string, content: string): string {
+  if (msgType !== 'post') {
+    return content;
+  }
+
+  try {
+    const parsed = JSON.parse(content) as unknown;
+    if (!isRecord(parsed)) {
+      return content;
+    }
+
+    const postContents = collectPostContents(parsed);
+    if (postContents.length === 0) {
+      return content;
+    }
+
+    let changed = false;
+
+    for (const postContent of postContents) {
+      if (!postContent.content || !Array.isArray(postContent.content)) {
+        continue;
+      }
+
+      for (const line of postContent.content) {
+        if (!Array.isArray(line)) {
+          continue;
+        }
+
+        for (const block of line) {
+          if (!isRecord(block) || block.tag !== 'md' || typeof block.text !== 'string') {
+            continue;
+          }
+
+          const convertedText = convertMarkdownTablesForLark(cfg, block.text);
+          if (convertedText !== block.text) {
+            block.text = convertedText;
+            changed = true;
+          }
+        }
+      }
+    }
+
+    return changed ? JSON.stringify(parsed) : content;
+  } catch {
+    return content;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Schema
@@ -141,6 +303,8 @@ export function registerFeishuImUserMessageTool(api: OpenClawPluginApi) {
               log.info(
                 `send: receive_id_type=${p.receive_id_type}, receive_id=${p.receive_id}, msg_type=${p.msg_type}`,
               );
+              const accountScopedCfg = createAccountScopedConfig(cfg, client.account.accountId);
+              const processedContent = preprocessPostContent(accountScopedCfg, p.msg_type, p.content);
 
               const res = await client.invoke(
                 'feishu_im_user_message.send',
@@ -151,7 +315,7 @@ export function registerFeishuImUserMessageTool(api: OpenClawPluginApi) {
                       data: {
                         receive_id: p.receive_id,
                         msg_type: p.msg_type,
-                        content: p.content,
+                        content: processedContent,
                         uuid: p.uuid,
                       },
                     },
@@ -181,6 +345,8 @@ export function registerFeishuImUserMessageTool(api: OpenClawPluginApi) {
               log.info(
                 `reply: message_id=${p.message_id}, msg_type=${p.msg_type}, reply_in_thread=${p.reply_in_thread ?? false}`,
               );
+              const accountScopedCfg = createAccountScopedConfig(cfg, client.account.accountId);
+              const processedContent = preprocessPostContent(accountScopedCfg, p.msg_type, p.content);
 
               const res = await client.invoke(
                 'feishu_im_user_message.reply',
@@ -189,7 +355,7 @@ export function registerFeishuImUserMessageTool(api: OpenClawPluginApi) {
                     {
                       path: { message_id: p.message_id },
                       data: {
-                        content: p.content,
+                        content: processedContent,
                         msg_type: p.msg_type,
                         reply_in_thread: p.reply_in_thread,
                         uuid: p.uuid,


### PR DESCRIPTION
## 问题背景
`feishu_im_user_message` 这条工具链路在发送 `msg_type = "post"` 时，会把 `content` 原样透传给飞书 API，没有像主回复链路那样先处理 markdown 表格。

结果是同样的 markdown 表格内容：
- 机器人主回复可以正常渲染
- `feishu_im_user_message` 工具发送时不会按预期渲染

此外，仓库里几条相关发送链路对 `markdown tableMode` 的读取方式并不完全一致，在多账号场景下会有配置漂移风险。

## 这次修了什么
- 在 `feishu_im_user_message` 中为 `post` 消息增加预处理，只转换 `tag: "md"` 文本节点里的 markdown 表格
- 兼容 flat 和 locale 包裹两种 `post` 结构
- 遇到异常块时跳过该块，避免整条消息预处理失败
- 统一工具发送、独立发送、静态回复、编辑消息这几条路径对 Feishu `tableMode` 的解析方式
- 将 `tableMode` 解析统一到账号级配置视图，避免多账号时读取到错误的顶层配置
- 让编辑消息路径的 post 样式参数与普通发送保持一致

## 影响范围
这次改动只围绕 #50 相关的 markdown 表格渲染链路展开，主要涉及：
- `src/tools/oapi/im/message.ts`
- `src/messaging/outbound/send.ts`
- `src/messaging/outbound/deliver.ts`
- `src/card/reply-dispatcher.ts`
- `src/core/accounts.ts`

## 验证
- `pnpm exec tsc --noEmit`
- `pnpm lint src/core/accounts.ts src/tools/oapi/im/message.ts src/messaging/outbound/send.ts src/messaging/outbound/deliver.ts src/card/reply-dispatcher.ts`
- `pnpm exec prettier --check src/core/accounts.ts src/tools/oapi/im/message.ts src/messaging/outbound/send.ts src/messaging/outbound/deliver.ts src/card/reply-dispatcher.ts`
- 额外做过多轮代码审查，重点检查了 flat/locale `post` 结构、多账号 `tableMode`、静态回复与编辑消息路径的一致性

## 说明
- 当前仓库缺少 `scripts/build.mjs`，`pnpm build` 不能作为有效验证命令
- Closes #50
