### PR TITLE
feat: allow allowFrom users to pass owner-policy OAuth check

### DIFF
--- a/src/core/owner-policy.ts
+++ b/src/core/owner-policy.ts
@@ -38,10 +38,14 @@ export class OwnerAccessDeniedError extends Error {
 // ---------------------------------------------------------------------------
 
 /**
- * 校验用户是否为应用 owner（fail-close 版本）。
+ * 校验用户是否有权执行 owner-level 操作（fail-close 版本）。
+ *
+ * 授权条件（满足任一即可）：
+ * 1. 用户是应用 owner
+ * 2. 用户在该账号的 `allowFrom` 列表中（已被管理员显式信任）
  *
  * - 获取 owner 失败时 → 拒绝（安全优先）
- * - owner 不匹配时 → 拒绝
+ * - owner 不匹配且不在 allowFrom 中 → 拒绝
  *
  * 适用于：`executeAuthorize`（OAuth 授权发起）、`commands/auth.ts`（批量授权）等
  * 赋予实质性权限的入口。
@@ -58,7 +62,18 @@ export async function assertOwnerAccessStrict(
     throw new OwnerAccessDeniedError(userOpenId, 'unknown');
   }
 
-  if (ownerOpenId !== userOpenId) {
-    throw new OwnerAccessDeniedError(userOpenId, ownerOpenId);
+  // Owner 直接放行
+  if (ownerOpenId === userOpenId) {
+    return;
   }
+
+  // allowFrom 中的用户也视为可信用户，允许 OAuth 授权。
+  // 这些用户已被管理员显式添加到信任列表中，适用于家庭/小团队等
+  // 多人共用同一应用的场景。每个用户仍使用自己的 UAT，数据隔离不受影响。
+  const allowFrom: string[] = account.config?.allowFrom ?? [];
+  if (allowFrom.some((entry) => String(entry) === userOpenId)) {
+    return;
+  }
+
+  throw new OwnerAccessDeniedError(userOpenId, ownerOpenId);
 }


### PR DESCRIPTION
## Problem

Currently, `assertOwnerAccessStrict` in `owner-policy.ts` only allows the app owner (creator) to authorize OAuth and use user-identity API calls. This means any non-owner user in a shared Feishu app gets `permission_denied` errors, even if they are explicitly listed in the `allowFrom` configuration.

This blocks legitimate multi-user scenarios such as:
- **Family members** sharing a single self-built Feishu app
- **Small teams** where one person creates the app but multiple people need user-identity features (calendar, docs, tasks, etc.)

## 问题描述

当前 `owner-policy.ts` 中的 `assertOwnerAccessStrict` 只允许应用创建者（owner）通过 OAuth 授权并使用用户身份 API。这导致即使用户被明确配置在 `allowFrom` 白名单中，非 owner 用户仍然会收到 `permission_denied` 错误。

这阻碍了以下合理的多用户场景：
- **家庭成员** 共享一个自建飞书应用
- **小型团队** 中一人创建应用，但多人需要使用用户身份功能（日历、文档、任务等）

## Solution / 解决方案

Extend `assertOwnerAccessStrict` to also accept users explicitly listed in the account's `allowFrom` configuration:

扩展 `assertOwnerAccessStrict`，允许 `allowFrom` 白名单中的用户通过 OAuth 授权：

1. App owner → pass (unchanged) / 应用 owner → 通过（不变）
2. User in `allowFrom` list → pass (**new**) / `allowFrom` 白名单用户 → 通过（**新增**）
3. All others → reject (unchanged) / 其他用户 → 拒绝（不变）

### Why this is safe / 为什么这是安全的

- `allowFrom` users are **already explicitly trusted** by the administrator for messaging access
  `allowFrom` 用户已被管理员**明确信任**，拥有消息访问权限
- Each user gets their **own UAT** (User Access Token), so data isolation is fully preserved
  每个用户获得**独立的 UAT**，数据隔离完全保留
- No user can access another user's data — each UAT is scoped to the individual
  用户之间无法互相访问数据——每个 UAT 的作用域仅限于个人
- The fail-close behavior is maintained: unknown users are still rejected
  默认拒绝策略不变：未知用户仍会被拒绝

## Changes / 改动

- `src/core/owner-policy.ts`: Modified `assertOwnerAccessStrict` to check `account.config.allowFrom` as a secondary trust source
  修改 `assertOwnerAccessStrict`，将 `account.config.allowFrom` 作为二级信任来源

## Testing / 测试

Tested in a real deployment with two users (owner + allowFrom user):
在真实部署环境中测试（owner + allowFrom 用户）：

- Owner: OAuth works as before ✅ / Owner：OAuth 授权正常 ✅
- allowFrom user: OAuth now works correctly ✅ / allowFrom 用户：OAuth 授权现在正常 ✅
- Non-allowFrom user: Still rejected ✅ / 非白名单用户：仍然被拒绝 ✅
