### PR TITLE
feat(channel): forward non-OAuth card actions to inbound message pipeline

### DIFF
--- a/src/channel/event-handlers.ts
+++ b/src/channel/event-handlers.ts
@@ -237,9 +237,99 @@ export async function handleBotMembershipEvent(
 // Card action handler
 // ---------------------------------------------------------------------------
 
+/**
+ * Handle a Feishu interactive card action event.
+ *
+ * First, we try the built-in OAuth handler (`handleCardAction`). This covers
+ * cases where the card action is part of the OAuth authorisation flow.
+ *
+ * If `handleCardAction` returns `undefined` the action is not OAuth-related.
+ * In that case we forward it into the standard inbound message pipeline so
+ * the agent can handle multi-step card interactions (e.g. a "Confirm / Cancel"
+ * button after the agent presents a draft).
+ *
+ * The card action payload is normalised into a synthetic `FeishuMessageEvent`
+ * so that the existing session-isolation, serialisation, and context logic in
+ * `handleMessageEvent` can be reused without modification.
+ */
 export async function handleCardActionEvent(ctx: MonitorContext, data: unknown): Promise<unknown> {
   try {
-    return await handleCardAction(data, ctx.cfg, ctx.accountId);
+    const result = await handleCardAction(data, ctx.cfg, ctx.accountId);
+    if (result !== undefined) return result;
+
+    // ── Non-OAuth card action: forward to agent via inbound message pipeline ──
+    const { accountId, log } = ctx;
+    const payload = data as Record<string, unknown>;
+    const operator = (payload.operator as Record<string, unknown>) ?? {};
+    const openId = (operator.open_id as string) ?? '';
+    const action = (payload.action as Record<string, unknown>) ?? {};
+    const context = (payload.context as Record<string, unknown>) ?? {};
+
+    const chatId = (payload.open_chat_id as string) || (context.open_chat_id as string) || '';
+    const msgId = (payload.open_message_id as string) || (context.open_message_id as string) || '';
+
+    // Merge action.value + action.form_value and tag with action metadata so
+    // the agent can identify which button was clicked and what form data was
+    // submitted.
+    const actionValue: Record<string, unknown> = {
+      ...((action.value as Record<string, unknown>) ?? {}),
+      ...((action.form_value as Record<string, unknown>) ?? {}),
+    };
+    if (action.tag) actionValue._action_tag = action.tag;
+
+    log(`feishu[${accountId}]: non-OAuth card action from ${openId} in chat ${chatId}: ${JSON.stringify(actionValue)}`);
+
+    const syntheticEvent: FeishuMessageEvent = {
+      sender: {
+        sender_id: { open_id: openId },
+        sender_type: 'user',
+      },
+      message: {
+        message_id: msgId || `card_action_${Date.now()}`,
+        chat_id: chatId,
+        chat_type: chatId.startsWith('oc_') ? 'group' : 'p2p',
+        message_type: 'text',
+        content: JSON.stringify({ text: JSON.stringify(actionValue) }),
+        // Signal to downstream handlers that this message originated from a
+        // card action so they can skip mention checks and format responses
+        // as a follow-up card rather than a fresh reply.
+        _card_action: true,
+      } as FeishuMessageEvent['message'],
+    };
+
+    const { status } = enqueueFeishuChatTask({
+      accountId,
+      chatId,
+      threadId: undefined,
+      task: async () => {
+        try {
+          await withTicket(
+            {
+              messageId: syntheticEvent.message?.message_id ?? '',
+              chatId,
+              accountId,
+              startTime: Date.now(),
+              senderOpenId: openId,
+              chatType: syntheticEvent.message?.chat_type as 'p2p' | 'group' | undefined,
+              threadId: undefined,
+            },
+            () =>
+              handleFeishuMessage({
+                cfg: ctx.cfg,
+                event: syntheticEvent,
+                botOpenId: ctx.lark.botOpenId,
+                runtime: ctx.runtime,
+                chatHistories: ctx.chatHistories,
+                accountId,
+              }),
+          );
+        } catch (err) {
+          elog.warn(`feishu[${accountId}]: error handling card action: ${String(err)}`);
+        }
+      },
+    });
+
+    log(`feishu[${accountId}]: card action from ${openId} enqueued for chat ${chatId} — ${status}`);
   } catch (err) {
     elog.warn(`card.action.trigger handler error: ${err}`);
   }


### PR DESCRIPTION
## Problem

When an agent sends an interactive card with buttons, clicking those buttons triggers a `card.action.trigger` WebSocket event. Currently `handleCardActionEvent()` delegates entirely to `handleCardAction()` which is designed for the OAuth authorisation flow. Any non-OAuth card action (e.g. a "Confirm draft", "Cancel", or form submission button) returns `undefined` from `handleCardAction()` and is silently dropped — the agent never sees it.

This makes it impossible to implement multi-step card interactions without patching the plugin locally.

Closes #128

## Solution

Add a fallback path in `handleCardActionEvent()`: when `handleCardAction()` returns `undefined`, normalise the card action payload into a synthetic `FeishuMessageEvent` and forward it through the existing `enqueueFeishuChatTask + withTicket + handleFeishuMessage` pipeline.

This reuses all existing session-isolation, serialisation, dedup, and agent-dispatch logic without modification.

### Synthetic message structure

- `sender.sender_id.open_id` — the user who clicked the button (from `event.operator.open_id`)
- `message.content` — JSON-encoded text containing merged `action.value` + `action.form_value`
- `message._action_tag` — the button's `tag` field, so the agent can identify which button was clicked
- `message._card_action: true` — signal to downstream handlers that this is a card callback, not a regular user message
- `message.chat_id` / `message.chat_type` — resolved from `event.open_chat_id` or `event.context.open_chat_id`

### Why this approach

- **Zero changes to the message pipeline**: the synthetic event flows through `enqueueFeishuChatTask` so card actions are serialised against concurrent messages in the same chat — no race conditions.
- **Session continuity**: because the `chatId` is preserved, the agent receives the card action in the same session context as the original message that sent the card.
- **Form support**: `action.form_value` is merged alongside `action.value`, so interactive forms (text inputs, dropdowns) work out of the box.
- **Backwards compatible**: the OAuth path is completely unchanged; the new code only executes when `handleCardAction` returns `undefined`.

## Testing

- TypeScript: `tsc --noEmit` passes with no errors
- Manually verified with a two-step email draft card: agent sends card with "AI Polish" / "Create Draft" / "Mark Done" buttons; clicking each button is received by the agent as a synthetic message with the correct `_action_name` in the content

## Related

- Issue #128 — Feature request for this exact behaviour
- The same workaround was independently developed by the issue author; this PR is a cleaned-up TypeScript implementation with proper type annotations and integration with the task queue
