### PR TITLE
fix: allow accounts.default overrides to take effect

### DIFF
--- a/src/core/accounts.ts
+++ b/src/core/accounts.ts
@@ -110,7 +110,7 @@ export function getLarkAccount(cfg: ClawdbotConfig, accountId?: string | null): 
   const base = baseConfig(section);
   const accountMap = getAccountMap(section);
   const accountOverride =
-    accountMap && requestedId !== DEFAULT_ACCOUNT_ID
+    accountMap
       ? (accountMap[requestedId] as Partial<FeishuConfig> | undefined)
       : undefined;
 


### PR DESCRIPTION
## Problem

When using multi-account configuration with an explicit `accounts.default` entry, any account-specific fields (such as `encryptKey` or `verificationToken`) defined under `accounts.default` are silently ignored.

## Root Cause

In `getLarkAccount()`, the override lookup explicitly skips the default account:

```typescript
const accountOverride =
    accountMap && requestedId !== DEFAULT_ACCOUNT_ID  // ← skips "default"
      ? (accountMap[requestedId])
      : undefined;
```

This means `accounts.default` is never merged.

## Fix

Remove the `requestedId !== DEFAULT_ACCOUNT_ID` guard so that `accounts.default` is merged the same way as any other account entry.

## Backward Compatibility

Fully backward-compatible: when `accounts.default` is absent, the `accountMap` lookup returns `undefined` and the existing fallback-to-base-config path is taken.

## Context

This fixes a breaking issue for multi-enterprise deployments where a single OpenClaw agent connects to multiple Feishu/Lark tenants.

Fixes #72