### PR TITLE
fix(system-command): ensure greeting message is received after session reset

### DIFF
--- a/src/messaging/inbound/dispatch.ts
+++ b/src/messaging/inbound/dispatch.ts
@@ -252,7 +252,7 @@ export async function dispatchToAgent(params: {
   const skillFilter = dc.isGroup ? (params.groupConfig?.skills ?? params.defaultGroupConfig?.skills) : undefined;
 
   if (isCommand) {
-    await dispatchSystemCommand(dc, ctxPayload, isBareNewOrReset, params.replyToMessageId);
+    await dispatchSystemCommand(dc, ctxPayload, false, params.replyToMessageId);
     // /new and /reset explicitly start a new session — clear pending history
     if (isBareNewOrReset && dc.isGroup && historyKey && params.chatHistories) {
       clearHistoryEntriesIfEnabled({


### PR DESCRIPTION
Previously, after resetting the session context, the greeting from OpenClaw was not received due to the `isBareNewOrReset` flag causing dispatchSystemCommand to skip sending messages. This change passes `false` instead, restoring the expected greeting behavior.

修复重置会话上下文后无法接收到 OpenClaw 招呼语的问题
在重置会话上下文后，由于 `isBareNewOrReset` 标志导致 dispatchSystemCommand 跳过发送消息，OpenClaw 的招呼语无法接收。此次修改将该参数改为 `false`，
确保招呼语按预期发送。

<img width="1463" height="1010" alt="image" src="https://github.com/user-attachments/assets/478eb744-af56-4c80-92b6-18e2c20ef322" />
