### PR TITLE
fix: 修复飞书卡片表格数量超限导致消息发送失败 (Error 230099)

### DIFF
--- a/src/card/card-error.ts
+++ b/src/card/card-error.ts
@@ -1,0 +1,232 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Unified card API error handling.
+ *
+ * Provides structured error class for CardKit API responses, sub-error
+ * parsing for the generic 230099 code, and helper predicates used by
+ * reply-dispatcher and streaming-card-controller.
+ */
+
+import { extractLarkApiCode } from '../core/api-error';
+
+// ---------------------------------------------------------------------------
+// Error code constants
+// ---------------------------------------------------------------------------
+
+/** 卡片 API 级别错误码。 */
+export const CARD_ERROR = {
+  /** 发送频率限制 */
+  RATE_LIMITED: 230020,
+  /** 卡片内容创建失败（通用码，需检查子错误） */
+  CARD_CONTENT_FAILED: 230099,
+} as const;
+
+/** 230099 子错误码，嵌套在 msg 的 ErrCode 字段中。 */
+export const CARD_CONTENT_SUB_ERROR = {
+  /** 卡片元素（表格等）数量超限 */
+  ELEMENT_LIMIT: 11310,
+} as const;
+
+// 经验性的飞书卡片表格上限 -- 4+ 张触发 230099/11310（2026-03 实测）。
+export const FEISHU_CARD_TABLE_LIMIT = 3;
+
+export interface MarkdownTableMatch {
+  index: number;
+  length: number;
+  raw: string;
+}
+
+// ---------------------------------------------------------------------------
+// Error class
+// ---------------------------------------------------------------------------
+
+/** CardKit API 返回非零 code 时的结构化错误。 */
+export class CardKitApiError extends Error {
+  readonly code: number;
+  readonly msg: string;
+
+  constructor(params: { api: string; code: number; msg: string; context: string }) {
+    const { api, code, msg, context } = params;
+    super(`cardkit ${api} FAILED: code=${code}, msg=${msg}, ${context}`);
+    this.name = 'CardKitApiError';
+    this.code = code;
+    this.msg = msg;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sub-error extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * 从 msg 字符串中提取子错误码。
+ *
+ * 示例输入: "Failed to create card content, ext=ErrCode: 11310; ErrMsg: element exceeds the limit; code:230099"
+ * 返回 11310 或 null。
+ */
+export function extractSubCode(msg: string): number | null {
+  const match = /ErrCode:\s*(\d+)/.exec(msg);
+  if (!match) return null;
+  const code = Number(match[1]);
+  return Number.isFinite(code) ? code : null;
+}
+
+// ---------------------------------------------------------------------------
+// Structured error parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * 从任意抛错对象中解析卡片 API 错误结构。
+ *
+ * 返回 { code, subCode, errMsg }，如果无法提取 code 则返回 null。
+ */
+export function parseCardApiError(err: unknown): { code: number; subCode: number | null; errMsg: string } | null {
+  const code = extractLarkApiCode(err);
+  if (code === undefined) return null;
+
+  // 按优先级提取 msg 文本
+  let errMsg = '';
+  if (err && typeof err === 'object') {
+    const e = err as {
+      msg?: unknown;
+      message?: unknown;
+      response?: { data?: { msg?: unknown } };
+    };
+    if (typeof e.msg === 'string') {
+      errMsg = e.msg;
+    } else if (typeof e.response?.data?.msg === 'string') {
+      // Axios errors: response.data.msg carries the Feishu detail with ErrCode
+      errMsg = e.response.data.msg;
+    } else if (typeof e.message === 'string') {
+      // Fallback to generic Error.message (e.g. CardKitApiError)
+      errMsg = e.message;
+    }
+  }
+
+  const subCode = extractSubCode(errMsg);
+  return { code, subCode, errMsg };
+}
+
+// ---------------------------------------------------------------------------
+// Helper predicates
+// ---------------------------------------------------------------------------
+
+/**
+ * 判断错误是否为卡片表格数量超限。
+ *
+ * 匹配条件：code 230099 + subCode 11310 + errMsg 含 "table number over limit"。
+ * 11310 是通用的元素超限码（也覆盖模板可见性、组件上限等），
+ * 必须同时检查 errMsg 确认是表格数量导致的。
+ *
+ * 实际错误格式（生产日志 2026-03-13）：
+ * "Failed to create card content, ext=ErrCode: 11310; ErrMsg: card table number over limit; ErrorValue: table; "
+ */
+export function isCardTableLimitError(err: unknown): boolean {
+  const parsed = parseCardApiError(err);
+  if (!parsed) return false;
+  return (
+    parsed.code === CARD_ERROR.CARD_CONTENT_FAILED &&
+    parsed.subCode === CARD_CONTENT_SUB_ERROR.ELEMENT_LIMIT &&
+    /table number over limit/i.test(parsed.errMsg)
+  );
+}
+
+/** 判断错误是否为卡片发送频率限制（230020）。 */
+export function isCardRateLimitError(err: unknown): boolean {
+  const parsed = parseCardApiError(err);
+  if (!parsed) return false;
+  return parsed.code === CARD_ERROR.RATE_LIMITED;
+}
+
+// ---------------------------------------------------------------------------
+// Text sanitization
+// ---------------------------------------------------------------------------
+
+/**
+ * 收集正文里可被飞书卡片实际渲染的 markdown 表格。
+ *
+ * 代码块里的示例表格不会被飞书解析成卡片表格元素，因此这里要先排除，
+ * 让 shouldUseCard() 预检和 sanitizeTextForCard() 降级逻辑使用同一份结果。
+ */
+export function findMarkdownTablesOutsideCodeBlocks(text: string): MarkdownTableMatch[] {
+  const codeBlockRanges: Array<{ start: number; end: number }> = [];
+  const codeBlockRegex = /```[\s\S]*?```/g;
+  let codeBlockMatch = codeBlockRegex.exec(text);
+  while (codeBlockMatch !== null) {
+    codeBlockRanges.push({
+      start: codeBlockMatch.index,
+      end: codeBlockMatch.index + codeBlockMatch[0].length,
+    });
+    codeBlockMatch = codeBlockRegex.exec(text);
+  }
+
+  const isInsideCodeBlock = (idx: number): boolean => codeBlockRanges.some((range) => idx >= range.start && idx < range.end);
+
+  const tableRegex = /\|.+\|[\r\n]+\|[-:| ]+\|[\s\S]*?(?=\n\n|\n(?!\|)|$)/g;
+  const matches: MarkdownTableMatch[] = [];
+  let tableMatch = tableRegex.exec(text);
+  while (tableMatch !== null) {
+    if (!isInsideCodeBlock(tableMatch.index)) {
+      matches.push({
+        index: tableMatch.index,
+        length: tableMatch[0].length,
+        raw: tableMatch[0],
+      });
+    }
+    tableMatch = tableRegex.exec(text);
+  }
+
+  return matches;
+}
+
+/**
+ * 对多段 markdown 文本共享一个表格预算。
+ *
+ * 段落按数组顺序消耗额度，适合处理“reasoning + 正文”这类会被飞书
+ * 作为同一张卡片渲染的多块文本。
+ */
+export function sanitizeTextSegmentsForCard(
+  texts: readonly string[],
+  tableLimit: number = FEISHU_CARD_TABLE_LIMIT,
+): string[] {
+  let remainingTableBudget = tableLimit;
+
+  return texts.map((text) => {
+    const matches = findMarkdownTablesOutsideCodeBlocks(text);
+    if (matches.length <= remainingTableBudget) {
+      remainingTableBudget -= matches.length;
+      return text;
+    }
+
+    const sanitizedText = wrapTablesBeyondLimit(text, matches, Math.max(remainingTableBudget, 0));
+    remainingTableBudget = 0;
+    return sanitizedText;
+  });
+}
+
+/**
+ * 对正文中超出 tableLimit 的 markdown 表格降级为 code block，
+ * 避免飞书卡片因表格数超限触发 230099/11310。
+ *
+ * 前 tableLimit 张表格保持原样（可正常卡片渲染）；
+ * 超出部分用反引号包裹，阻止飞书将其解析为卡片表格元素。
+ */
+export function sanitizeTextForCard(text: string, tableLimit: number = FEISHU_CARD_TABLE_LIMIT): string {
+  return sanitizeTextSegmentsForCard([text], tableLimit)[0];
+}
+
+function wrapTablesBeyondLimit(text: string, matches: readonly MarkdownTableMatch[], keepCount: number): string {
+  if (matches.length <= keepCount) return text;
+
+  // Back-to-front replacement keeps the original indices stable.
+  let result = text;
+  for (let i = matches.length - 1; i >= keepCount; i--) {
+    const { index, length, raw } = matches[i];
+    const replacement = `\`\`\`\n${raw}\n\`\`\``;
+    result = result.slice(0, index) + replacement + result.slice(index + length);
+  }
+
+  return result;
+}

--- a/src/card/cardkit.ts
+++ b/src/card/cardkit.ts
@@ -6,11 +6,12 @@
  */
 
 import type { ClawdbotConfig } from 'openclaw/plugin-sdk';
-import type { FeishuSendResult } from '../messaging/types';
 import { LarkClient } from '../core/lark-client';
 import { larkLogger } from '../core/lark-logger';
-import { normalizeFeishuTarget, normalizeMessageId, resolveReceiveIdType } from '../core/targets';
 import { runWithMessageUnavailableGuard } from '../core/message-unavailable';
+import { normalizeFeishuTarget, normalizeMessageId, resolveReceiveIdType } from '../core/targets';
+import type { FeishuSendResult } from '../messaging/types';
+import { CardKitApiError } from './card-error';
 
 const log = larkLogger('card/cardkit');
 
@@ -45,8 +46,13 @@ function logCardKitResponse(params: { resp: CardKitResponse; api: string; contex
   const { code, msg } = resp;
   log.info(`cardkit ${api} response`, { code, msg, context });
   if (code && code !== 0) {
-    log.warn(`cardkit ${api} FAILED`, { code, msg, context, fullResponse: resp });
-    throw new Error(`cardkit ${api} FAILED: code=${code}, msg=${msg ?? ''}, ${context}`);
+    log.warn(`cardkit ${api} FAILED`, {
+      code,
+      msg,
+      context,
+      fullResponse: resp,
+    });
+    throw new CardKitApiError({ api, code, msg: msg ?? '', context });
   }
 }
 
@@ -80,7 +86,11 @@ export async function createCardEntity(params: {
   // 兼容不同 SDK 包装层：优先 data.card_id，回退顶层 card_id
   const cardId =
     ((response.data?.card_id ?? (response as Record<string, unknown>).card_id) as string | undefined) ?? null;
-  logCardKitResponse({ resp: response, api: 'card.create', context: `cardId=${cardId}` });
+  logCardKitResponse({
+    resp: response,
+    api: 'card.create',
+    context: `cardId=${cardId}`,
+  });
   return cardId;
 }
 
@@ -198,7 +208,11 @@ export async function sendCardByCardId(params: {
       fn: () =>
         client.im.message.reply({
           path: { message_id: normalizedId! },
-          data: { content: contentPayload, msg_type: 'interactive', reply_in_thread: replyInThread },
+          data: {
+            content: contentPayload,
+            msg_type: 'interactive',
+            reply_in_thread: replyInThread,
+          },
         }),
     });
     return {

--- a/src/card/reply-dispatcher.ts
+++ b/src/card/reply-dispatcher.ts
@@ -19,13 +19,14 @@ import { createAccountScopedConfig, getLarkAccount } from '../core/accounts';
 import { resolveFooterConfig } from '../core/footer-config';
 import { LarkClient } from '../core/lark-client';
 import { larkLogger } from '../core/lark-logger';
-import { sendMessageFeishu, sendMarkdownCardFeishu } from '../messaging/outbound/send';
+import { sendMediaLark } from '../messaging/outbound/deliver';
+import { sendMarkdownCardFeishu, sendMessageFeishu } from '../messaging/outbound/send';
 import { addTypingIndicator, removeTypingIndicator, type TypingIndicatorState } from '../messaging/outbound/typing';
-import { resolveReplyMode, expandAutoMode, shouldUseCard } from './reply-mode';
+import { isCardTableLimitError } from './card-error';
+import type { CreateFeishuReplyDispatcherParams, FeishuReplyDispatcherResult } from './reply-dispatcher-types';
+import { expandAutoMode, resolveReplyMode, shouldUseCard } from './reply-mode';
 import { StreamingCardController } from './streaming-card-controller';
 import { UnavailableGuard } from './unavailable-guard';
-import { sendMediaLark } from '../messaging/outbound/deliver';
-import type { CreateFeishuReplyDispatcherParams, FeishuReplyDispatcherResult } from './reply-dispatcher-types';
 
 const log = larkLogger('card/reply-dispatcher');
 
@@ -43,6 +44,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   // Resolve account so we can read per-account config (e.g. replyMode)
   const account = getLarkAccount(cfg, accountId);
   const feishuCfg = account.config;
+  // accountScopedCfg 用于需要 account-level 覆盖的配置项（如 tableMode）
   const accountScopedCfg = createAccountScopedConfig(cfg, account.accountId);
 
   const prefixContext = createReplyPrefixContext({ cfg, agentId });
@@ -71,6 +73,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   // ---- Chunk & render settings (static mode only) ----
   const textChunkLimit = core.channel.text.resolveTextChunkLimit(cfg, 'feishu', accountId, { fallbackLimit: 4000 });
   const chunkMode = core.channel.text.resolveChunkMode(cfg, 'feishu');
+  // 使用 accountScopedCfg 以支持 per-account tableMode 覆盖
   const tableMode = core.channel.text.resolveMarkdownTableMode({
     cfg: accountScopedCfg,
     channel: 'feishu',
@@ -178,7 +181,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     },
 
     deliver: async (payload: ReplyPayload) => {
-      log.debug('deliver called', { textPreview: payload.text?.slice(0, 100) });
+      log.debug('deliver called', {
+        textPreview: payload.text?.slice(0, 100),
+      });
 
       if (shouldSkip('deliver.entry')) return;
 
@@ -196,10 +201,13 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         return;
       }
 
+      // 提取文本和媒体 URL
       const text = payload.text ?? '';
-      const payloadMediaUrls = payload.mediaUrls?.length ? payload.mediaUrls
-        : payload.mediaUrl ? [payload.mediaUrl]
-        : [];
+      const payloadMediaUrls = payload.mediaUrls?.length
+        ? payload.mediaUrls
+        : payload.mediaUrl
+          ? [payload.mediaUrl]
+          : [];
       if (!text.trim() && payloadMediaUrls.length === 0) {
         log.debug('deliver: empty text and no media, skipping');
         return;
@@ -222,8 +230,30 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       if (text.trim()) {
         if (shouldUseCard(text)) {
           const chunks = core.channel.text.chunkTextWithMode(text, textChunkLimit, chunkMode);
-          log.info('deliver: sending card chunks', { count: chunks.length, chatId });
+          log.info('deliver: sending card chunks', {
+            count: chunks.length,
+            chatId,
+          });
+          // Runtime fallback: shouldUseCard() 通过但 API 仍拒绝（表格数超限）
+          let cardTableLimitHit = false;
           for (const chunk of chunks) {
+            if (cardTableLimitHit) {
+              // 已触发降级，后续 chunk 直接走纯文本
+              try {
+                await sendMessageFeishu({
+                  cfg,
+                  to: chatId,
+                  text: chunk,
+                  replyToMessageId,
+                  replyInThread,
+                  accountId,
+                });
+              } catch (fallbackErr) {
+                if (staticGuard?.terminate('deliver.textFallback', fallbackErr)) return;
+                throw fallbackErr;
+              }
+              continue;
+            }
             try {
               await sendMarkdownCardFeishu({
                 cfg,
@@ -235,13 +265,35 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               });
             } catch (err) {
               if (staticGuard?.terminate('deliver.cardChunk', err)) return;
+              // 卡片表格数超出飞书限制 — 降级为纯文本
+              if (isCardTableLimitError(err)) {
+                log.warn('card table limit exceeded (230099/11310), falling back to text', { chatId });
+                cardTableLimitHit = true;
+                try {
+                  await sendMessageFeishu({
+                    cfg,
+                    to: chatId,
+                    text: chunk,
+                    replyToMessageId,
+                    replyInThread,
+                    accountId,
+                  });
+                } catch (fallbackErr) {
+                  if (staticGuard?.terminate('deliver.textFallback', fallbackErr)) return;
+                  throw fallbackErr;
+                }
+                continue;
+              }
               throw err;
             }
           }
         } else {
           const converted = core.channel.text.convertMarkdownTables(text, tableMode);
           const chunks = core.channel.text.chunkTextWithMode(converted, textChunkLimit, chunkMode);
-          log.info('deliver: sending text chunks', { count: chunks.length, chatId });
+          log.info('deliver: sending text chunks', {
+            count: chunks.length,
+            chatId,
+          });
           for (const chunk of chunks) {
             try {
               await sendMessageFeishu({
@@ -264,7 +316,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       for (const mediaUrl of payloadMediaUrls) {
         if (!mediaUrl?.trim()) continue;
         try {
-          log.info('deliver: sending media via static path', { mediaUrl: mediaUrl.slice(0, 80) });
+          log.info('deliver: sending media via static path', {
+            mediaUrl: mediaUrl.slice(0, 80),
+          });
           await sendMediaLark({
             cfg,
             to: chatId,
@@ -275,7 +329,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           });
         } catch (mediaErr) {
           if (staticGuard?.terminate('deliver.media', mediaErr)) return;
-          log.error('deliver: static media send failed', { error: String(mediaErr) });
+          log.error('deliver: static media send failed', {
+            error: String(mediaErr),
+          });
         }
       }
     },

--- a/src/card/reply-mode.ts
+++ b/src/card/reply-mode.ts
@@ -9,6 +9,7 @@
  */
 
 import type { FeishuConfig } from '../core/types';
+import { FEISHU_CARD_TABLE_LIMIT, findMarkdownTablesOutsideCodeBlocks } from './card-error';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -75,12 +76,17 @@ export function expandAutoMode(params: {
  * markdown tables).
  */
 export function shouldUseCard(text: string): boolean {
+  // Table limit takes priority -- even with code blocks, too many tables will fail
+  const tableMatches = findMarkdownTablesOutsideCodeBlocks(text);
+  if (tableMatches.length > FEISHU_CARD_TABLE_LIMIT) {
+    return false;
+  }
   // Fenced code blocks
   if (/```[\s\S]*?```/.test(text)) {
     return true;
   }
   // Markdown tables (header + separator rows separated by pipes)
-  if (/\|.+\|[\r\n]+\|[-:| ]+\|/.test(text)) {
+  if (tableMatches.length > 0) {
     return true;
   }
   return false;

--- a/src/card/streaming-card-controller.ts
+++ b/src/card/streaming-card-controller.ts
@@ -15,36 +15,52 @@ import { SILENT_REPLY_TOKEN } from 'openclaw/plugin-sdk/reply-runtime';
 import type { ReplyPayload } from 'openclaw/plugin-sdk';
 import { extractLarkApiCode } from '../core/api-error';
 import { larkLogger } from '../core/lark-logger';
+import { registerShutdownHook } from '../core/shutdown-hooks';
 import { sendCardFeishu, updateCardFeishu } from '../messaging/outbound/send';
+import { buildCardContent, STREAMING_ELEMENT_ID, splitReasoningText, stripReasoningTags, toCardKit2 } from './builder';
+import {
+  FEISHU_CARD_TABLE_LIMIT,
+  isCardRateLimitError,
+  isCardTableLimitError,
+  sanitizeTextSegmentsForCard,
+} from './card-error';
 import {
   createCardEntity,
   sendCardByCardId,
+  setCardStreamingMode,
   streamCardContent,
   updateCardKitCard,
-  setCardStreamingMode,
 } from './cardkit';
-import { buildCardContent, splitReasoningText, stripReasoningTags, STREAMING_ELEMENT_ID, toCardKit2 } from './builder';
-import { optimizeMarkdownStyle } from './markdown-style';
-import { ImageResolver } from './image-resolver';
-import { registerShutdownHook } from '../core/shutdown-hooks';
 import { FlushController } from './flush-controller';
-import { UnavailableGuard } from './unavailable-guard';
+import { ImageResolver } from './image-resolver';
+import { optimizeMarkdownStyle } from './markdown-style';
 import type {
-  CardPhase,
-  TerminalReason,
-  ReasoningState,
-  StreamingTextState,
   CardKitState,
+  CardPhase,
+  ReasoningState,
   StreamingCardDeps,
+  StreamingTextState,
+  TerminalReason,
 } from './reply-dispatcher-types';
 import {
-  TERMINAL_PHASES,
-  PHASE_TRANSITIONS,
-  THROTTLE_CONSTANTS,
   EMPTY_REPLY_FALLBACK_TEXT,
+  PHASE_TRANSITIONS,
+  TERMINAL_PHASES,
+  THROTTLE_CONSTANTS,
 } from './reply-dispatcher-types';
+import { UnavailableGuard } from './unavailable-guard';
 
 const log = larkLogger('card/streaming');
+
+interface TerminalCardTextImageResolver {
+  resolveImages(text: string): string;
+}
+
+interface TerminalCardContentInput {
+  text: string;
+  reasoningText?: string;
+}
+
 // ---------------------------------------------------------------------------
 // CardKit 2.0 initial streaming payload
 // ---------------------------------------------------------------------------
@@ -53,6 +69,7 @@ const STREAMING_THINKING_CARD = {
   schema: '2.0',
   config: {
     streaming_mode: true,
+    // locales 用于支持多语言摘要展示
     locales: ['zh_cn', 'en_us'],
     summary: {
       content: 'Thinking...',
@@ -376,10 +393,16 @@ export class StreamingCardController {
         const rawErrorText = this.text.accumulatedText
           ? `${this.text.accumulatedText}\n\n---\n**Error**: An error occurred while generating the response.`
           : '**Error**: An error occurred while generating the response.';
-        const errorText = this.imageResolver.resolveImages(rawErrorText);
+        const terminalContent = prepareTerminalCardContent(
+          {
+            text: rawErrorText,
+            reasoningText: this.reasoning.accumulatedReasoningText || undefined,
+          },
+          this.imageResolver,
+        );
         const errorCard = buildCardContent('complete', {
-          text: errorText,
-          reasoningText: this.reasoning.accumulatedReasoningText || undefined,
+          text: terminalContent.text,
+          reasoningText: terminalContent.reasoningText,
           reasoningElapsedMs: this.reasoning.reasoningElapsedMs || undefined,
           elapsedMs: this.elapsed(),
           isError: true,
@@ -444,11 +467,20 @@ export class StreamingCardController {
           log.warn('reply completed without visible text, using empty-reply fallback');
         }
 
+        // 等待图片异步解析（最多 15s），避免终态卡片留占位符
         const resolvedDisplayText = await this.imageResolver.resolveImagesAwait(displayText, 15_000);
 
+        const terminalContent = prepareTerminalCardContent(
+          {
+            text: resolvedDisplayText,
+            reasoningText: this.reasoning.accumulatedReasoningText || undefined,
+          },
+          this.imageResolver,
+        );
+
         const completeCard = buildCardContent('complete', {
-          text: resolvedDisplayText,
-          reasoningText: this.reasoning.accumulatedReasoningText || undefined,
+          text: terminalContent.text,
+          reasoningText: terminalContent.reasoningText,
           reasoningElapsedMs: this.reasoning.reasoningElapsedMs || undefined,
           elapsedMs: this.elapsed(),
           footer: this.deps.resolvedFooter,
@@ -511,10 +543,16 @@ export class StreamingCardController {
       const effectiveCardId = this.cardKit.cardKitCardId ?? this.cardKit.originalCardKitCardId;
       if (effectiveCardId) {
         const elapsedMs = Date.now() - this.dispatchStartTime;
-        const abortText = this.imageResolver.resolveImages(this.text.accumulatedText || 'Aborted.');
+        const terminalContent = prepareTerminalCardContent(
+          {
+            text: this.text.accumulatedText || 'Aborted.',
+            reasoningText: this.reasoning.accumulatedReasoningText || undefined,
+          },
+          this.imageResolver,
+        );
         const abortCardContent = buildCardContent('complete', {
-          text: abortText,
-          reasoningText: this.reasoning.accumulatedReasoningText || undefined,
+          text: terminalContent.text,
+          reasoningText: terminalContent.reasoningText,
           reasoningElapsedMs: this.reasoning.reasoningElapsedMs || undefined,
           elapsedMs,
           isAborted: true,
@@ -525,10 +563,16 @@ export class StreamingCardController {
       } else if (this.cardKit.cardMessageId) {
         // IM fallback: 卡片不是通过 CardKit 发的，用 im.message.patch 更新
         const elapsedMs = Date.now() - this.dispatchStartTime;
-        const abortText = this.imageResolver.resolveImages(this.text.accumulatedText || 'Aborted.');
+        const terminalContent = prepareTerminalCardContent(
+          {
+            text: this.text.accumulatedText || 'Aborted.',
+            reasoningText: this.reasoning.accumulatedReasoningText || undefined,
+          },
+          this.imageResolver,
+        );
         const abortCard = buildCardContent('complete', {
-          text: abortText,
-          reasoningText: this.reasoning.accumulatedReasoningText || undefined,
+          text: terminalContent.text,
+          reasoningText: terminalContent.reasoningText,
           reasoningElapsedMs: this.reasoning.reasoningElapsedMs || undefined,
           elapsedMs,
           isAborted: true,
@@ -540,7 +584,9 @@ export class StreamingCardController {
           card: abortCard as unknown as Record<string, unknown>,
           accountId: this.deps.accountId,
         });
-        log.info('abortCard completed (IM fallback)', { messageId: this.cardKit.cardMessageId });
+        log.info('abortCard completed (IM fallback)', {
+          messageId: this.cardKit.cardMessageId,
+        });
       }
     } catch (err) {
       log.warn('abortCard failed', { error: String(err) });
@@ -663,7 +709,9 @@ export class StreamingCardController {
         if (this.guard.terminate('ensureCardCreated.outer', err)) {
           return;
         }
-        log.warn('thinking card failed, falling back to static', { error: String(err) });
+        log.warn('thinking card failed, falling back to static', {
+          error: String(err),
+        });
         this.transition('creation_failed', 'ensureCardCreated.outer', 'creation_failed');
       }
     })();
@@ -691,6 +739,7 @@ export class StreamingCardController {
 
     try {
       const displayText = this.buildDisplayText();
+      // 流式中间帧使用同步 resolveImages（不等待异步上传）
       const resolvedText = this.imageResolver.resolveImages(displayText);
 
       if (this.cardKit.cardKitCardId) {
@@ -727,10 +776,21 @@ export class StreamingCardController {
 
       const apiCode = extractLarkApiCode(err);
 
-      if (apiCode === 230020) {
+      // 速率限制（230020）— 跳过此帧，不降级
+      if (isCardRateLimitError(err)) {
         log.info('flushCardUpdate: rate limited (230020), skipping', {
           seq: this.cardKit.cardKitSequence,
         });
+        return;
+      }
+
+      // 卡片表格数超出飞书限制（230099/11310）— 禁用 CardKit 流式，
+      // 保留 originalCardKitCardId 供 onIdle 做最终 CardKit 更新
+      if (isCardTableLimitError(err)) {
+        log.warn('flushCardUpdate: card table limit exceeded (230099/11310), disabling CardKit streaming', {
+          seq: this.cardKit.cardKitSequence,
+        });
+        this.cardKit.cardKitCardId = null;
         return;
       }
 
@@ -809,6 +869,32 @@ export class StreamingCardController {
 // ---------------------------------------------------------------------------
 // Error detail extraction helpers (replacing `any` casts)
 // ---------------------------------------------------------------------------
+
+/**
+ * 终态卡片的正文和 reasoning 都会被飞书按 markdown 渲染，
+ * 因此两者都要先做图片替换与表格降级，避免再次撞到 230099/11310。
+ */
+export function prepareTerminalCardContent(
+  content: TerminalCardContentInput,
+  imageResolver: TerminalCardTextImageResolver,
+  tableLimit: number = FEISHU_CARD_TABLE_LIMIT,
+): TerminalCardContentInput {
+  const resolvedReasoningText = content.reasoningText ? imageResolver.resolveImages(content.reasoningText) : undefined;
+  const resolvedText = imageResolver.resolveImages(content.text);
+  const sanitizedSegments = sanitizeTextSegmentsForCard(
+    resolvedReasoningText ? [resolvedReasoningText, resolvedText] : [resolvedText],
+    tableLimit,
+  );
+
+  if (resolvedReasoningText) {
+    return {
+      reasoningText: sanitizedSegments[0],
+      text: sanitizedSegments[1],
+    };
+  }
+
+  return { text: sanitizedSegments[0] };
+}
 
 function extractApiDetail(err: unknown): string {
   if (!err || typeof err !== 'object') return String(err);

--- a/test/card-review-followup.test.mjs
+++ b/test/card-review-followup.test.mjs
@@ -1,0 +1,264 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const rootDir = process.cwd();
+const tempDir = path.join(rootDir, 'test/.tmp/card-review-followup');
+fs.mkdirSync(tempDir, { recursive: true });
+
+function tempModuleUrl(filename) {
+  return pathToFileURL(path.join(tempDir, filename)).href;
+}
+
+function writeTempModule(filename, content) {
+  const target = path.join(tempDir, filename);
+  fs.writeFileSync(target, content, 'utf8');
+  return tempModuleUrl(filename);
+}
+
+function loadSource(relativePath) {
+  return fs.readFileSync(path.join(rootDir, relativePath), 'utf8');
+}
+
+function writeCardErrorModule() {
+  const apiErrorStubUrl = writeTempModule(
+    'api-error.stub.mjs',
+    'export function extractLarkApiCode() { return undefined; }\n',
+  );
+
+  const source = loadSource('src/card/card-error.ts').replace("'../core/api-error'", `'${apiErrorStubUrl}'`);
+  const filename = `card-error.${Date.now()}-${Math.random().toString(16).slice(2)}.ts`;
+  fs.writeFileSync(path.join(tempDir, filename), source, 'utf8');
+  return tempModuleUrl(filename);
+}
+
+function writeReplyModeModule(cardErrorUrl) {
+  const source = loadSource('src/card/reply-mode.ts')
+    .replace("import type { FeishuConfig } from '../core/types';\n", 'type FeishuConfig = any;\n')
+    .replace("'./card-error'", `'${cardErrorUrl}'`);
+
+  const filename = `reply-mode.${Date.now()}-${Math.random().toString(16).slice(2)}.ts`;
+  fs.writeFileSync(path.join(tempDir, filename), source, 'utf8');
+  return tempModuleUrl(filename);
+}
+
+function writeStreamingControllerModule(cardErrorUrl) {
+  const pluginSdkStubUrl = writeTempModule(
+    'plugin-sdk.stub.mjs',
+    "export const SILENT_REPLY_TOKEN = '__silent__';\n",
+  );
+  const apiErrorStubUrl = writeTempModule(
+    'controller-api-error.stub.mjs',
+    'export function extractLarkApiCode() { return undefined; }\n',
+  );
+  const loggerStubUrl = writeTempModule(
+    'lark-logger.stub.mjs',
+    [
+      'export function larkLogger() {',
+      '  return { debug() {}, info() {}, warn() {}, error() {} };',
+      '}',
+      '',
+    ].join('\n'),
+  );
+  const shutdownHooksStubUrl = writeTempModule(
+    'shutdown-hooks.stub.mjs',
+    'export function registerShutdownHook() { return () => {}; }\n',
+  );
+  const outboundSendStubUrl = writeTempModule(
+    'outbound-send.stub.mjs',
+    [
+      'export async function sendCardFeishu() { return { messageId: "msg_stub" }; }',
+      'export async function updateCardFeishu() {}',
+      '',
+    ].join('\n'),
+  );
+  const builderStubUrl = writeTempModule(
+    'builder.stub.mjs',
+    [
+      'export const STREAMING_ELEMENT_ID = "streaming";',
+      'export function splitReasoningText(text) { return { answerText: text }; }',
+      'export function stripReasoningTags(text) { return text; }',
+      'export function toCardKit2(card) { return card; }',
+      'export function buildCardContent(state, data = {}) { return { state, ...data }; }',
+      '',
+    ].join('\n'),
+  );
+  const cardkitStubUrl = writeTempModule(
+    'cardkit.stub.mjs',
+    [
+      'export async function createCardEntity() { return "card_stub"; }',
+      'export async function sendCardByCardId() { return { messageId: "msg_stub" }; }',
+      'export async function setCardStreamingMode() {}',
+      'export async function streamCardContent() {}',
+      'export async function updateCardKitCard() {}',
+      '',
+    ].join('\n'),
+  );
+  const flushControllerStubUrl = writeTempModule(
+    'flush-controller.stub.mjs',
+    [
+      'export class FlushController {',
+      '  constructor(flush) { this.flush = flush; }',
+      '  cancelPendingFlush() {}',
+      '  complete() {}',
+      '  waitForFlush() { return Promise.resolve(); }',
+      '  setCardMessageReady() {}',
+      '  throttledUpdate() { return Promise.resolve(); }',
+      '}',
+      '',
+    ].join('\n'),
+  );
+  const imageResolverStubUrl = writeTempModule(
+    'image-resolver.stub.mjs',
+    [
+      'export class ImageResolver {',
+      '  constructor() {}',
+      '  resolveImages(text) { return text; }',
+      '  resolveImagesAwait(text) { return Promise.resolve(text); }',
+      '}',
+      '',
+    ].join('\n'),
+  );
+  const markdownStyleStubUrl = writeTempModule(
+    'markdown-style.stub.mjs',
+    'export function optimizeMarkdownStyle(text) { return text; }\n',
+  );
+  const dispatcherTypesStubUrl = writeTempModule(
+    'reply-dispatcher-types.stub.mjs',
+    [
+      'export const EMPTY_REPLY_FALLBACK_TEXT = "Done.";',
+      'export const PHASE_TRANSITIONS = {',
+      '  idle: new Set(["creating", "aborted", "terminated"]),',
+      '  creating: new Set(["streaming", "creation_failed", "aborted", "terminated"]),',
+      '  streaming: new Set(["completed", "aborted", "terminated"]),',
+      '  completed: new Set(),',
+      '  aborted: new Set(),',
+      '  terminated: new Set(),',
+      '  creation_failed: new Set(),',
+      '};',
+      'export const TERMINAL_PHASES = new Set(["completed", "aborted", "terminated", "creation_failed"]);',
+      'export const THROTTLE_CONSTANTS = { CARDKIT_MS: 100, PATCH_MS: 1500 };',
+      '',
+    ].join('\n'),
+  );
+  const unavailableGuardStubUrl = writeTempModule(
+    'unavailable-guard.stub.mjs',
+    [
+      'export class UnavailableGuard {',
+      '  constructor() {}',
+      '  shouldSkip() { return false; }',
+      '  terminate() { return false; }',
+      '  get isTerminated() { return false; }',
+      '}',
+      '',
+    ].join('\n'),
+  );
+
+  const source = loadSource('src/card/streaming-card-controller.ts')
+    .replace(
+      "import { type ReplyPayload, SILENT_REPLY_TOKEN } from 'openclaw/plugin-sdk';",
+      `import { SILENT_REPLY_TOKEN } from '${pluginSdkStubUrl}';\ntype ReplyPayload = any;`,
+    )
+    .replace(
+      "import type {\n  CardKitState,\n  CardPhase,\n  ReasoningState,\n  StreamingCardDeps,\n  StreamingTextState,\n  TerminalReason,\n} from './reply-dispatcher-types';",
+      'type CardKitState = any;\ntype CardPhase = any;\ntype ReasoningState = any;\ntype StreamingCardDeps = any;\ntype StreamingTextState = any;\ntype TerminalReason = any;',
+    )
+    .replace("'../core/api-error'", `'${apiErrorStubUrl}'`)
+    .replace("'../core/lark-logger'", `'${loggerStubUrl}'`)
+    .replace("'../core/shutdown-hooks'", `'${shutdownHooksStubUrl}'`)
+    .replace("'../messaging/outbound/send'", `'${outboundSendStubUrl}'`)
+    .replace("'./builder'", `'${builderStubUrl}'`)
+    .replace("'./card-error'", `'${cardErrorUrl}'`)
+    .replace("'./cardkit'", `'${cardkitStubUrl}'`)
+    .replace("'./flush-controller'", `'${flushControllerStubUrl}'`)
+    .replace("'./image-resolver'", `'${imageResolverStubUrl}'`)
+    .replace("'./markdown-style'", `'${markdownStyleStubUrl}'`)
+    .replace("'./reply-dispatcher-types'", `'${dispatcherTypesStubUrl}'`)
+    .replace("'./unavailable-guard'", `'${unavailableGuardStubUrl}'`);
+
+  const filename = `streaming-card-controller.${Date.now()}-${Math.random().toString(16).slice(2)}.ts`;
+  fs.writeFileSync(path.join(tempDir, filename), source, 'utf8');
+  return tempModuleUrl(filename);
+}
+
+function buildTable(label) {
+  return `| name | value |\n| --- | --- |\n| ${label} | ${label} |`;
+}
+
+function buildCodeBlockWithTables(count) {
+  return [
+    '```md',
+    ...Array.from({ length: count }, (_, index) => buildTable(`code-${index + 1}`)),
+    '```',
+  ].join('\n\n');
+}
+
+test('shouldUseCard ignores fenced-code tables when checking the table limit', async () => {
+  const cardErrorUrl = writeCardErrorModule();
+  const replyModeUrl = writeReplyModeModule(cardErrorUrl);
+  const { shouldUseCard } = await import(`${replyModeUrl}?case=${Date.now()}`);
+
+  const text = buildCodeBlockWithTables(4);
+
+  assert.equal(shouldUseCard(text), true);
+});
+
+test('sanitizeTextForCard only wraps excess tables outside fenced code blocks', async () => {
+  const cardErrorUrl = writeCardErrorModule();
+  const { sanitizeTextForCard } = await import(`${cardErrorUrl}?case=${Date.now()}`);
+
+  const text = [
+    buildCodeBlockWithTables(4),
+    buildTable('real-1'),
+    buildTable('real-2'),
+    buildTable('real-3'),
+    buildTable('real-4'),
+  ].join('\n\n');
+
+  const sanitized = sanitizeTextForCard(text);
+
+  assert.match(sanitized, /```md[\s\S]*\| code-4 \| code-4 \|[\s\S]*```/);
+  assert.match(sanitized, /```\n\| name \| value \|\n\| --- \| --- \|\n\| real-4 \| real-4 \|\n```/);
+  assert.ok(!sanitized.includes('```\n| name | value |\n| --- | --- |\n| code-4 | code-4 |\n```'));
+});
+
+test('streaming terminal helper shares the table budget across reasoning and body', async () => {
+  const cardErrorUrl = writeCardErrorModule();
+  const controllerUrl = writeStreamingControllerModule(cardErrorUrl);
+  const { findMarkdownTablesOutsideCodeBlocks } = await import(`${cardErrorUrl}?case=${Date.now()}-tables`);
+  const { prepareTerminalCardContent } = await import(`${controllerUrl}?case=${Date.now()}`);
+
+  assert.equal(typeof prepareTerminalCardContent, 'function');
+
+  const rawText = [
+    'Before',
+    buildTable('real-1'),
+    buildTable('real-2'),
+    'After',
+  ].join('\n\n');
+  const rawReasoningText = [
+    buildTable('reason-1'),
+    buildTable('reason-2'),
+  ].join('\n\n');
+  const imageResolver = {
+    resolveImages(text) {
+      return text.replace('Before', 'Resolved');
+    },
+  };
+
+  const safeContent = prepareTerminalCardContent(
+    {
+      text: rawText,
+      reasoningText: rawReasoningText,
+    },
+    imageResolver,
+  );
+
+  assert.match(safeContent.text, /^Resolved/);
+  assert.equal(findMarkdownTablesOutsideCodeBlocks(safeContent.reasoningText).length, 2);
+  assert.equal(findMarkdownTablesOutsideCodeBlocks(safeContent.text).length, 1);
+  assert.match(safeContent.text, /```\n\| name \| value \|\n\| --- \| --- \|\n\| real-2 \| real-2 \|\n```/);
+  assert.ok(!safeContent.reasoningText.includes('```\n| name | value |'));
+});


### PR DESCRIPTION
## 问题

飞书卡片在包含过多 markdown 表格时会返回错误码 `230099`（子错误 `ErrCode: 11310`，`card table number over limit`），导致消息发送失败，用户端永远停在"正在输入"，收不到任何回复。

## 修复方案

### 新建 `src/card/card-error.ts` 统一卡片错误模块

- `CardKitApiError` 结构化错误类，保留 `code`/`msg` 字段
- 子错误码解析（从 msg 中提取 `ErrCode`）
- `isCardTableLimitError` / `isCardRateLimitError` 判断函数
- `sanitizeTextForCard` 将超限表格降级为 code block
- `FEISHU_CARD_TABLE_LIMIT` 常量（经验值 3）

### 修复 `src/card/cardkit.ts`

`logCardKitResponse` 改抛 `CardKitApiError` 替代普通 `Error`，使 `extractLarkApiCode` 能从 CardKit API 错误中提取错误码（修复了 230020 rate limit 处理在 CardKit 路径上的同一问题）

### 修复 `src/card/reply-mode.ts`

`shouldUseCard()` 表格超限检查移到代码块检查之前，避免同时含代码块和 4+ 表格时预检失效

### 修复 `src/card/reply-dispatcher.ts`

- 精确匹配 230099/11310（通过 `isCardTableLimitError`）
- 降级 `sendMessageFeishu` 加 `try/catch` + `staticGuard` 保护
- `cardTableLimitHit` 标志跳过后续 chunk 的卡片尝试

### 修复 `src/card/streaming-card-controller.ts`

- `performFlush` 中用 `isCardRateLimitError` / `isCardTableLimitError` 替代裸错误码判断
- `onIdle` 终态更新前用 `sanitizeTextForCard` 预检，避免最终 CardKit 更新再次触发 230099

## 测试计划

- [ ] 发送生成 4+ 张表格的消息，应收到纯文本回复而非卡住
- [ ] 发送 1-3 张表格的消息，应正常渲染为卡片
- [ ] 发送含代码块 + 4 张表格的消息，应走纯文本
- [ ] 流式模式下表格超限时，应正确降级
- [ ] 代码块内的示例表格不应被误计数

Closes #53, closes #46