### PR TITLE
feat: add replyInThread config option for group chat thread creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Additionally, the plugin supports:
 - **📱 Interactive Cards**: Real-time status updates (Thinking/Generating/Complete), plus confirmation buttons for sensitive operations
 - **🌊 Streaming Responses**: Live streaming text directly within message cards
 - **🔒 Permission Policies**: Flexible access control policies for DMs and group chats
-- **⚙️ Advanced Group Configuration**: Per-group settings including allowlists, skill bindings, and custom system prompts
+- **⚙️ Advanced Group Configuration**: Per-group settings including allowlists, skill bindings, custom system prompts, and thread-reply controls
+
+> Note: When `replyInThread` is enabled, a single bot turn that emits multiple messages (for example, a card plus a follow-up text) may create multiple threads in non-thread parents. This is a current platform limitation because the first created thread ID is not yet captured and reused for subsequent messages in the same turn.
 
 ## Security & Risk Warnings (Read Before Use)
 

--- a/src/channel/config-adapter.ts
+++ b/src/channel/config-adapter.ts
@@ -14,6 +14,7 @@ import type { ClawdbotConfig } from 'openclaw/plugin-sdk';
 import { DEFAULT_ACCOUNT_ID } from 'openclaw/plugin-sdk';
 import type { FeishuConfig } from '../core/types';
 import { getLarkAccount, getLarkAccountIds } from '../core/accounts';
+import type { FeishuGroupConfig } from '../core/types';
 import { collectIsolationWarnings } from '../core/security-check';
 
 /** Generic Feishu account config merge. */
@@ -96,6 +97,21 @@ export function deleteAccount(cfg: ClawdbotConfig, accountId: string): ClawdbotC
   };
 }
 
+function isReplyInThreadEnabled(groupConfig?: FeishuGroupConfig): boolean {
+  return groupConfig?.replyInThread === 'enabled';
+}
+
+export function hasReplyInThreadWithoutThreadSession(feishuCfg?: FeishuConfig): boolean {
+  const groups = feishuCfg?.groups;
+  const defaultGroupConfig = groups?.['*'];
+  const hasReplyInThreadEnabled =
+    feishuCfg?.replyInThread === 'enabled'
+    || isReplyInThreadEnabled(defaultGroupConfig)
+    || Object.entries(groups ?? {}).some(([groupId, groupConfig]) => groupId !== '*' && isReplyInThreadEnabled(groupConfig));
+
+  return hasReplyInThreadEnabled && feishuCfg?.threadSession !== true;
+}
+
 /** Collect security warnings for a Feishu account. */
 export function collectFeishuSecurityWarnings(params: { cfg: ClawdbotConfig; accountId: string }): string[] {
   const { cfg, accountId } = params;
@@ -111,6 +127,12 @@ export function collectFeishuSecurityWarnings(params: { cfg: ClawdbotConfig; acc
   if (groupPolicy === 'open') {
     warnings.push(
       `- Feishu[${account.accountId}] groups: groupPolicy="open" allows any group to interact (mention-gated). To restrict which groups are allowed, set groupPolicy="allowlist" and list group IDs in channels.feishu.groups. To restrict which senders can trigger the bot, set channels.feishu.groupAllowFrom with user open_ids (ou_xxx).`,
+    );
+  }
+
+  if (hasReplyInThreadWithoutThreadSession(feishuCfg)) {
+    warnings.push(
+      `- Feishu[${account.accountId}] replyInThread is enabled but threadSession is not. Replies may open separate threads while still sharing one conversation session. Consider enabling channels.feishu.threadSession to avoid context bleeding across threads.`,
     );
   }
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -10,6 +10,7 @@ import { runDiagnosis, formatDiagReportText } from './diagnose';
 import { runFeishuDoctor } from './doctor';
 import { runFeishuAuth } from './auth';
 import { getPluginVersion } from '../core/version';
+import { hasReplyInThreadWithoutThreadSession } from '../channel/config-adapter';
 
 import type { FeishuLocale } from './locale';
 
@@ -21,6 +22,7 @@ const T: Record<FeishuLocale, {
   // start
   legacyNotDisabled: string;
   toolsProfileWarn: (profile: string) => string;
+  replyInThreadWarn: string;
   startFailed: (details: string) => string;
   startWithWarnings: (version: string, details: string) => string;
   startOk: (version: string) => string;
@@ -46,6 +48,8 @@ const T: Record<FeishuLocale, {
       '```',
     toolsProfileWarn: (profile) =>
       `⚠️ 工具 Profile 当前为 \`${profile}\`，飞书工具可能无法加载。请检查配置是否正确。\n`,
+    replyInThreadWarn:
+      '⚠️ 已启用 `replyInThread`，但未启用 `threadSession`。机器人可能会在群里为每次回复新开话题，但这些话题仍共享同一个会话上下文，导致上下文串线。建议同时开启 `channels.feishu.threadSession`。\n',
     startFailed: (details) => `❌ 飞书 OpenClaw 插件启动失败：\n\n${details}`,
     startWithWarnings: (version, details) =>
       `⚠️ 飞书 OpenClaw 插件已启动 v${version}（存在警告）\n\n${details}`,
@@ -70,6 +74,8 @@ const T: Record<FeishuLocale, {
       '```',
     toolsProfileWarn: (profile) =>
       `⚠️ Tools profile is currently set to \`${profile}\`. Feishu tools may not load properly. Please check your configuration.\n`,
+    replyInThreadWarn:
+      '⚠️ `replyInThread` is enabled, but `threadSession` is not. The bot may open a new thread for each group reply while still sharing one conversation session across those threads. Consider enabling `channels.feishu.threadSession` to avoid context bleeding.\n',
     startFailed: (details) => `❌ Feishu OpenClaw plugin failed to start:\n\n${details}`,
     startWithWarnings: (version, details) =>
       `⚠️ Feishu OpenClaw plugin started v${version} (with warnings)\n\n${details}`,
@@ -114,6 +120,10 @@ export function runFeishuStart(
   const incompleteProfiles = new Set(['minimal', 'coding', 'messaging']);
   if (profile && incompleteProfiles.has(profile)) {
     warnings.push(t.toolsProfileWarn(profile));
+  }
+
+  if (hasReplyInThreadWithoutThreadSession(cfg.channels?.feishu)) {
+    warnings.push(t.replyInThreadWarn);
   }
 
   if (errors.length > 0) {

--- a/src/core/config-schema.ts
+++ b/src/core/config-schema.ts
@@ -135,12 +135,12 @@ const DmConfigSchema = z
 export const FeishuGroupSchema = z.object({
   groupPolicy: GroupPolicyEnum.optional(),
   requireMention: z.boolean().optional(),
+  replyInThread: z.enum(['enabled', 'disabled']).optional(),
   tools: ToolPolicySchema,
   skills: z.array(z.string()).optional(),
   enabled: z.boolean().optional(),
   allowFrom: AllowFromSchema,
   systemPrompt: z.string().optional(),
-  replyInThread: z.enum(['enabled', 'disabled']).optional(),
 });
 
 // ---------------------------------------------------------------------------

--- a/src/messaging/inbound/dispatch-commands.ts
+++ b/src/messaging/inbound/dispatch-commands.ts
@@ -66,7 +66,7 @@ export async function dispatchPermissionNotification(
     replyToMessageId: replyToMessageId ?? dc.ctx.messageId,
     accountId: dc.account.accountId,
     chatType: dc.ctx.chatType,
-    replyInThread: dc.isThread || dc.forceReplyInThread,
+    replyInThread: dc.forceReplyInThread || dc.isThread,
   });
 
   dc.log(`feishu[${dc.account.accountId}]: dispatching permission error notification to agent`);
@@ -123,7 +123,7 @@ export async function dispatchSystemCommand(
           text,
           replyToMessageId: replyToMessageId ?? dc.ctx.messageId,
           accountId: dc.account.accountId,
-          replyInThread: dc.isThread || dc.forceReplyInThread,
+          replyInThread: dc.forceReplyInThread || dc.isThread,
         });
         delivered = true;
       },

--- a/src/messaging/inbound/dispatch-context.ts
+++ b/src/messaging/inbound/dispatch-context.ts
@@ -12,7 +12,7 @@
 import type { ClawdbotConfig, RuntimeEnv } from 'openclaw/plugin-sdk';
 import { resolveThreadSessionKeys } from 'openclaw/plugin-sdk';
 import type { MessageContext } from '../types';
-import type { LarkAccount, FeishuGroupConfig } from '../../core/types';
+import type { FeishuGroupConfig, LarkAccount } from '../../core/types';
 import { LarkClient } from '../../core/lark-client';
 import { larkLogger } from '../../core/lark-logger';
 import { isThreadCapableGroup } from '../../core/chat-info-cache';
@@ -76,6 +76,7 @@ export function buildDispatchContext(params: {
   runtime?: RuntimeEnv;
   commandAuthorized?: boolean;
   groupConfig?: FeishuGroupConfig;
+  defaultGroupConfig?: FeishuGroupConfig;
 }): DispatchContext {
   const { ctx, account, accountScopedCfg } = params;
 
@@ -92,6 +93,11 @@ export function buildDispatchContext(params: {
   const envelopeFrom = isGroup ? `${ctx.chatId}:${ctx.senderId}` : ctx.senderId;
 
   const envelopeOptions = core.channel.reply.resolveEnvelopeFormatOptions(accountScopedCfg);
+
+  const replyInThreadSetting = isGroup
+    ? (params.groupConfig?.replyInThread ?? params.defaultGroupConfig?.replyInThread ?? account.config?.replyInThread)
+    : undefined;
+  const forceReplyInThread = isGroup && replyInThreadSetting === 'enabled';
 
   // ---- Route resolution ----
   const route = core.channel.routing.resolveAgentRoute({
@@ -123,11 +129,6 @@ export function buildDispatchContext(params: {
     sessionKey: route.sessionKey,
     contextKey: `feishu:message:${ctx.chatId}:${ctx.messageId}`,
   });
-
-  const forceReplyInThread = isGroup && (
-    params.groupConfig?.replyInThread === 'enabled'
-    || account.config?.replyInThread === 'enabled'
-  );
 
   return {
     ctx,

--- a/src/messaging/inbound/dispatch.ts
+++ b/src/messaging/inbound/dispatch.ts
@@ -89,7 +89,7 @@ async function dispatchNormalMessage(
     accountId: dc.account.accountId,
     chatType: dc.ctx.chatType,
     skipTyping,
-    replyInThread: dc.isThread || dc.forceReplyInThread,
+    replyInThread: dc.forceReplyInThread || dc.isThread,
   });
 
   // Create an AbortController so the abort fast-path can cancel the
@@ -175,7 +175,7 @@ export async function dispatchToAgent(params: {
   skipTyping?: boolean;
 }): Promise<void> {
   // 1. Derive shared context (including route resolution + system event)
-  const dc = buildDispatchContext({ ...params, groupConfig: params.groupConfig });
+  const dc = buildDispatchContext(params);
 
   // 1b. Resolve thread session isolation (async: may query group info API)
   if (dc.isThread && dc.ctx.threadId) {
@@ -300,7 +300,7 @@ export async function dispatchToAgent(params: {
         card,
         replyToMessageId: params.replyToMessageId ?? dc.ctx.messageId,
         accountId: dc.account.accountId,
-        replyInThread: dc.isThread || dc.forceReplyInThread,
+        replyInThread: dc.forceReplyInThread || dc.isThread,
       });
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
@@ -311,7 +311,7 @@ export async function dispatchToAgent(params: {
         text: `${i18nCommandName} failed: ${errMsg}`,
         replyToMessageId: params.replyToMessageId ?? dc.ctx.messageId,
         accountId: dc.account.accountId,
-        replyInThread: dc.isThread || dc.forceReplyInThread,
+        replyInThread: dc.forceReplyInThread || dc.isThread,
       });
     }
     return;


### PR DESCRIPTION
## Problem

The plugin only replies in a thread when the incoming message is already in a thread (`dc.isThread`). There is no config option to force thread creation for group replies, which is needed for keeping group chats organized.

## Solution

Add a `replyInThread` config option (`'enabled'` | `'disabled'`) at both the account level and per-group level. When set to `'enabled'`, all group replies are sent as thread replies regardless of whether the original message was in a thread.

Per-group config takes priority over account-level config.

### Usage

Account-level (all groups):
```json
{
  "channels": {
    "feishu": {
      "replyInThread": "enabled"
    }
  }
}
```

Per-group override:
```json
{
  "channels": {
    "feishu": {
      "groups": {
        "oc_xxx": {
          "replyInThread": "enabled"
        }
      }
    }
  }
}
```

## Changes

- `src/core/config-schema.ts`: Add `replyInThread` to `FeishuAccountConfigSchema` and `FeishuGroupSchema`
- `src/messaging/inbound/dispatch-context.ts`: Compute `forceReplyInThread` from config, add to `DispatchContext` interface
- `src/messaging/inbound/dispatch.ts`: Pass `groupConfig` to `buildDispatchContext`, apply `forceReplyInThread` at all reply sites
- `src/messaging/inbound/dispatch-commands.ts`: Apply `forceReplyInThread` at command reply sites

Closes #116