### PR TITLE
feat: add sticker message support

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -48,6 +48,7 @@ export {
   sendTextLark,
   sendCardLark,
   sendMediaLark,
+  sendStickerLark,
   type SendTextLarkParams,
   type SendCardLarkParams,
   type SendMediaLarkParams,

--- a/src/messaging/outbound/deliver.ts
+++ b/src/messaging/outbound/deliver.ts
@@ -81,7 +81,7 @@ async function sendImMessage(params: {
   client: ReturnType<typeof LarkClient.fromCfg>['sdk'];
   to: string;
   content: string;
-  msgType: 'post' | 'interactive';
+  msgType: 'post' | 'interactive' | 'sticker';
   replyToMessageId?: string;
   replyInThread?: boolean;
 }): Promise<FeishuSendResult> {
@@ -234,6 +234,12 @@ export interface SendTextLarkParams {
  */
 export async function sendTextLark(params: SendTextLarkParams): Promise<FeishuSendResult> {
   const { cfg, to, text, replyToMessageId, replyInThread, accountId } = params;
+
+  // Detect sticker shorthand: STICKER:<file_key>
+  const stickerMatch = text.trim().match(/^STICKER:(\S+)$/);
+  if (stickerMatch) {
+    return sendStickerLark({ cfg, to, fileKey: stickerMatch[1], replyToMessageId, replyInThread, accountId });
+  }
 
   // Detect card JSON in text — route to card sending before text preprocessing.
   const card = detectCardJson(text);
@@ -389,6 +395,44 @@ export interface SendMediaLarkParams {
  * });
  * ```
  */
+// ---------------------------------------------------------------------------
+// sendStickerLark
+// ---------------------------------------------------------------------------
+
+export interface SendStickerLarkParams {
+  cfg: ClawdbotConfig;
+  to: string;
+  fileKey: string;
+  replyToMessageId?: string;
+  replyInThread?: boolean;
+  accountId?: string;
+}
+
+/**
+ * Send a sticker message to a Feishu chat or user.
+ *
+ * Stickers use `msg_type: "sticker"` with a `file_key` obtained from
+ * a previously received sticker message.  There is no API to upload
+ * custom images as stickers — the bot can only re-send stickers it
+ * has received before.
+ *
+ * @param params - See {@link SendStickerLarkParams}.
+ * @returns The message ID and chat ID.
+ */
+export async function sendStickerLark(params: SendStickerLarkParams): Promise<FeishuSendResult> {
+  const { cfg, to, fileKey, replyToMessageId, replyInThread, accountId } = params;
+
+  log.info(`sendStickerLark: target=${to}, fileKey=${fileKey}`);
+  const client = LarkClient.fromCfg(cfg, accountId).sdk;
+  const content = JSON.stringify({ file_key: fileKey });
+
+  return sendImMessage({ client, to, content, msgType: 'sticker', replyToMessageId, replyInThread });
+}
+
+// ---------------------------------------------------------------------------
+// sendMediaLark
+// ---------------------------------------------------------------------------
+
 export async function sendMediaLark(params: SendMediaLarkParams): Promise<FeishuSendResult> {
   const { cfg, to, mediaUrl, replyToMessageId, replyInThread, accountId, mediaLocalRoots } = params;
 

--- a/src/tools/oapi/im/message.ts
+++ b/src/tools/oapi/im/message.ts
@@ -32,10 +32,10 @@ const FeishuImMessageSchema = Type.Union([
       description: "接收者 ID，与 receive_id_type 对应。open_id 填 'ou_xxx'，chat_id 填 'oc_xxx'",
     }),
     msg_type: StringEnum(
-      ['text', 'post', 'image', 'file', 'audio', 'media', 'interactive', 'share_chat', 'share_user'],
+      ['text', 'post', 'image', 'file', 'audio', 'media', 'interactive', 'share_chat', 'share_user', 'sticker'],
       {
         description:
-          '消息类型：text（纯文本）、post（富文本）、image（图片）、file（文件）、interactive（消息卡片）、share_chat（群名片）、share_user（个人名片）等',
+          '消息类型：text（纯文本）、post（富文本）、image（图片）、file（文件）、interactive（消息卡片）、share_chat（群名片）、share_user（个人名片）、sticker（表情包）等',
       },
     ),
     content: Type.String({
@@ -44,6 +44,7 @@ const FeishuImMessageSchema = Type.Union([
         '示例：text → \'{"text":"你好"}\'，' +
         'image → \'{"image_key":"img_xxx"}\'，' +
         'share_chat → \'{"chat_id":"oc_xxx"}\'，' +
+        'sticker → \'{"file_key":"xxx"}\'，' +
         'post → \'{"zh_cn":{"title":"标题","content":[[{"tag":"text","text":"正文"}]]}}\'',
     }),
     uuid: Type.Optional(
@@ -60,9 +61,9 @@ const FeishuImMessageSchema = Type.Union([
       description: '被回复消息的 ID（om_xxx 格式）',
     }),
     msg_type: StringEnum(
-      ['text', 'post', 'image', 'file', 'audio', 'media', 'interactive', 'share_chat', 'share_user'],
+      ['text', 'post', 'image', 'file', 'audio', 'media', 'interactive', 'share_chat', 'share_user', 'sticker'],
       {
-        description: '消息类型：text（纯文本）、post（富文本）、image（图片）、interactive（消息卡片）等',
+        description: '消息类型：text（纯文本）、post（富文本）、image（图片）、interactive（消息卡片）、sticker（表情包）等',
       },
     ),
     content: Type.String({


### PR DESCRIPTION
## Summary

Add support for sending sticker (表情包) messages via the Feishu IM API.

## Changes

### `feishu_im_user_message` tool (`src/tools/oapi/im/message.ts`)
- Add `sticker` to `msg_type` enum for both send and reply actions
- Add sticker content format example: `'{"file_key":"xxx"}'`

### Bot-identity sticker sending (`src/messaging/outbound/deliver.ts`)
- Add `sendStickerLark()` function using existing `sendImMessage` infrastructure
- Add `STICKER:<file_key>` shorthand detection in `sendTextLark()` for bot-identity sticker sending through the standard text delivery path
- Expand `SendImMessageParams.msgType` union to include `sticker`

### Export (`index.ts`)
- Export `sendStickerLark` for external consumers

## How it works

Feishu stickers use `msg_type: sticker` with a `file_key` from a previously received sticker message. No API exists to upload custom stickers.

- **User identity:** `feishu_im_user_message(msg_type=sticker, content='{"file_key":"xxx"}')`
- **Bot identity:** Send `STICKER:<file_key>` as text — automatically routed to sticker sending

## Testing

Tested with a real Feishu sticker file_key:
- ✅ User-identity sticker sends as `msg_type: sticker`
- ✅ Bot-identity sticker via shorthand sends as `msg_type: sticker` from bot
- ✅ TypeScript compilation: zero errors
