### PR TITLE
feat(feishu): 在消息 footer 展示模型名与 skills 信息

### DIFF
--- a/src/card/builder.ts
+++ b/src/card/builder.ts
@@ -204,7 +204,9 @@ export function buildCardContent(
     elapsedMs?: number;
     isError?: boolean;
     isAborted?: boolean;
-    footer?: { status?: boolean; elapsed?: boolean };
+    footer?: { status?: boolean; elapsed?: boolean; model?: boolean; skills?: boolean };
+    modelName?: string;
+    usedSkills?: string[];
   } = {},
 ): FeishuCard {
   switch (state) {
@@ -222,6 +224,8 @@ export function buildCardContent(
         reasoningElapsedMs: data.reasoningElapsedMs,
         isAborted: data.isAborted,
         footer: data.footer,
+        modelName: data.modelName,
+        usedSkills: data.usedSkills,
       });
     case 'confirm':
       return buildConfirmCard(data.confirmData!);
@@ -291,9 +295,22 @@ function buildCompleteCard(params: {
   reasoningText?: string;
   reasoningElapsedMs?: number;
   isAborted?: boolean;
-  footer?: { status?: boolean; elapsed?: boolean };
+  footer?: { status?: boolean; elapsed?: boolean; model?: boolean; skills?: boolean };
+  modelName?: string;
+  usedSkills?: string[];
 }): FeishuCard {
-  const { text, toolCalls, elapsedMs, isError, reasoningText, reasoningElapsedMs, isAborted, footer } = params;
+  const {
+    text,
+    toolCalls,
+    elapsedMs,
+    isError,
+    reasoningText,
+    reasoningElapsedMs,
+    isAborted,
+    footer,
+    modelName,
+    usedSkills,
+  } = params;
   const elements: CardElement[] = [];
 
   // Collapsible reasoning panel (before main content)
@@ -365,6 +382,15 @@ function buildCompleteCard(params: {
 
   if (footer?.elapsed && elapsedMs != null) {
     parts.push(`耗时 ${formatElapsed(elapsedMs)}`);
+  }
+
+  if (footer?.model) {
+    parts.push(`模型 ${modelName?.trim() || 'unknown'}`);
+  }
+
+  if (footer?.skills) {
+    const skillText = usedSkills && usedSkills.length > 0 ? usedSkills.join(', ') : 'none';
+    parts.push(`Skills ${skillText}`);
   }
 
   if (parts.length > 0) {

--- a/src/card/reply-dispatcher-types.ts
+++ b/src/card/reply-dispatcher-types.ts
@@ -121,6 +121,8 @@ export interface CreateFeishuReplyDispatcherParams {
   skipTyping?: boolean;
   /** When true, replies are sent into the thread instead of main chat. */
   replyInThread?: boolean;
+  /** Effective skill filter for this run (group-level resolved). */
+  skillFilter?: string[];
 }
 
 /**
@@ -165,4 +167,6 @@ export interface StreamingCardDeps {
   replyToMessageId: string | undefined;
   replyInThread: boolean | undefined;
   resolvedFooter: Required<FeishuFooterConfig>;
+  modelName?: string;
+  usedSkills?: string[];
 }

--- a/src/card/reply-dispatcher.ts
+++ b/src/card/reply-dispatcher.ts
@@ -62,6 +62,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
 
   const resolvedFooter = resolveFooterConfig(feishuCfg?.footer);
 
+  let selectedModelName: string | undefined;
+  let usedSkills: string[] = params.skillFilter ? [...params.skillFilter] : [];
+
   log.info('reply mode resolved', {
     effectiveReplyMode,
     replyMode,
@@ -85,6 +88,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         replyToMessageId,
         replyInThread,
         resolvedFooter,
+        modelName: selectedModelName,
+        usedSkills,
       })
     : null;
 
@@ -306,7 +311,19 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     dispatcher,
     replyOptions: {
       ...replyOptions,
-      onModelSelected: prefixContext.onModelSelected,
+      onModelSelected: (ctx: { provider: string; model: string; thinkLevel: string | undefined }) => {
+        selectedModelName = `${ctx.provider}/${ctx.model}`;
+        controller?.setModelName(selectedModelName);
+        prefixContext.onModelSelected?.(ctx);
+      },
+      onToolStart: async (payload: { name?: string; phase?: string }) => {
+        const toolName = payload.name?.trim();
+        if (!toolName) return;
+        if (!usedSkills.includes(toolName)) {
+          usedSkills = [...usedSkills, toolName];
+          controller?.setUsedSkills(usedSkills);
+        }
+      },
       disableBlockStreaming: !enableBlockStreaming,
       ...(controller
         ? {

--- a/src/card/streaming-card-controller.ts
+++ b/src/card/streaming-card-controller.ts
@@ -120,12 +120,17 @@ export class StreamingCardController {
   // ---- Injected dependencies ----
   private readonly deps: StreamingCardDeps;
 
+  private modelName: string | undefined;
+  private usedSkills: string[] = [];
+
   private elapsed(): number {
     return Date.now() - this.dispatchStartTime;
   }
 
   constructor(deps: StreamingCardDeps) {
     this.deps = deps;
+    this.modelName = deps.modelName;
+    this.usedSkills = deps.usedSkills ?? [];
 
     this.guard = new UnavailableGuard({
       replyToMessageId: deps.replyToMessageId,
@@ -183,6 +188,14 @@ export class StreamingCardController {
   /** @internal — exposed for test assertions only. */
   get currentPhase(): CardPhase {
     return this.phase;
+  }
+
+  setModelName(modelName: string | undefined): void {
+    this.modelName = modelName;
+  }
+
+  setUsedSkills(skills: string[]): void {
+    this.usedSkills = skills;
   }
 
   // ------------------------------------------------------------------
@@ -366,6 +379,8 @@ export class StreamingCardController {
           elapsedMs: this.elapsed(),
           isError: true,
           footer: this.deps.resolvedFooter,
+          modelName: this.modelName,
+          usedSkills: this.usedSkills,
         });
         if (errorEffectiveCardId) {
           await this.closeStreamingAndUpdate(errorEffectiveCardId, errorCard, 'onError');
@@ -432,6 +447,8 @@ export class StreamingCardController {
           reasoningElapsedMs: this.reasoning.reasoningElapsedMs || undefined,
           elapsedMs: this.elapsed(),
           footer: this.deps.resolvedFooter,
+          modelName: this.modelName,
+          usedSkills: this.usedSkills,
         });
 
         if (idleEffectiveCardId) {
@@ -499,6 +516,8 @@ export class StreamingCardController {
           elapsedMs,
           isAborted: true,
           footer: this.deps.resolvedFooter,
+          modelName: this.modelName,
+          usedSkills: this.usedSkills,
         });
         await this.closeStreamingAndUpdate(effectiveCardId, abortCardContent, 'abortCard');
         log.info('abortCard completed', { effectiveCardId });
@@ -513,6 +532,8 @@ export class StreamingCardController {
           elapsedMs,
           isAborted: true,
           footer: this.deps.resolvedFooter,
+          modelName: this.modelName,
+          usedSkills: this.usedSkills,
         });
         await updateCardFeishu({
           cfg: this.deps.cfg,

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -11,7 +11,6 @@ import { runFeishuDoctor } from './doctor';
 import { runFeishuAuth } from './auth';
 import { getPluginVersion } from '../core/version';
 
-
 export function registerCommands(api: OpenClawPluginApi): void {
   // /feishu_diagnose
   api.registerCommand({

--- a/src/core/config-schema.ts
+++ b/src/core/config-schema.ts
@@ -63,6 +63,8 @@ const FeishuFooterSchema = z
   .object({
     status: z.boolean().optional(),
     elapsed: z.boolean().optional(),
+    model: z.boolean().optional(),
+    skills: z.boolean().optional(),
   })
   .optional();
 

--- a/src/core/footer-config.ts
+++ b/src/core/footer-config.ts
@@ -23,6 +23,8 @@ import type { FeishuFooterConfig } from './types';
 export const DEFAULT_FOOTER_CONFIG: Required<FeishuFooterConfig> = {
   status: false,
   elapsed: false,
+  model: false,
+  skills: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -40,5 +42,7 @@ export function resolveFooterConfig(cfg?: FeishuFooterConfig): Required<FeishuFo
   return {
     status: cfg.status ?? DEFAULT_FOOTER_CONFIG.status,
     elapsed: cfg.elapsed ?? DEFAULT_FOOTER_CONFIG.elapsed,
+    model: cfg.model ?? DEFAULT_FOOTER_CONFIG.model,
+    skills: cfg.skills ?? DEFAULT_FOOTER_CONFIG.skills,
   };
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -72,6 +72,8 @@ export interface FeishuToolsConfig {
 export interface FeishuFooterConfig {
   status?: boolean;
   elapsed?: boolean;
+  model?: boolean;
+  skills?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/messaging/inbound/dispatch.ts
+++ b/src/messaging/inbound/dispatch.ts
@@ -85,6 +85,7 @@ async function dispatchNormalMessage(
     chatType: dc.ctx.chatType,
     skipTyping,
     replyInThread: dc.isThread,
+    skillFilter,
   });
 
   // Create an AbortController so the abort fast-path can cancel the


### PR DESCRIPTION
Motivation
提高回复透明性，在 Feishu 卡片 footer 额外展示本次回复使用的大模型名称与运行中使用到的 skills 信息，且对现有 status / elapsed 配置向后兼容。
Description
配置与类型：在 FeishuFooterConfig 中新增 model 与 skills 开关，并在 src/core/config-schema.ts、src/core/footer-config.ts 中增加 schema 与默认值（默认均为 false）。
分发链路改动：将 inbound 解析得到的 skillFilter 传入 createFeishuReplyDispatcher，在 dispatcher 中通过 onModelSelected 捕获实际 provider/model 并通过 onToolStart 增量记录使用到的 skill 名称。
卡片与渲染：StreamingCardController 新增 modelName 与 usedSkills 状态与 setter，并在最终卡片（complete/error/abort）构建时注入 modelName 与 usedSkills；buildCompleteCard 在 footer 根据开关以 模型 <name> 与 Skills <a,b> 的格式渲染（无值分别回落为 unknown / none）。
Testing
代码格式：运行 prettier --check src/**/*.ts（npm run format:check）后格式检查通过。
类型检查：运行 npx tsc --noEmit 通过，无类型错误。
Lint：运行 npm run lint，ESLint 报告为仓库已有的 warnings（无新增 errors）。
构建：尝试运行 npm run build 因仓库环境中缺少 scripts/build.mjs 导致失败，该失败与本次逻辑改动无关（环境/脚本缺失）。