### PR TITLE
feat(src): make feishu owner-only user auth configurable

### DIFF
--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -5,7 +5,8 @@
  * feishu_auth command — 飞书用户权限批量授权命令实现
  *
  * 直接复用 onboarding-auth.ts 的 triggerOnboarding() 函数。
- * 注意：此命令仅限应用 owner 执行（与 onboarding 逻辑一致）
+ * 当 `ownerOnlyUserAuth=true` 时，此命令仅限应用 owner 执行；
+ * 当 `ownerOnlyUserAuth=false` 时，允许当前用户为自己发起授权。
  */
 
 import type { OpenClawConfig } from 'openclaw/plugin-sdk';

--- a/src/core/accounts.ts
+++ b/src/core/accounts.ts
@@ -13,7 +13,14 @@ import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from 'openclaw/plugin-sdk';
 
 import type { ClawdbotConfig } from 'openclaw/plugin-sdk';
 
-import type { FeishuConfig, LarkBrand, LarkAccount, LarkCredentials, ConfiguredLarkAccount } from './types';
+import type {
+  FeishuConfig,
+  FeishuAccountConfig,
+  LarkBrand,
+  LarkAccount,
+  LarkCredentials,
+  ConfiguredLarkAccount,
+} from './types';
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -25,21 +32,21 @@ function getLarkConfig(cfg: ClawdbotConfig): FeishuConfig | undefined {
 }
 
 /** Return the per-account override map, if present. */
-function getAccountMap(section: FeishuConfig): Record<string, Partial<FeishuConfig>> | undefined {
-  return (section as FeishuConfig & { accounts?: Record<string, Partial<FeishuConfig>> }).accounts;
+function getAccountMap(section: FeishuConfig): Record<string, Partial<FeishuAccountConfig>> | undefined {
+  return (section as FeishuConfig & { accounts?: Record<string, Partial<FeishuAccountConfig>> }).accounts;
 }
 
 /** Strip the `accounts` key and return the remaining top-level config. */
-function baseConfig(section: FeishuConfig): Omit<FeishuConfig, 'accounts'> {
+function baseConfig(section: FeishuConfig): FeishuAccountConfig {
   const { accounts: _ignored, ...rest } = section as FeishuConfig & {
     accounts?: Record<string, unknown>;
   };
-  return rest;
+  return rest as FeishuAccountConfig;
 }
 
 /** Merge base config with account override (account fields take precedence). */
-function mergeAccountConfig(base: Omit<FeishuConfig, 'accounts'>, override: Partial<FeishuConfig>): FeishuConfig {
-  return { ...base, ...override } as FeishuConfig;
+function mergeAccountConfig(base: FeishuAccountConfig, override: Partial<FeishuAccountConfig>): FeishuAccountConfig {
+  return { ...base, ...override } as FeishuAccountConfig;
 }
 
 /** Coerce a domain string to `LarkBrand`, defaulting to `"feishu"`. */
@@ -103,7 +110,7 @@ export function getLarkAccount(cfg: ClawdbotConfig, accountId?: string | null): 
       enabled: false,
       configured: false,
       brand: 'feishu',
-      config: {} as FeishuConfig,
+      config: {} as FeishuAccountConfig,
     };
   }
 
@@ -111,12 +118,12 @@ export function getLarkAccount(cfg: ClawdbotConfig, accountId?: string | null): 
   const accountMap = getAccountMap(section);
   const accountOverride =
     accountMap && requestedId !== DEFAULT_ACCOUNT_ID
-      ? (accountMap[requestedId] as Partial<FeishuConfig> | undefined)
+      ? (accountMap[requestedId] as Partial<FeishuAccountConfig> | undefined)
       : undefined;
 
-  const merged: FeishuConfig = accountOverride
+  const merged: FeishuAccountConfig = accountOverride
     ? mergeAccountConfig(base, accountOverride)
-    : ({ ...base } as FeishuConfig);
+    : ({ ...base } as FeishuAccountConfig);
 
   const appId = merged.appId;
   const appSecret = merged.appSecret;

--- a/src/core/config-schema.ts
+++ b/src/core/config-schema.ts
@@ -178,6 +178,7 @@ export const FeishuAccountConfigSchema = z.object({
   footer: FeishuFooterSchema,
   markdown: MarkdownConfigSchema,
   configWrites: z.boolean().optional(),
+  ownerOnlyUserAuth: z.boolean().optional(),
   capabilities: CapabilitiesSchema,
   dedup: DedupSchema,
   reactionNotifications: ReactionNotificationModeSchema,

--- a/src/core/owner-policy.ts
+++ b/src/core/owner-policy.ts
@@ -5,10 +5,10 @@
  * owner-policy.ts — 应用 Owner 访问控制策略。
  *
  * 从 uat-client.ts 迁移 owner 检查逻辑到独立 policy 层。
- * 提供 fail-close 策略（安全优先：授权发起路径）。
+ * 提供可配置的 fail-close 策略（安全优先：授权发起路径）。
  */
 
-import type { ConfiguredLarkAccount } from './types';
+import type { ConfiguredLarkAccount, FeishuAccountConfig } from './types';
 import { getAppOwnerFallback } from './app-owner-fallback';
 
 // ---------------------------------------------------------------------------
@@ -38,8 +38,20 @@ export class OwnerAccessDeniedError extends Error {
 // ---------------------------------------------------------------------------
 
 /**
+ * 是否启用“仅 App Owner 可发起用户授权 / 使用用户态能力”策略。
+ *
+ * 默认值为 true，保持当前安全策略不变；仅当配置显式设为 false 时关闭。
+ */
+export function isOwnerOnlyUserAuthEnabled(
+  config: Pick<FeishuAccountConfig, 'ownerOnlyUserAuth'> | undefined,
+): boolean {
+  return config?.ownerOnlyUserAuth !== false;
+}
+
+/**
  * 校验用户是否为应用 owner（fail-close 版本）。
  *
+ * - 当 `ownerOnlyUserAuth=false` 时 → 直接放行
  * - 获取 owner 失败时 → 拒绝（安全优先）
  * - owner 不匹配时 → 拒绝
  *
@@ -52,6 +64,10 @@ export async function assertOwnerAccessStrict(
   sdk: any,
   userOpenId: string,
 ): Promise<void> {
+  if (!isOwnerOnlyUserAuthEnabled(account.config)) {
+    return;
+  }
+
   const ownerOpenId = await getAppOwnerFallback(account, sdk);
 
   if (!ownerOpenId) {

--- a/src/core/tool-client.ts
+++ b/src/core/tool-client.ts
@@ -37,7 +37,6 @@ import { getTicket } from './lark-ticket';
 import { callWithUAT } from './uat-client';
 import { getStoredToken } from './token-store';
 import { getAppGrantedScopes, invalidateAppScopeCache, missingScopes } from './app-scope-checker';
-import { getAppOwnerFallback } from './app-owner-fallback';
 import { larkLogger } from './lark-logger';
 import { type ToolActionKey, getRequiredScopes } from './scope-manager';
 import { rawLarkRequest } from './raw-request';
@@ -231,20 +230,14 @@ export class ToolClient {
       return this.invokeAsTenant(toolAction, fn, requiredScopes);
     }
 
-    // 5.1 获取 userOpenId，支持兜底逻辑
+    // 5.1 获取 userOpenId。用户态调用必须绑定到明确用户，不再回退到 app owner。
     let userOpenId = options?.userOpenId ?? this.senderOpenId;
 
-    // 5.2 兜底逻辑：如果没有 senderOpenId，尝试使用应用所有者
     if (!userOpenId) {
-      const fallbackUserId = await getAppOwnerFallback(this.account, this.sdk);
-      if (fallbackUserId) {
-        userOpenId = fallbackUserId;
-        tcLog.info(`Using app owner as fallback user`, {
-          toolAction,
-          appId: this.account.appId,
-          ownerId: fallbackUserId,
-        });
-      }
+      throw new Error(
+        `User identity required for ${toolAction} but senderOpenId is missing. ` +
+          `This usually means the tool was called outside a message context.`,
+      );
     }
 
     return this.invokeAsUser(toolAction, fn, requiredScopes, userOpenId, appScopeVerified);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -86,7 +86,7 @@ interface LarkAccountBase {
   encryptKey?: string;
   verificationToken?: string;
   brand: LarkBrand;
-  config: FeishuConfig;
+  config: FeishuAccountConfig;
 }
 
 /** An account with both `appId` and `appSecret` present. */

--- a/src/tools/onboarding-auth.ts
+++ b/src/tools/onboarding-auth.ts
@@ -4,8 +4,9 @@
  *
  * Onboarding 预授权模块。
  *
- * 配对后自动发起 OAuth Device Flow，引导应用 owner 完成用户授权。
- * 仅当配对用户 === 应用 owner 时触发。
+ * 配对后自动发起 OAuth Device Flow，引导用户完成授权。
+ * 当 `ownerOnlyUserAuth=true` 时，仅允许应用 owner 继续；
+ * 当 `ownerOnlyUserAuth=false` 时，允许当前用户继续。
  *
  * 飞书限制：单次 OAuth 最多 50 个 scope。
  * 超过 50 个时自动分批处理，每批授权完成后自动发起下一批（链式触发）。
@@ -16,6 +17,7 @@ import { getLarkAccount } from '../core/accounts';
 import { LarkClient } from '../core/lark-client';
 import { getAppGrantedScopes } from '../core/app-scope-checker';
 import { getAppOwnerFallback } from '../core/app-owner-fallback';
+import { isOwnerOnlyUserAuthEnabled } from '../core/owner-policy';
 import { executeAuthorize } from './oauth';
 import { larkLogger } from '../core/lark-logger';
 import { filterSensitiveScopes } from '../core/tool-scopes';
@@ -36,7 +38,7 @@ const MAX_SCOPES_PER_BATCH = 100;
  * 配对后触发 onboarding OAuth 授权。
  *
  * 流程：
- *   1. 检查 userOpenId === 应用 owner，不匹配则静默跳过
+ *   1. owner-only 模式下检查 userOpenId === 应用 owner，不匹配则静默跳过
  *   2. 读取 onboarding-scopes.json 中的 user scope 列表
  *   3. 分批处理（每批最多 50 个），第一批直接发起 OAuth Device Flow
  *   4. 每批授权完成后通过 onAuthComplete 回调自动发起下一批
@@ -57,18 +59,22 @@ export async function triggerOnboarding(params: {
   const sdk = LarkClient.fromAccount(acct).sdk;
   const { appId } = acct;
 
-  // 1. 检查 userOpenId === 应用 owner（统一走 getAppOwnerFallback）
-  const ownerOpenId = await getAppOwnerFallback(acct, sdk);
-  if (!ownerOpenId) {
-    log.info(`app ${appId} has no owner info, skipping`);
-    return;
-  }
-  if (userOpenId !== ownerOpenId) {
-    log.info(`user ${userOpenId} is not app owner (${ownerOpenId}), skipping`);
-    return;
-  }
+  // 1. owner-only 模式下检查 userOpenId === 应用 owner（统一走 getAppOwnerFallback）
+  if (isOwnerOnlyUserAuthEnabled(acct.config)) {
+    const ownerOpenId = await getAppOwnerFallback(acct, sdk);
+    if (!ownerOpenId) {
+      log.info(`app ${appId} has no owner info, skipping`);
+      return;
+    }
+    if (userOpenId !== ownerOpenId) {
+      log.info(`user ${userOpenId} is not app owner (${ownerOpenId}), skipping`);
+      return;
+    }
 
-  log.info(`user ${userOpenId} is app owner, starting OAuth`);
+    log.info(`user ${userOpenId} is app owner, starting OAuth`);
+  } else {
+    log.info(`owner-only auth disabled, starting OAuth for user ${userOpenId}`);
+  }
 
   // 3. 动态获取应用已开通的 user scope 列表
   let allUserScopes: string[];


### PR DESCRIPTION
## Summary
- add `ownerOnlyUserAuth` as a Feishu account config switch
- make owner-only user OAuth enforcement configurable while keeping the default behavior unchanged
- tighten account config typing and remove owner fallback when user identity is missing

## Config
Default behavior: `channels.feishu.ownerOnlyUserAuth` defaults to `true`.

When it is `true`:
- only the app owner can start user-level OAuth
- non-owner users cannot use user-scoped auth flows

When it is `false`:
- any user who can chat with the bot can authorize themselves
- user-scoped calls require an explicit user identity and no longer fall back to the app owner

## Operation commands
Disable globally:
```bash
openclaw config set channels.feishu.ownerOnlyUserAuth false --json
```

Disable for a single Feishu account:
```bash
openclaw config set channels.feishu.accounts.<accountId>.ownerOnlyUserAuth false --json
```

## Notes
- this PR only includes `src` source changes; markdown docs are intentionally excluded
- manually verified with a teammate that the auth flow works after disabling the switch