### PR TITLE
feat: subscribe to bitable record change events and forward to Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Additionally, the plugin supports:
 - **🌊 Streaming Responses**: Live streaming text directly within message cards
 - **🔒 Permission Policies**: Flexible access control policies for DMs and group chats
 - **⚙️ Advanced Group Configuration**: Per-group settings including allowlists, skill bindings, and custom system prompts
+- **🔔 Base Record Change Notifications**: Subscribe to record change events in specified bases and automatically forward changes to the Agent
 
 ## Security & Risk Warnings (Read Before Use)
 
@@ -68,6 +69,51 @@ Before you start, make sure you have the following:
 ## Usage Guide
 
 [How to Use the Official Lark/Feishu Plugin for OpenClaw](https://bytedance.larkoffice.com/docx/MFK7dDFLFoVlOGxWCv5cTXKmnMh)
+
+## Base Record Change Notifications
+
+The plugin supports subscribing to Base record change events (`drive.file.bitable_record_changed_v1`). When records are added, edited, or deleted in a Base table, the plugin automatically forwards the change details to the Agent in a specified Feishu chat.
+
+### Prerequisites
+
+1. **Enable the event subscription**: In the [Feishu Developer Console](https://open.feishu.cn/) → Your App → Events & Callbacks → Event Configuration, add the **Base Record Changed** event (`drive.file.bitable_record_changed_v1`) and set the subscription method to **Persistent Connection (长连接)**.
+
+2. **Subscribe to the specific file**: Call the Feishu Drive subscribe API (`drive.file.subscribe`) for the target Base file. You can do this via the `feishu_drive` tool in OpenClaw Agent or using the Feishu API Explorer manually.
+
+### Configuration
+
+Add `bitableNotifications` to your Feishu account config in `openclaw.json`:
+
+```json
+{
+  "channels": {
+    "feishu": {
+      "appId": "cli_xxxxxxxx",
+      "appSecret": "xxxxxxxx",
+      "bitableNotifications": [
+        {
+          "fileToken": "RyGZbWS8ia64cbsBsrAc0tzCnXy",
+          "chatId": "oc_xxxxxxxxxxxxxxxxxxxxxxxx",
+          "label": "Requirements Tracker"
+        },
+        {
+          "fileToken": "AbCdEfGhIjKlMnOpQrStUvWxYz1",
+          "chatId": "oc_yyyyyyyyyyyyyyyyyyyyyyyy",
+          "tableIds": ["tblABC123"],
+          "label": "Project Progress (Sprint table only)"
+        }
+      ]
+    }
+  }
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `fileToken` | ✅ | The Base app token (the part after `base/` in the URL) |
+| `chatId` | ✅ | Target Feishu chat ID to receive notifications (`oc_xxx` for both DMs and group chats) |
+| `tableIds` | ❌ | Only listen to specific table IDs; omit to monitor all tables in the Base |
+| `label` | ❌ | Human-readable name shown in the notification message to help distinguish multiple bases |
 
 ## Contributing
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -26,6 +26,7 @@
 - **🌊 流式回复**：在消息卡片中提供实时的流式响应
 - **🔒 权限策略**：为私聊和群聊提供灵活的访问控制策略
 - **⚙️ 高级群组配置**：每个群聊的独立设置，包括白名单、技能绑定和自定义系统提示词
+- **🔔 多维表格记录变更通知**：订阅指定多维表格的记录变更事件，自动将变更内容转发给 Agent
 
 ## 安全与风险提示（使用前必读）
 
@@ -68,6 +69,51 @@
 
 ## 使用说明
 [OpenClaw  Lark/飞书官方插件使用指南](https://bytedance.larkoffice.com/docx/MFK7dDFLFoVlOGxWCv5cTXKmnMh)
+
+## 多维表格记录变更通知
+
+插件支持订阅多维表格的记录变更事件（`drive.file.bitable_record_changed_v1`），当多维表格中有记录新增、编辑或删除时，自动将变更内容发送给 Agent 所在的指定会话。
+
+### 前置准备
+
+1. **开启事件订阅**：在飞书开放平台 [开发者后台](https://open.feishu.cn/) → 应用 → 事件与回调 → 事件配置，添加 **多维表记录变更** 事件（`drive.file.bitable_record_changed_v1`），订阅方式选择**长连接**。
+
+2. **订阅具体文件**：需要调用飞书 Drive 订阅 API，对目标多维表文件发起订阅请求（`drive.file.subscribe`）。可通过 OpenClaw Agent 中的 `feishu_drive` 工具执行，或使用飞书 API 调试工具手动完成。
+
+### 配置示例
+
+在 `openclaw.json` 的飞书账号配置中添加 `bitableNotifications` 字段：
+
+```json
+{
+  "channels": {
+    "feishu": {
+      "appId": "cli_xxxxxxxx",
+      "appSecret": "xxxxxxxx",
+      "bitableNotifications": [
+        {
+          "fileToken": "RyGZbWS8ia64cbsBsrAc0tzCnXy",
+          "chatId": "oc_xxxxxxxxxxxxxxxxxxxxxxxx",
+          "label": "需求跟踪表"
+        },
+        {
+          "fileToken": "AbCdEfGhIjKlMnOpQrStUvWxYz1",
+          "chatId": "oc_yyyyyyyyyyyyyyyyyyyyyyyy",
+          "tableIds": ["tblABC123"],
+          "label": "项目进度表（仅跟踪 Sprint 表）"
+        }
+      ]
+    }
+  }
+}
+```
+
+| 字段 | 必填 | 说明 |
+|------|------|------|
+| `fileToken` | ✅ | 多维表格的 App Token（URL 中 `base/` 后的部分） |
+| `chatId` | ✅ | 接收通知的会话 ID（p2p 使用 `oc_xxx`，群聊同样使用 `oc_xxx`） |
+| `tableIds` | ❌ | 只监听指定数据表，省略则监听该多维表下所有数据表 |
+| `label` | ❌ | 通知消息中显示的可读名称，便于区分多个多维表 |
 
 ## 贡献
 

--- a/src/channel/event-handlers.ts
+++ b/src/channel/event-handlers.ts
@@ -9,9 +9,15 @@
  * dependencies needed to process the event.
  */
 
-import type { FeishuMessageEvent, FeishuBotAddedEvent, FeishuReactionCreatedEvent } from '../messaging/types';
+import type {
+  FeishuMessageEvent,
+  FeishuBotAddedEvent,
+  FeishuReactionCreatedEvent,
+  FeishuBitableRecordChangedEvent,
+} from '../messaging/types';
 import { handleFeishuMessage } from '../messaging/inbound/handler';
 import { handleFeishuReaction, resolveReactionContext } from '../messaging/inbound/reaction-handler';
+import { handleFeishuBitableRecordChanged } from '../messaging/inbound/bitable-handler';
 import { isMessageExpired } from '../messaging/inbound/dedup';
 import { withTicket } from '../core/lark-ticket';
 import { larkLogger } from '../core/lark-logger';
@@ -242,5 +248,56 @@ export async function handleCardActionEvent(ctx: MonitorContext, data: unknown):
     return await handleCardAction(data, ctx.cfg, ctx.accountId);
   } catch (err) {
     elog.warn(`card.action.trigger handler error: ${err}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bitable record-changed handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle a `drive.file.bitable_record_changed_v1` event.
+ *
+ * The SDK's EventDispatcher delivers the inner `event` object directly as
+ * handler data, so `data` here maps to the `event` field of the raw
+ * webhook body.  The outer v2 envelope `app_id` is injected by the SDK
+ * into the data object alongside the inner fields.
+ *
+ * The handler uses `bitableNotifications` config to resolve which chats
+ * should receive the notification, then dispatches a synthetic message
+ * to the agent for each matching target.
+ */
+export async function handleBitableRecordChangedEvent(ctx: MonitorContext, data: unknown): Promise<void> {
+  if (!isEventOwnershipValid(ctx, data)) return;
+  const { accountId, log, error } = ctx;
+  try {
+    const event = data as FeishuBitableRecordChangedEvent;
+
+    // Basic sanity check — must have a file_token to be useful
+    if (!event.file_token) {
+      log(`feishu[${accountId}]: bitable_record_changed missing file_token, skipping`);
+      return;
+    }
+
+    // Dedup: use a composite key so reconnect-replayed events are suppressed
+    const actionCount = event.action_list?.length ?? 0;
+    const firstRecordId = event.action_list?.[0]?.record_id ?? '';
+    const dedupKey = `bitable:${event.file_token}:${event.table_id}:${event.revision ?? event.update_time ?? Date.now()}:${firstRecordId}:${actionCount}`;
+    if (!ctx.messageDedup.tryRecord(dedupKey, accountId)) {
+      log(`feishu[${accountId}]: duplicate bitable_record_changed ${dedupKey}, skipping`);
+      return;
+    }
+
+    log(`feishu[${accountId}]: bitable_record_changed file=${event.file_token} table=${event.table_id} actions=${actionCount}`);
+
+    await handleFeishuBitableRecordChanged({
+      cfg: ctx.cfg,
+      event,
+      runtime: ctx.runtime,
+      chatHistories: ctx.chatHistories,
+      accountId,
+    });
+  } catch (err) {
+    error(`feishu[${accountId}]: error handling bitable_record_changed: ${String(err)}`);
   }
 }

--- a/src/channel/monitor.ts
+++ b/src/channel/monitor.ts
@@ -21,6 +21,7 @@ import {
   handleReactionEvent,
   handleBotMembershipEvent,
   handleCardActionEvent,
+  handleBitableRecordChangedEvent,
 } from './event-handlers';
 
 const mlog = larkLogger('channel/monitor');
@@ -102,6 +103,10 @@ async function monitorSingleAccount(params: {
       'card.action.trigger': ((data: unknown) =>
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         handleCardActionEvent(ctx, data)) as any,
+      // drive.file.bitable_record_changed_v1 在 node-sdk 类型定义中缺失，需要 as any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      'drive.file.bitable_record_changed_v1': ((data: unknown) =>
+        handleBitableRecordChangedEvent(ctx, data)) as any,
     },
     abortSignal,
   });

--- a/src/core/config-schema.ts
+++ b/src/core/config-schema.ts
@@ -114,6 +114,23 @@ const DedupSchema = z
 
 const ReactionNotificationModeSchema = z.enum(['off', 'own', 'all']).optional();
 
+/**
+ * Per-bitable subscription: which chat to forward record-changed events to.
+ *
+ * `fileToken` is the bitable app token (used to match the incoming event).
+ * `chatId`    is the target Feishu chat (p2p or group) to post the notification.
+ * `tableIds`  optional list of table IDs to filter (defaults to all tables).
+ */
+const BitableNotificationEntrySchema = z.object({
+  fileToken: z.string(),
+  chatId: z.string(),
+  tableIds: z.array(z.string()).optional(),
+  /** Human-readable label shown in the notification prefix (e.g. "需求跟踪表"). */
+  label: z.string().optional(),
+});
+
+const BitableNotificationsSchema = z.array(BitableNotificationEntrySchema).optional();
+
 export const UATConfigSchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -181,6 +198,7 @@ export const FeishuAccountConfigSchema = z.object({
   capabilities: CapabilitiesSchema,
   dedup: DedupSchema,
   reactionNotifications: ReactionNotificationModeSchema,
+  bitableNotifications: BitableNotificationsSchema,
   threadSession: z.boolean().optional(),
   uat: UATConfigSchema,
 });

--- a/src/messaging/inbound/bitable-handler.ts
+++ b/src/messaging/inbound/bitable-handler.ts
@@ -1,0 +1,300 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Bitable record-changed event handler for the Lark/Feishu channel plugin.
+ *
+ * Handles `drive.file.bitable_record_changed_v1` events by building a
+ * synthetic {@link MessageContext} that describes the record change and
+ * dispatching it to the agent via {@link dispatchToAgent}, bypassing the
+ * full 7-stage message pipeline.
+ *
+ * Routing is driven by `bitableNotifications` in the account config:
+ * each entry maps a `fileToken` (bitable app token) to a target `chatId`.
+ * When a record-changed event arrives, all matching entries are notified.
+ *
+ * The feature requires the application to have previously subscribed to
+ * bitable file events via the `drive.file.subscribe` API — this plugin
+ * does NOT auto-subscribe; that must be done manually or via tooling.
+ */
+
+import * as crypto from 'node:crypto';
+import type { ClawdbotConfig, RuntimeEnv, HistoryEntry } from 'openclaw/plugin-sdk';
+import { DEFAULT_GROUP_HISTORY_LIMIT } from 'openclaw/plugin-sdk';
+import type {
+  FeishuBitableRecordChangedEvent,
+  FeishuBitableRecordAction,
+  FeishuBitableFieldValue,
+  MessageContext,
+} from '../types';
+import { getLarkAccount } from '../../core/accounts';
+import { resolveUserName } from './user-name-cache';
+import { dispatchToAgent } from './dispatch';
+import { resolveFeishuGroupConfig } from './policy';
+import { larkLogger } from '../../core/lark-logger';
+import { getChatTypeFeishu } from '../../core/chat-info-cache';
+
+const logger = larkLogger('inbound/bitable-handler');
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a JSON-serialised `field_value` string into a human-readable snippet.
+ *
+ * Feishu encodes all field values as JSON strings. We attempt to summarise
+ * the parsed value in a compact, readable form for the AI context message.
+ */
+function parseFieldValueSnippet(raw: string): string {
+  if (!raw) return '(empty)';
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // Not JSON — return the raw string trimmed
+    return raw.slice(0, 200);
+  }
+
+  if (typeof parsed === 'string') return parsed.slice(0, 200);
+  if (typeof parsed === 'number' || typeof parsed === 'boolean') return String(parsed);
+
+  if (Array.isArray(parsed)) {
+    // Rich text / link / person arrays — extract text content
+    const parts: string[] = [];
+    for (const item of parsed as Record<string, unknown>[]) {
+      if (typeof item === 'object' && item !== null) {
+        const text = (item as Record<string, unknown>).text;
+        const name = (item as Record<string, unknown>).name;
+        if (typeof text === 'string') parts.push(text);
+        else if (typeof name === 'string') parts.push(name);
+      }
+    }
+    const joined = parts.join(', ');
+    return joined.slice(0, 200) || JSON.stringify(parsed).slice(0, 200);
+  }
+
+  return JSON.stringify(parsed).slice(0, 200);
+}
+
+/**
+ * Format a list of changed fields as a Markdown-ish table row.
+ */
+function formatFields(fields: FeishuBitableFieldValue[]): string {
+  return fields
+    .map((f) => `  • ${f.field_id}: ${parseFieldValueSnippet(f.field_value)}`)
+    .join('\n');
+}
+
+/**
+ * Render a single record action as a human-readable block.
+ */
+function formatAction(action: FeishuBitableRecordAction, idx: number): string {
+  const header = `[记录 ${idx + 1}] ${action.record_id} (${action.action})`;
+  const lines: string[] = [header];
+
+  if (action.action === 'record_edited') {
+    if (action.before_value?.length) {
+      lines.push('  变更前:');
+      lines.push(formatFields(action.before_value));
+    }
+    if (action.after_value?.length) {
+      lines.push('  变更后:');
+      lines.push(formatFields(action.after_value));
+    }
+  } else if (action.action === 'record_added') {
+    if (action.after_value?.length) {
+      lines.push('  新增字段:');
+      lines.push(formatFields(action.after_value));
+    }
+  } else if (action.action === 'record_deleted') {
+    if (action.before_value?.length) {
+      lines.push('  删除的字段值:');
+      lines.push(formatFields(action.before_value));
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Build the text body of the synthetic notification message.
+ */
+function buildNotificationText(
+  event: FeishuBitableRecordChangedEvent,
+  label: string | undefined,
+  operatorName: string | undefined,
+): string {
+  const tableLabel = label ? `【${label}】` : '';
+  const actor = operatorName ?? event.operator_id?.open_id ?? '未知用户';
+  const ts = event.update_time
+    ? new Date(event.update_time * 1000).toLocaleString('zh-CN', { timeZone: 'Asia/Shanghai' })
+    : undefined;
+
+  const lines: string[] = [];
+  lines.push(`[多维表格记录变更]${tableLabel}`);
+  lines.push(`操作人：${actor}${ts ? `  时间：${ts}` : ''}`);
+  lines.push(`多维表格 Token：${event.file_token}  数据表：${event.table_id}`);
+  lines.push('');
+
+  const actions = event.action_list ?? [];
+  if (actions.length === 0) {
+    lines.push('(无记录变更详情)');
+  } else {
+    for (let i = 0; i < actions.length; i++) {
+      lines.push(formatAction(actions[i], i));
+      if (i < actions.length - 1) lines.push('');
+    }
+  }
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface BitableNotificationTarget {
+  fileToken: string;
+  chatId: string;
+  tableIds?: string[];
+  label?: string;
+}
+
+/**
+ * Resolve which notification targets should receive the given bitable event.
+ *
+ * Matches on `fileToken` (required) and optionally filters by `tableIds`.
+ */
+export function resolveBitableTargets(
+  targets: BitableNotificationTarget[],
+  event: FeishuBitableRecordChangedEvent,
+): BitableNotificationTarget[] {
+  return targets.filter((t) => {
+    if (t.fileToken !== event.file_token) return false;
+    if (t.tableIds && t.tableIds.length > 0) {
+      return t.tableIds.includes(event.table_id);
+    }
+    return true;
+  });
+}
+
+/**
+ * Handle a `drive.file.bitable_record_changed_v1` event.
+ *
+ * For each matching `bitableNotifications` entry, build a synthetic
+ * {@link MessageContext} and dispatch to the agent as if the record-change
+ * notification were a user message sent to the target chat.
+ */
+export async function handleFeishuBitableRecordChanged(params: {
+  cfg: ClawdbotConfig;
+  event: FeishuBitableRecordChangedEvent;
+  runtime?: RuntimeEnv;
+  chatHistories?: Map<string, HistoryEntry[]>;
+  accountId?: string;
+}): Promise<void> {
+  const { cfg, event, runtime, chatHistories, accountId } = params;
+  const log = runtime?.log ?? ((...args: unknown[]) => logger.info(args.map(String).join(' ')));
+  const error = runtime?.error ?? ((...args: unknown[]) => logger.error(args.map(String).join(' ')));
+
+  const account = getLarkAccount(cfg, accountId);
+  const accountFeishuCfg = account.config;
+
+  // Resolve notification targets from config
+  const rawTargets = (accountFeishuCfg?.bitableNotifications ?? []) as BitableNotificationTarget[];
+  const targets = resolveBitableTargets(rawTargets, event);
+
+  if (targets.length === 0) {
+    log(`feishu[${accountId}]: bitable_record_changed for ${event.file_token}/${event.table_id} — no matching targets, skipping`);
+    return;
+  }
+
+  const accountScopedCfg: ClawdbotConfig = {
+    ...cfg,
+    channels: { ...cfg.channels, feishu: accountFeishuCfg },
+  };
+
+  // Resolve operator name once (shared across targets)
+  const operatorOpenId = event.operator_id?.open_id ?? '';
+  let operatorName: string | undefined;
+  if (operatorOpenId) {
+    const nameResult = await resolveUserName({ account, openId: operatorOpenId, log });
+    operatorName = nameResult.name;
+  }
+
+  for (const target of targets) {
+    try {
+      // Determine chat type for the target chat
+      let chatType: 'p2p' | 'group' = 'p2p';
+      try {
+        chatType = await getChatTypeFeishu({ cfg: accountScopedCfg, chatId: target.chatId, accountId });
+      } catch {
+        // Default to p2p on error
+      }
+
+      const notificationText = buildNotificationText(event, target.label, operatorName);
+      const syntheticMessageId = `bitable:${event.file_token}:${event.table_id}:${crypto.randomUUID()}`;
+
+      const ctx: MessageContext = {
+        chatId: target.chatId,
+        messageId: syntheticMessageId,
+        // Use operator's open_id as sender so the agent knows who made the change
+        senderId: operatorOpenId || 'bitable-system',
+        senderName: operatorName,
+        chatType,
+        content: notificationText,
+        contentType: 'text',
+        resources: [],
+        mentions: [],
+        rawMessage: {
+          message_id: syntheticMessageId,
+          chat_id: target.chatId,
+          chat_type: chatType,
+          message_type: 'text',
+          content: JSON.stringify({ text: notificationText }),
+          create_time: event.update_time ? String(event.update_time * 1000) : String(Date.now()),
+        },
+        rawSender: {
+          sender_id: {
+            open_id: operatorOpenId || undefined,
+            user_id: event.operator_id?.user_id,
+            union_id: event.operator_id?.union_id,
+          },
+          sender_type: 'user',
+        },
+      };
+
+      const isGroup = chatType === 'group';
+      const groupConfig = isGroup ? resolveFeishuGroupConfig({ cfg: accountFeishuCfg, groupId: target.chatId }) : undefined;
+      const defaultGroupConfig = isGroup ? accountFeishuCfg?.groups?.['*'] : undefined;
+
+      const historyLimit = Math.max(
+        0,
+        accountFeishuCfg?.historyLimit ?? accountScopedCfg.messages?.groupChat?.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT,
+      );
+
+      log(`feishu[${accountId}]: bitable_record_changed ${event.file_token}/${event.table_id} → dispatching to chat ${target.chatId}`);
+      logger.info(`bitable record changed: file=${event.file_token} table=${event.table_id} actions=${event.action_list?.length ?? 0} → chat=${target.chatId}`);
+
+      await dispatchToAgent({
+        ctx,
+        permissionError: undefined,
+        mediaPayload: {},
+        quotedContent: undefined,
+        account,
+        accountScopedCfg,
+        runtime,
+        chatHistories,
+        historyLimit,
+        replyToMessageId: undefined,
+        commandAuthorized: false,
+        groupConfig,
+        defaultGroupConfig,
+        skipTyping: true,
+      });
+    } catch (err) {
+      error(`feishu[${accountId}]: error dispatching bitable record changed to chat ${target.chatId}: ${String(err)}`);
+    }
+  }
+}

--- a/src/messaging/types.ts
+++ b/src/messaging/types.ts
@@ -61,6 +61,66 @@ export interface FeishuReactionCreatedEvent {
   action_time?: string;
 }
 
+// ---------------------------------------------------------------------------
+// Bitable record changed event
+// ---------------------------------------------------------------------------
+
+/** A single field value in a bitable record action. */
+export interface FeishuBitableFieldValue {
+  field_id: string;
+  /** JSON-serialised field value string. Deserialise with JSON.parse() for the actual value. */
+  field_value: string;
+  field_identity_value?: {
+    users?: Array<{
+      user_id?: { union_id?: string; user_id?: string; open_id?: string };
+      name?: string;
+      en_name?: string;
+      avatar_url?: string;
+    }>;
+  };
+}
+
+/** A single record action (edit / add / delete) in a bitable record changed event. */
+export interface FeishuBitableRecordAction {
+  record_id: string;
+  /** "record_edited" | "record_added" | "record_deleted" */
+  action: string;
+  before_value?: FeishuBitableFieldValue[];
+  after_value?: FeishuBitableFieldValue[];
+}
+
+/**
+ * Event payload for `drive.file.bitable_record_changed_v1`.
+ *
+ * The SDK's EventDispatcher delivers the `event` sub-object directly as the
+ * handler data, so the top-level fields here map to `event.*` in the raw
+ * webhook body.
+ */
+export interface FeishuBitableRecordChangedEvent {
+  /** Always "bitable". */
+  file_type: string;
+  /** The bitable app token (table file token). */
+  file_token: string;
+  /** ID of the data-table where the change occurred. */
+  table_id: string;
+  /** Revision number of the table after the change. */
+  revision?: number;
+  /** The user who triggered the change. */
+  operator_id?: {
+    union_id?: string;
+    user_id?: string;
+    open_id?: string;
+  };
+  /** List of record-level actions (edit / add / delete). */
+  action_list?: FeishuBitableRecordAction[];
+  /** Users subscribed to this bitable. */
+  subscriber_id_list?: Array<{ union_id?: string; user_id?: string; open_id?: string }>;
+  /** Unix timestamp (seconds) of the edit. */
+  update_time?: number;
+  /** Available when event is delivered via the SDK dispatcher (v2 envelope). */
+  app_id?: string;
+}
+
 export interface FeishuBotAddedEvent {
   chat_id: string;
   operator_id: {


### PR DESCRIPTION
Adds support for `drive.file.bitable_record_changed_v1` events, allowing the plugin to forward Base record changes to a configured Feishu chat as synthetic Agent messages.

Application scenario: By subscribing to multidimensional table record change events for the Agent, the Agent can participate in task dashboards maintained using multidimensional tables.

Changes:
- src/messaging/types.ts: add FeishuBitableRecordChangedEvent, FeishuBitableRecordAction, FeishuBitableFieldValue interfaces
- src/core/config-schema.ts: add bitableNotifications config field (array of { fileToken, chatId, tableIds?, label? })
- src/messaging/inbound/bitable-handler.ts: new handler that matches incoming events against bitableNotifications config, formats record changes into a human-readable text, and dispatches a synthetic MessageContext to the Agent
- src/channel/event-handlers.ts: add handleBitableRecordChangedEvent with deduplication logic
- src/channel/monitor.ts: register drive.file.bitable_record_changed_v1 handler in the WebSocket EventDispatcher
- README.md / README.zh.md: document the new feature and configuration

Note: the Feishu app must have drive.file.bitable_record_changed_v1 added in its event subscriptions (Developer Console → Events & Callbacks) and must call drive.file.subscribe for each target Base file beforehand.


Made-with: Cursor