### PR TITLE
feat: merge subagent results into main streaming card

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -26,6 +26,8 @@ import {
 import { registerCommands } from './src/commands/index';
 import { larkLogger } from './src/core/lark-logger';
 import { emitSecurityWarnings } from './src/core/security-check';
+import { trackSubagentSpawned, trackSubagentEnded } from './src/card/subagent-tracker';
+import { normalizeFeishuTarget } from './src/core/targets';
 
 const log = larkLogger('plugin');
 
@@ -132,6 +134,25 @@ const plugin = {
         log.error(`tool fail: ${event.toolName} ${event.error} (${event.durationMs ?? 0}ms)`);
       } else {
         log.info(`tool done: ${event.toolName} ok (${event.durationMs ?? 0}ms)`);
+      }
+    });
+
+    // ---- Subagent lifecycle hooks (card status tracking) ----
+
+    api.on('subagent_spawned', (event) => {
+      const chatId = event.requester?.to ? normalizeFeishuTarget(event.requester.to) : undefined;
+      if (chatId) {
+        trackSubagentSpawned({
+          runId: event.runId,
+          chatId,
+          accountId: event.requester?.accountId,
+        });
+      }
+    });
+
+    api.on('subagent_ended', (event) => {
+      if (event.runId) {
+        trackSubagentEnded(event.runId);
       }
     });
 

--- a/src/card/card-registry.ts
+++ b/src/card/card-registry.ts
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Tracks the last completed streaming card per chat so that subsequent
+ * outbound deliveries (e.g. subagent announce results) can UPDATE the
+ * existing card instead of sending a new message.
+ *
+ * This avoids the confusing UX where the first card shows "已完成" but
+ * a second card appears later with the actual subagent result.
+ */
+
+import { larkLogger } from '../core/lark-logger';
+
+const log = larkLogger('card/registry');
+
+/** Max age before an entry is considered stale and ignored (5 min). */
+const TTL_MS = 5 * 60 * 1000;
+
+export interface CardEntry {
+  /** The IM message ID of the completed streaming card. */
+  messageId: string;
+  /** The CardKit card ID (if available, for CardKit v2 updates). */
+  cardKitCardId: string | null;
+  /** Current CardKit sequence number (for ordering updates). */
+  cardKitSequence: number;
+  /** The completed display text shown in the card (accumulates with merges). */
+  completedText: string;
+  /** The original streaming card text (never changes, used for dedup). */
+  originalCompletedText: string;
+  /** Whether the CardKit streaming mode is still open (needs closing on merge). */
+  streamingOpen: boolean;
+  /** Dispatch start time (for calculating elapsed time in footer). */
+  startedAt: number;
+  /** Footer config (status/elapsed visibility). */
+  footer?: { status?: boolean; elapsed?: boolean };
+  /** Timestamp of registration. */
+  registeredAt: number;
+}
+
+const entries = new Map<string, CardEntry>();
+
+function buildKey(chatId: string, accountId?: string): string {
+  return accountId ? `${accountId}:${chatId}` : chatId;
+}
+
+/**
+ * Register a completed streaming card so outbound deliveries can update it.
+ */
+export function registerCompletedCard(params: {
+  chatId: string;
+  accountId?: string;
+  messageId: string;
+  cardKitCardId: string | null;
+  cardKitSequence: number;
+  completedText: string;
+  originalCompletedText?: string;
+  streamingOpen?: boolean;
+  startedAt?: number;
+  footer?: { status?: boolean; elapsed?: boolean };
+}): void {
+  const key = buildKey(params.chatId, params.accountId);
+  entries.set(key, {
+    messageId: params.messageId,
+    cardKitCardId: params.cardKitCardId,
+    cardKitSequence: params.cardKitSequence,
+    completedText: params.completedText,
+    originalCompletedText: params.originalCompletedText ?? params.completedText,
+    streamingOpen: params.streamingOpen ?? false,
+    startedAt: params.startedAt ?? Date.now(),
+    footer: params.footer,
+    registeredAt: Date.now(),
+  });
+  log.info('registered completed card', { key, messageId: params.messageId });
+}
+
+/**
+ * Consume (take and remove) the last completed card for a chat.
+ * Returns `undefined` if no card is registered or the entry has expired.
+ */
+export function consumeCompletedCard(chatId: string, accountId?: string): CardEntry | undefined {
+  // Try exact key first, then fallback to alternative key format.
+  // Registration uses accountId from reply-dispatcher (e.g. "default"),
+  // but outbound sendText may receive undefined accountId from the SDK.
+  const key = buildKey(chatId, accountId);
+  const fallbackKey = accountId ? chatId : undefined;
+
+  let matchedKey = key;
+  let entry = entries.get(key);
+
+  if (!entry && fallbackKey) {
+    entry = entries.get(fallbackKey);
+    if (entry) matchedKey = fallbackKey;
+  }
+
+  // If still not found, scan for any entry ending with `:${chatId}`
+  if (!entry) {
+    for (const [k, v] of entries) {
+      if (k === chatId || k.endsWith(`:${chatId}`)) {
+        entry = v;
+        matchedKey = k;
+        break;
+      }
+    }
+  }
+
+  if (!entry) return undefined;
+
+  entries.delete(matchedKey);
+
+  if (Date.now() - entry.registeredAt > TTL_MS) {
+    log.info('card entry expired, discarding', { key: matchedKey });
+    return undefined;
+  }
+
+  log.info('consumed completed card', { key: matchedKey, messageId: entry.messageId });
+  return entry;
+}
+
+/**
+ * Remove a completed card entry without returning it.
+ * Used to clean up stale entries when all subagents have ended.
+ */
+export function removeCompletedCard(chatId: string, accountId?: string): void {
+  const key = buildKey(chatId, accountId);
+  if (entries.delete(key)) {
+    log.info('removed stale card entry', { key });
+  }
+}

--- a/src/card/reply-dispatcher.ts
+++ b/src/card/reply-dispatcher.ts
@@ -27,6 +27,8 @@ import { resolveReplyMode, expandAutoMode, shouldUseCard } from './reply-mode';
 import { StreamingCardController } from './streaming-card-controller';
 import { UnavailableGuard } from './unavailable-guard';
 import type { CreateFeishuReplyDispatcherParams, FeishuReplyDispatcherResult } from './reply-dispatcher-types';
+import { registerCompletedCard } from './card-registry';
+import { hasActiveSubagents } from './subagent-tracker';
 
 const log = larkLogger('card/reply-dispatcher');
 
@@ -288,7 +290,43 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       }
 
       if (controller) {
-        await controller.onIdle();
+        const mergeEnabled = feishuCfg?.subagent?.mergeToMain !== false;
+        const subagentsActive = mergeEnabled && hasActiveSubagents(chatId, accountId);
+
+        if (subagentsActive && controller.cardMessageId) {
+          // SubAgents still running — do NOT finalize the streaming card.
+          // Keep it visually "loading" so the user knows work is in progress.
+          // The outbound sendText will close streaming + update content later.
+          log.info('deferring card finalization (subagents active)');
+
+          registerCompletedCard({
+            chatId,
+            accountId,
+            messageId: controller.cardMessageId,
+            cardKitCardId: controller.cardKitCardId,
+            cardKitSequence: controller.cardKitSequence,
+            completedText: controller.completedText,
+            streamingOpen: true,
+            startedAt: controller.startTime,
+            footer: resolvedFooter,
+          });
+        } else {
+          // No active subagents — finalize normally.
+          await controller.onIdle();
+
+          if (mergeEnabled && controller.cardMessageId) {
+            registerCompletedCard({
+              chatId,
+              accountId,
+              messageId: controller.cardMessageId,
+              cardKitCardId: controller.cardKitCardId,
+              cardKitSequence: controller.cardKitSequence,
+              completedText: controller.completedText,
+              startedAt: controller.startTime,
+              footer: resolvedFooter,
+            });
+          }
+        }
       }
 
       typingCallbacks.onIdle?.();

--- a/src/card/streaming-card-controller.ts
+++ b/src/card/streaming-card-controller.ts
@@ -162,6 +162,22 @@ export class StreamingCardController {
     return this.cardKit.cardMessageId;
   }
 
+  get cardKitCardId(): string | null {
+    return this.cardKit.cardKitCardId ?? this.cardKit.originalCardKitCardId;
+  }
+
+  get cardKitSequence(): number {
+    return this.cardKit.cardKitSequence;
+  }
+
+  get completedText(): string {
+    return this.text.completedText || this.text.accumulatedText;
+  }
+
+  get startTime(): number {
+    return this.dispatchStartTime;
+  }
+
   get isTerminalPhase(): boolean {
     return TERMINAL_PHASES.has(this.phase);
   }

--- a/src/card/subagent-tracker.ts
+++ b/src/card/subagent-tracker.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Tracks active subagent runs per chat so the streaming card can show
+ * "处理中..." instead of "已完成" while subagents are still running.
+ */
+
+import { larkLogger } from '../core/lark-logger';
+import { removeCompletedCard } from './card-registry';
+
+const log = larkLogger('card/subagent-tracker');
+
+/** Active subagent runs keyed by runId → chat target info. */
+const activeRuns = new Map<string, { chatId: string; accountId?: string }>();
+
+/** Per-chat active subagent count. Key: `${accountId}:${chatId}` or `${chatId}`. */
+const chatCounts = new Map<string, number>();
+
+function buildChatKey(chatId: string, accountId?: string): string {
+  return accountId ? `${accountId}:${chatId}` : chatId;
+}
+
+/**
+ * Record a subagent spawn for a chat.
+ */
+export function trackSubagentSpawned(params: {
+  runId: string;
+  chatId: string;
+  accountId?: string;
+}): void {
+  const { runId, chatId, accountId } = params;
+  const key = buildChatKey(chatId, accountId);
+
+  activeRuns.set(runId, { chatId, accountId });
+
+  const prev = chatCounts.get(key) ?? 0;
+  chatCounts.set(key, prev + 1);
+
+  log.info('subagent spawned', { runId, chatId, count: prev + 1 });
+}
+
+/**
+ * Record a subagent end.
+ */
+export function trackSubagentEnded(runId: string): void {
+  const entry = activeRuns.get(runId);
+  if (!entry) return;
+
+  activeRuns.delete(runId);
+
+  const key = buildChatKey(entry.chatId, entry.accountId);
+  const prev = chatCounts.get(key) ?? 1;
+  const remaining = Math.max(0, prev - 1);
+  if (prev <= 1) {
+    chatCounts.delete(key);
+    // All subagents done — clean up any stale card registry entry
+    // left by the last sendText merge (which couldn't know it was last
+    // because subagent_ended fires after sendText).
+    removeCompletedCard(entry.chatId, entry.accountId);
+  } else {
+    chatCounts.set(key, prev - 1);
+  }
+
+  log.info('subagent ended', { runId, chatId: entry.chatId, remaining });
+}
+
+/**
+ * Check whether a chat has any active subagent runs.
+ */
+export function hasActiveSubagents(chatId: string, accountId?: string): boolean {
+  const key = buildChatKey(chatId, accountId);
+  return (chatCounts.get(key) ?? 0) > 0;
+}

--- a/src/core/config-schema.ts
+++ b/src/core/config-schema.ts
@@ -182,6 +182,14 @@ export const FeishuAccountConfigSchema = z.object({
   dedup: DedupSchema,
   reactionNotifications: ReactionNotificationModeSchema,
   threadSession: z.boolean().optional(),
+  subagent: z
+    .object({
+      /** Merge subagent output into the main agent's streaming card (default: true). */
+      mergeToMain: z.boolean().optional(),
+      /** When not merging, how to deliver the subagent result: 'card' | 'text' (default: 'text'). */
+      deliveryType: z.enum(['card', 'text']).optional(),
+    })
+    .optional(),
   uat: UATConfigSchema,
 });
 

--- a/src/messaging/outbound/outbound.ts
+++ b/src/messaging/outbound/outbound.ts
@@ -15,6 +15,14 @@ import type { ChannelOutboundAdapter, ClawdbotConfig } from 'openclaw/plugin-sdk
 import type { FeishuSendResult } from '../types';
 import { LarkClient } from '../../core/lark-client';
 import { sendTextLark, sendMediaLark, sendCardLark } from './deliver';
+import { updateCardFeishu, buildMarkdownCard } from './send';
+import { getLarkAccount } from '../../core/accounts';
+import { consumeCompletedCard, registerCompletedCard } from '../../card/card-registry';
+import { buildCardContent, toCardKit2 } from '../../card/builder';
+import { updateCardKitCard, setCardStreamingMode, streamCardContent } from '../../card/cardkit';
+import { STREAMING_ELEMENT_ID } from '../../card/builder';
+import { normalizeFeishuTarget } from '../../core/targets';
+import { hasActiveSubagents } from '../../card/subagent-tracker';
 import { larkLogger } from '../../core/lark-logger';
 import { parseFeishuRouteTarget } from '../../core/targets';
 
@@ -166,6 +174,136 @@ export const feishuOutbound: ChannelOutboundAdapter = {
   sendText: async ({ cfg, to, text, accountId, replyToId, threadId }) => {
     log.info(`sendText: target=${to}, textLength=${text.length}`);
     const ctx = resolveFeishuSendContext({ cfg, to, accountId, replyToId, threadId });
+    const account = getLarkAccount(cfg, accountId);
+
+    // When subagent merge is enabled, try to update the existing
+    // streaming card instead of sending a new message.
+    if (account.config?.subagent?.mergeToMain !== false) {
+      // Registry uses bare chatId (oc_...), but `to` has prefix (chat:oc_...).
+      const chatId = normalizeFeishuTarget(to) ?? to;
+      const existing = consumeCompletedCard(chatId, ctx.accountId);
+
+      if (existing) {
+        // Accumulate subagent results into the existing card text.
+        // Use originalCompletedText (the initial streaming card text) to detect
+        // when the SDK sends an accumulated announce that already contains it.
+        const origText = existing.originalCompletedText;
+        let mergedText: string;
+        if (text.startsWith(existing.completedText)) {
+          // Announce already includes all accumulated text — use as-is
+          mergedText = text;
+        } else if (text.startsWith(origText)) {
+          // SDK sent full response (origText + subagent results).
+          // Strip the original prefix to get only the new content,
+          // then append to the current accumulated text.
+          const newContent = text.slice(origText.length).trim();
+          mergedText = newContent
+            ? existing.completedText + '\n' + newContent
+            : existing.completedText;
+        } else {
+          // Independent subagent result — append to existing card
+          mergedText = existing.completedText + '\n' + text;
+        }
+
+        const elapsedMs = Date.now() - existing.startedAt;
+        log.info('sendText: merging into existing card', {
+          messageId: existing.messageId,
+          streamingOpen: existing.streamingOpen,
+          elapsedMs,
+        });
+
+        try {
+          let nextSeq = existing.cardKitSequence;
+
+          if (existing.streamingOpen && existing.cardKitCardId) {
+            // --- Streaming merge: stream content → close → finalize ---
+            // 1. Push merged text via streaming API (CardKit auto-diffs for animation)
+            nextSeq += 1;
+            await streamCardContent({
+              cfg,
+              cardId: existing.cardKitCardId,
+              elementId: STREAMING_ELEMENT_ID,
+              content: mergedText,
+              sequence: nextSeq,
+              accountId: ctx.accountId,
+            });
+            log.info('sendText: streamed merged content', { seq: nextSeq });
+
+            // 2. Close streaming mode
+            nextSeq += 1;
+            await setCardStreamingMode({
+              cfg,
+              cardId: existing.cardKitCardId,
+              streamingMode: false,
+              sequence: nextSeq,
+              accountId: ctx.accountId,
+            });
+
+            // 3. Final card.update with footer
+            nextSeq += 1;
+            await updateCardKitCard({
+              cfg,
+              cardId: existing.cardKitCardId,
+              card: toCardKit2(buildCardContent('complete', { text: mergedText, elapsedMs, footer: existing.footer })),
+              sequence: nextSeq,
+              accountId: ctx.accountId,
+            });
+            log.info('sendText: finalized card', { seq: nextSeq, elapsedMs });
+          } else if (existing.cardKitCardId) {
+            // --- Non-streaming merge: direct card.update ---
+            nextSeq += 1;
+            await updateCardKitCard({
+              cfg,
+              cardId: existing.cardKitCardId,
+              card: toCardKit2(buildCardContent('complete', { text: mergedText, elapsedMs, footer: existing.footer })),
+              sequence: nextSeq,
+              accountId: ctx.accountId,
+            });
+          } else {
+            // --- Legacy IM patch fallback ---
+            await updateCardFeishu({
+              cfg,
+              messageId: existing.messageId,
+              card: buildMarkdownCard(mergedText),
+              accountId: ctx.accountId,
+            });
+          }
+
+          // Re-register for subsequent merges. Streaming is now closed,
+          // so next merge will use the non-streaming card.update path.
+          // removeCompletedCard() in trackSubagentEnded cleans up when
+          // all subagents finish, preventing stale entry issues.
+          if (hasActiveSubagents(chatId, ctx.accountId)) {
+            registerCompletedCard({
+              chatId,
+              accountId: ctx.accountId,
+              messageId: existing.messageId,
+              cardKitCardId: existing.cardKitCardId,
+              cardKitSequence: nextSeq,
+              completedText: mergedText,
+              originalCompletedText: origText,
+              startedAt: existing.startedAt,
+              footer: existing.footer,
+              streamingOpen: false,
+            });
+          }
+
+          return { channel: 'feishu', messageId: existing.messageId, chatId };
+        } catch (err) {
+          log.warn('sendText: card merge failed, falling back', { error: String(err) });
+        }
+      }
+    }
+
+    // When deliveryType is 'card', send as a standalone card even without
+    // an existing card to merge into (e.g. when the main agent produced no
+    // streaming card reply and only spawned subAgents).
+    if (account.config?.subagent?.deliveryType === 'card') {
+      const card = buildMarkdownCard(text);
+      const result = await sendCardLark({ ...ctx, to: ctx.to, card });
+      return { channel: 'feishu', ...result };
+    }
+
     const result = await sendTextLark({ ...ctx, to: ctx.to, text });
     return { channel: 'feishu', ...result };
   },


### PR DESCRIPTION
## Summary

Merge subagent announce results into the main agent's streaming card instead of
delivering them as separate messages, providing a unified conversation experience.

## Problem

When the main agent spawns subagents, each subagent's result was sent as a new
standalone message via `sendText`. This caused a confusing UX:
1. The main streaming card finalizes with "已完成"
2. One or more additional messages appear later with the actual subagent results

## Solution

### New modules
- **`src/card/card-registry.ts`** — Tracks the last completed streaming card per
  chat (keyed by `accountId:chatId`). Entries auto-expire after 5 minutes.
- **`src/card/subagent-tracker.ts`** — Monitors active subagent runs per chat via
  `subagent_spawned` / `subagent_ended` lifecycle events. Cleans up stale card
  registry entries when the last subagent ends.

### Modified modules
- **`src/card/reply-dispatcher.ts`** — When subagents are active at stream
  completion, defers card finalization and registers the card for later merge.
  When no subagents are active, finalizes normally and still registers for
  potential late merges.
- **`src/card/streaming-card-controller.ts`** — Exposes `cardKitCardId`,
  `cardKitSequence`, `completedText`, and `startTime` getters needed by the
  card registry.
- **`src/messaging/outbound/outbound.ts`** — In `sendText`, consumes the
  registered card and merges subagent text into it. Supports three paths:
  streaming merge (stream → close → finalize), non-streaming CardKit update,
  and legacy IM patch fallback. Re-registers the card for subsequent merges
  when more subagents are still running.
- **`src/core/config-schema.ts`** — Adds `subagent` config block with
  `mergeToMain` (default: true) and `deliveryType` ('card' | 'text') options.
- **`index.ts`** — Wires `subagent_spawned` and `subagent_ended` event listeners.

## Configuration

```yaml
feishu:
  accounts:
    default:
      subagent:
        mergeToMain: true      # default, merge into main card
        deliveryType: text     # fallback when no card to merge into