### PR TITLE
fix: keep block streaming enabled for Feishu streaming cardsfix

### DIFF
--- a/src/card/reply-dispatcher.ts
+++ b/src/card/reply-dispatcher.ts
@@ -57,8 +57,13 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   });
   const useStreamingCards = replyMode === 'streaming';
 
-  // ---- Block streaming for static mode ----
-  const enableBlockStreaming = feishuCfg?.blockStreaming === true && !useStreamingCards;
+  // ---- Block streaming ----
+  // Keep block streaming enabled whenever the channel/account enables it.
+  // Some Anthropic-compatible providers (e.g. MiniMax) surface visible text
+  // primarily through block-level streaming callbacks. Disabling block streaming
+  // in card-streaming mode causes Feishu to receive only the final aggregated
+  // deliver() payload, which appears as "not streaming" in chat.
+  const enableBlockStreaming = feishuCfg?.blockStreaming === true;
 
   const resolvedFooter = resolveFooterConfig(feishuCfg?.footer);
 
@@ -66,6 +71,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     effectiveReplyMode,
     replyMode,
     chatType,
+    useStreamingCards,
+    enableBlockStreaming,
   });
 
   // ---- Chunk & render settings (static mode only) ----
@@ -307,6 +314,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     replyOptions: {
       ...replyOptions,
       onModelSelected: prefixContext.onModelSelected,
+      // `true` means the SDK should NOT use block streaming. We only disable
+      // it when the account/channel has not enabled block streaming.
       disableBlockStreaming: !enableBlockStreaming,
       ...(controller
         ? {


### PR DESCRIPTION
## 问题
在 Feishu 渠道中，GPT-5.4 可以正常流式显示，但 MiniMax-M2.5 虽然服务端支持 SSE 流式，在消息卡片中却表现为长时间无输出，最后一次性返回整段内容。

## 原因
Feishu 插件在 streaming card 模式下，会将 block streaming 关闭：
ts
const enableBlockStreaming = feishuCfg?.blockStreaming === true && !useStreamingCards;

这会导致某些依赖 block-level 增量事件的 provider（如 MiniMax Anthropic-compatible stream）无法及时将增量内容传递到 Feishu 卡片流式渲染层，只剩最终聚合输出。

## 修复
改为只要配置启用了 blockStreaming，就保持启用，不再因为 useStreamingCards 而自动关闭：
ts
const enableBlockStreaming = feishuCfg?.blockStreaming === true;

## 影响
- 不影响未开启 blockStreaming 的账户
- 改善 MiniMax-M2.5 在 Feishu streaming cards 下的可见流式表现
- 保持 GPT-5.4 等原本可流式模型的行为一致