### PR TITLE
Add Feishu thread binding support

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -12,6 +12,7 @@ import type { OpenClawPluginApi } from 'openclaw/plugin-sdk';
 import { emptyPluginConfigSchema } from 'openclaw/plugin-sdk';
 import { feishuPlugin } from './src/channel/plugin';
 import { LarkClient } from './src/core/lark-client';
+import { registerFeishuSessionBindingAdapters, registerFeishuSubagentHooks } from './src/channel/thread-bindings';
 import { registerOapiTools } from './src/tools/oapi/index';
 import { registerFeishuMcpDocTools } from './src/tools/mcp/doc/index';
 import { registerFeishuOAuthTool } from './src/tools/oauth';
@@ -103,9 +104,11 @@ const plugin = {
   name: 'Feishu',
   description: 'Lark/Feishu channel plugin with im/doc/wiki/drive/task/calendar tools',
   configSchema: emptyPluginConfigSchema(),
-  register(api: OpenClawPluginApi) {
+  register(api: OpenClawPluginApi): void {
     LarkClient.setRuntime(api.runtime);
     api.registerChannel({ plugin: feishuPlugin });
+    registerFeishuSessionBindingAdapters(api.config);
+    registerFeishuSubagentHooks(api);
 
     // ========================================
 

--- a/src/channel/thread-bindings.ts
+++ b/src/channel/thread-bindings.ts
@@ -93,6 +93,17 @@ function listBindingsForAccount(accountId: string): FeishuBindingEntry[] {
   return [...state.bindingsByAccountConversation.values()].filter((entry) => entry.accountId === accountId);
 }
 
+function findLatestBindingByParentConversation(accountId: string, parentConversationId: string): FeishuBindingEntry | null {
+  const normalizedParentConversationId = normalizeConversationId(parentConversationId);
+  if (!normalizedParentConversationId) return null;
+
+  const candidates = listBindingsForAccount(accountId)
+    .filter((entry) => entry.parentConversationId === normalizedParentConversationId)
+    .sort((left, right) => right.lastActivityAt - left.lastActivityAt);
+
+  return candidates[0] ?? null;
+}
+
 function getBindingByConversation(accountId: string, conversationId: string): FeishuBindingEntry | null {
   const state = getBindingState();
   return state.bindingsByAccountConversation.get(toBindingKey(accountId, conversationId)) ?? null;
@@ -168,7 +179,16 @@ function createFeishuSessionBindingAdapter(accountId: string): SessionBindingAda
       const conversationId = normalizeConversationId(ref.conversationId);
       if (!conversationId) return null;
       const binding = getBindingByConversation(accountId, conversationId);
-      return binding ? toSessionBindingRecord(binding) : null;
+      if (binding) return toSessionBindingRecord(binding);
+
+      // Some Feishu follow-up messages only carry chat-level context even when
+      // the original ACP session was bound to a topic/root thread. In that
+      // case, fall back to the latest active binding in the same chat.
+      const parentConversationId = normalizeConversationId(ref.parentConversationId) ?? conversationId;
+      const fallbackBinding = parentConversationId
+        ? findLatestBindingByParentConversation(accountId, parentConversationId)
+        : null;
+      return fallbackBinding ? toSessionBindingRecord(fallbackBinding) : null;
     },
     touch: (bindingId, at) => {
       const prefix = `${accountId}:`;

--- a/src/channel/thread-bindings.ts
+++ b/src/channel/thread-bindings.ts
@@ -19,6 +19,9 @@ import {
   registerSessionBindingAdapter,
   unregisterSessionBindingAdapter,
 } from 'openclaw/plugin-sdk';
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
 import { getLarkAccount, getLarkAccountIds } from '../core/accounts';
 import { larkLogger } from '../core/lark-logger';
 import { normalizeFeishuTarget } from '../core/targets';
@@ -39,7 +42,17 @@ interface FeishuBindingEntry {
 
 interface FeishuBindingState {
   bindingsByAccountConversation: Map<string, FeishuBindingEntry>;
+  loadedFromDisk: boolean;
+  dirty: boolean;
 }
+
+interface PersistedFeishuBindingState {
+  version: 1;
+  bindings: FeishuBindingEntry[];
+}
+
+const FEISHU_BINDING_STATE_PATH = join(homedir(), '.openclaw', 'state', 'openclaw-lark', 'feishu-thread-bindings.json');
+const OPENCLAW_CODEX_SESSION_STORE_PATH = join(homedir(), '.openclaw', 'agents', 'codex', 'sessions', 'sessions.json');
 
 function getBindingState(): FeishuBindingState {
   const globalState = globalThis as typeof globalThis & {
@@ -47,8 +60,143 @@ function getBindingState(): FeishuBindingState {
   };
   globalState[FEISHU_BINDING_STATE_SYMBOL] ??= {
     bindingsByAccountConversation: new Map<string, FeishuBindingEntry>(),
+    loadedFromDisk: false,
+    dirty: false,
   };
-  return globalState[FEISHU_BINDING_STATE_SYMBOL]!;
+  const state = globalState[FEISHU_BINDING_STATE_SYMBOL]!;
+  ensureBindingStateLoaded(state);
+  return state;
+}
+
+function ensureBindingStateLoaded(state: FeishuBindingState): void {
+  if (state.loadedFromDisk) return;
+  state.loadedFromDisk = true;
+
+  try {
+    const raw = readFileSync(FEISHU_BINDING_STATE_PATH, 'utf8');
+    const parsed = JSON.parse(raw) as PersistedFeishuBindingState;
+    if (parsed?.version !== 1 || !Array.isArray(parsed.bindings)) {
+      log.warn(`ignored invalid Feishu binding state file at ${FEISHU_BINDING_STATE_PATH}`);
+      return;
+    }
+
+    for (const entry of parsed.bindings) {
+      const accountId = normalizeAccountId(entry.accountId);
+      const conversationId = normalizeConversationId(entry.conversationId);
+      const targetSessionKey = entry.targetSessionKey?.trim();
+      if (!conversationId || !targetSessionKey) continue;
+
+      state.bindingsByAccountConversation.set(toBindingKey(accountId, conversationId), {
+        ...entry,
+        accountId,
+        conversationId,
+        parentConversationId: normalizeConversationId(entry.parentConversationId),
+        targetSessionKey,
+        boundAt: Number.isFinite(entry.boundAt) ? Math.floor(entry.boundAt) : Date.now(),
+        lastActivityAt: Number.isFinite(entry.lastActivityAt) ? Math.floor(entry.lastActivityAt) : Date.now(),
+      });
+    }
+
+    if (state.bindingsByAccountConversation.size > 0) {
+      log.info(`loaded ${state.bindingsByAccountConversation.size} persisted Feishu thread binding(s)`);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if ((error as NodeJS.ErrnoException | undefined)?.code !== 'ENOENT') {
+      log.warn(`failed to load persisted Feishu thread bindings: ${message}`);
+    }
+  }
+
+  bootstrapBindingsFromSessionStore(state);
+}
+
+interface BootstrapSessionStoreEntry {
+  updatedAt?: number;
+  spawnedBy?: string;
+  channel?: string;
+  lastChannel?: string;
+}
+
+function bootstrapBindingsFromSessionStore(state: FeishuBindingState): void {
+  try {
+    const raw = readFileSync(OPENCLAW_CODEX_SESSION_STORE_PATH, 'utf8');
+    const parsed = JSON.parse(raw) as Record<string, BootstrapSessionStoreEntry>;
+    const latestByChat = new Map<string, FeishuBindingEntry>();
+
+    for (const [sessionKey, entry] of Object.entries(parsed ?? {})) {
+      if (!sessionKey.startsWith('agent:')) continue;
+      if ((entry.channel ?? entry.lastChannel) !== 'feishu') continue;
+
+      const spawnedBy = entry.spawnedBy?.trim();
+      const match = spawnedBy?.match(/^agent:main:feishu:group:(.+)$/);
+      const chatId = normalizeConversationId(match?.[1]);
+      if (!chatId) continue;
+
+      const accountId = 'default';
+      const updatedAt = Number.isFinite(entry.updatedAt) ? Math.floor(entry.updatedAt!) : Date.now();
+      const nextEntry: FeishuBindingEntry = {
+        accountId,
+        conversationId: chatId,
+        parentConversationId: chatId,
+        targetSessionKey: sessionKey,
+        targetKind: 'subagent',
+        boundAt: updatedAt,
+        lastActivityAt: updatedAt,
+        metadata: {
+          recoveredBy: 'session-store-bootstrap',
+          placement: 'current',
+        },
+      };
+
+      const existing = latestByChat.get(toBindingKey(accountId, chatId));
+      if (!existing || nextEntry.lastActivityAt > existing.lastActivityAt) {
+        latestByChat.set(toBindingKey(accountId, chatId), nextEntry);
+      }
+    }
+
+    let inserted = 0;
+    for (const entry of latestByChat.values()) {
+      const key = toBindingKey(entry.accountId, entry.conversationId);
+      const existing = state.bindingsByAccountConversation.get(key);
+      if (existing && existing.lastActivityAt >= entry.lastActivityAt) continue;
+      state.bindingsByAccountConversation.set(key, entry);
+      inserted += 1;
+    }
+
+    if (inserted > 0) {
+      log.info(`bootstrapped ${inserted} Feishu thread binding(s) from session store`);
+      state.dirty = true;
+      persistBindingState(state);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if ((error as NodeJS.ErrnoException | undefined)?.code !== 'ENOENT') {
+      log.warn(`failed to bootstrap Feishu thread bindings from session store: ${message}`);
+    }
+  }
+}
+
+function persistBindingState(state: FeishuBindingState): void {
+  if (!state.loadedFromDisk) return;
+  const payload: PersistedFeishuBindingState = {
+    version: 1,
+    bindings: [...state.bindingsByAccountConversation.values()].sort((left, right) =>
+      left.accountId === right.accountId
+        ? left.conversationId.localeCompare(right.conversationId)
+        : left.accountId.localeCompare(right.accountId),
+    ),
+  };
+
+  try {
+    mkdirSync(dirname(FEISHU_BINDING_STATE_PATH), { recursive: true });
+    const tempPath = `${FEISHU_BINDING_STATE_PATH}.tmp`;
+    writeFileSync(tempPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+    renameSync(tempPath, FEISHU_BINDING_STATE_PATH);
+    state.dirty = false;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.warn(`failed to persist Feishu thread bindings: ${message}`);
+  }
 }
 
 function normalizeAccountId(input: string | undefined | null): string {
@@ -112,6 +260,8 @@ function getBindingByConversation(accountId: string, conversationId: string): Fe
 function setBinding(entry: FeishuBindingEntry): FeishuBindingEntry {
   const state = getBindingState();
   state.bindingsByAccountConversation.set(toBindingKey(entry.accountId, entry.conversationId), entry);
+  state.dirty = true;
+  persistBindingState(state);
   return entry;
 }
 
@@ -121,6 +271,8 @@ function deleteBinding(accountId: string, conversationId: string): FeishuBinding
   const existing = state.bindingsByAccountConversation.get(key) ?? null;
   if (existing) {
     state.bindingsByAccountConversation.delete(key);
+    state.dirty = true;
+    persistBindingState(state);
   }
   return existing;
 }
@@ -179,7 +331,12 @@ function createFeishuSessionBindingAdapter(accountId: string): SessionBindingAda
       const conversationId = normalizeConversationId(ref.conversationId);
       if (!conversationId) return null;
       const binding = getBindingByConversation(accountId, conversationId);
-      if (binding) return toSessionBindingRecord(binding);
+      if (binding) {
+        log.info(
+          `resolved Feishu binding by conversation ${conversationId} -> ${binding.targetSessionKey} (account=${accountId})`,
+        );
+        return toSessionBindingRecord(binding);
+      }
 
       // Some Feishu follow-up messages only carry chat-level context even when
       // the original ACP session was bound to a topic/root thread. In that
@@ -188,7 +345,16 @@ function createFeishuSessionBindingAdapter(accountId: string): SessionBindingAda
       const fallbackBinding = parentConversationId
         ? findLatestBindingByParentConversation(accountId, parentConversationId)
         : null;
-      return fallbackBinding ? toSessionBindingRecord(fallbackBinding) : null;
+      if (fallbackBinding) {
+        log.info(
+          `resolved Feishu binding by parent conversation ${parentConversationId} -> ${fallbackBinding.targetSessionKey} (account=${accountId})`,
+        );
+        return toSessionBindingRecord(fallbackBinding);
+      }
+      log.info(
+        `no Feishu binding resolved for conversation ${conversationId} (parent=${parentConversationId ?? '-'}) (account=${accountId}, bindings=${listBindingsForAccount(accountId).length})`,
+      );
+      return null;
     },
     touch: (bindingId, at) => {
       const prefix = `${accountId}:`;
@@ -266,6 +432,7 @@ export function buildFeishuConversationRef(params: {
 
 function registerFeishuSessionBindingAdapterForAccount(accountId: string): void {
   try {
+    getBindingState();
     registerSessionBindingAdapter(createFeishuSessionBindingAdapter(accountId));
     log.info(`registered Feishu session binding adapter for ${accountId}`);
   } catch (error) {

--- a/src/channel/thread-bindings.ts
+++ b/src/channel/thread-bindings.ts
@@ -1,0 +1,362 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Minimal Feishu session/thread binding support.
+ *
+ * This file uses the public session-binding surface from openclaw/plugin-sdk.
+ * The current local runtime is patched to expose these APIs until they land
+ * upstream in a released OpenClaw build.
+ */
+
+import {
+  type ClawdbotConfig,
+  type ConversationRef,
+  type OpenClawPluginApi,
+  type SessionBindingAdapter,
+  type SessionBindingRecord,
+  getSessionBindingService,
+  registerSessionBindingAdapter,
+  unregisterSessionBindingAdapter,
+} from 'openclaw/plugin-sdk';
+import { getLarkAccount, getLarkAccountIds } from '../core/accounts';
+import { larkLogger } from '../core/lark-logger';
+import { normalizeFeishuTarget } from '../core/targets';
+
+const log = larkLogger('thread-bindings');
+const FEISHU_BINDING_STATE_SYMBOL = Symbol.for('openclaw-lark.feishuThreadBindings');
+
+interface FeishuBindingEntry {
+  accountId: string;
+  conversationId: string;
+  parentConversationId?: string;
+  targetSessionKey: string;
+  targetKind: SessionBindingTargetKind;
+  boundAt: number;
+  lastActivityAt: number;
+  metadata?: Record<string, unknown>;
+}
+
+interface FeishuBindingState {
+  bindingsByAccountConversation: Map<string, FeishuBindingEntry>;
+}
+
+function getBindingState(): FeishuBindingState {
+  const globalState = globalThis as typeof globalThis & {
+    [FEISHU_BINDING_STATE_SYMBOL]?: FeishuBindingState;
+  };
+  globalState[FEISHU_BINDING_STATE_SYMBOL] ??= {
+    bindingsByAccountConversation: new Map<string, FeishuBindingEntry>(),
+  };
+  return globalState[FEISHU_BINDING_STATE_SYMBOL]!;
+}
+
+function normalizeAccountId(input: string | undefined | null): string {
+  return (input ?? 'default').trim() || 'default';
+}
+
+function normalizeConversationId(input: string | undefined | null): string | undefined {
+  const value = input?.trim();
+  return value ? value : undefined;
+}
+
+function resolveConversationParentTarget(input: string | undefined | null): string | undefined {
+  return normalizeConversationId(input ? normalizeFeishuTarget(input) : null);
+}
+
+function toBindingKey(accountId: string, conversationId: string): string {
+  return `${normalizeAccountId(accountId)}:${conversationId}`;
+}
+
+function toSessionBindingRecord(entry: FeishuBindingEntry): SessionBindingRecord {
+  return {
+    bindingId: toBindingKey(entry.accountId, entry.conversationId),
+    targetSessionKey: entry.targetSessionKey,
+    targetKind: entry.targetKind,
+    conversation: {
+      channel: 'feishu',
+      accountId: entry.accountId,
+      conversationId: entry.conversationId,
+      parentConversationId: entry.parentConversationId,
+    },
+    status: 'active',
+    boundAt: entry.boundAt,
+    metadata: {
+      ...(entry.metadata ?? {}),
+      lastActivityAt: entry.lastActivityAt,
+    },
+  };
+}
+
+function listBindingsForAccount(accountId: string): FeishuBindingEntry[] {
+  const state = getBindingState();
+  return [...state.bindingsByAccountConversation.values()].filter((entry) => entry.accountId === accountId);
+}
+
+function getBindingByConversation(accountId: string, conversationId: string): FeishuBindingEntry | null {
+  const state = getBindingState();
+  return state.bindingsByAccountConversation.get(toBindingKey(accountId, conversationId)) ?? null;
+}
+
+function setBinding(entry: FeishuBindingEntry): FeishuBindingEntry {
+  const state = getBindingState();
+  state.bindingsByAccountConversation.set(toBindingKey(entry.accountId, entry.conversationId), entry);
+  return entry;
+}
+
+function deleteBinding(accountId: string, conversationId: string): FeishuBindingEntry | null {
+  const state = getBindingState();
+  const key = toBindingKey(accountId, conversationId);
+  const existing = state.bindingsByAccountConversation.get(key) ?? null;
+  if (existing) {
+    state.bindingsByAccountConversation.delete(key);
+  }
+  return existing;
+}
+
+function createFeishuSessionBindingAdapter(accountId: string): SessionBindingAdapter {
+  return {
+    channel: 'feishu',
+    accountId,
+    capabilities: {
+      // Current-thread binding is the true MVP. We also advertise child so ACP
+      // thread=true can pass the core capability gate on the current runtime.
+      placements: ['current', 'child'],
+      bindSupported: true,
+      unbindSupported: true,
+    },
+    resolveConversationForSpawn: ({ to, threadId }) =>
+      buildFeishuConversationRef({
+        accountId,
+        chatId: resolveConversationParentTarget(to),
+        threadId,
+        rootId: typeof threadId === 'string' && threadId.startsWith('om_') ? threadId : undefined,
+      }),
+    bind: async (input) => {
+      if (input.conversation.channel !== 'feishu') return null;
+
+      const conversationId = normalizeConversationId(input.conversation.conversationId);
+      if (!conversationId) return null;
+
+      const now = Date.now();
+      const existing = getBindingByConversation(accountId, conversationId);
+      const entry: FeishuBindingEntry = {
+        accountId,
+        conversationId,
+        parentConversationId: normalizeConversationId(input.conversation.parentConversationId),
+        targetSessionKey: input.targetSessionKey.trim(),
+        targetKind: input.targetKind,
+        boundAt: now,
+        lastActivityAt: now,
+        metadata: {
+          ...(existing?.metadata ?? {}),
+          ...(input.metadata ?? {}),
+          placement: input.placement ?? 'current',
+        },
+      };
+      return toSessionBindingRecord(setBinding(entry));
+    },
+    listBySession: (targetSessionKeyRaw) => {
+      const targetSessionKey = targetSessionKeyRaw.trim();
+      if (!targetSessionKey) return [];
+      return listBindingsForAccount(accountId)
+        .filter((entry) => entry.targetSessionKey === targetSessionKey)
+        .map(toSessionBindingRecord);
+    },
+    resolveByConversation: (ref) => {
+      if (ref.channel !== 'feishu') return null;
+      const conversationId = normalizeConversationId(ref.conversationId);
+      if (!conversationId) return null;
+      const binding = getBindingByConversation(accountId, conversationId);
+      return binding ? toSessionBindingRecord(binding) : null;
+    },
+    touch: (bindingId, at) => {
+      const prefix = `${accountId}:`;
+      if (!bindingId.startsWith(prefix)) return;
+      const conversationId = bindingId.slice(prefix.length).trim();
+      if (!conversationId) return;
+      const existing = getBindingByConversation(accountId, conversationId);
+      if (!existing) return;
+      setBinding({
+        ...existing,
+        lastActivityAt: typeof at === 'number' && Number.isFinite(at) ? Math.floor(at) : Date.now(),
+      });
+    },
+    unbind: async (input) => {
+      const removed: SessionBindingRecord[] = [];
+
+      if (input.bindingId) {
+        const prefix = `${accountId}:`;
+        if (input.bindingId.startsWith(prefix)) {
+          const conversationId = input.bindingId.slice(prefix.length).trim();
+          const removedEntry = deleteBinding(accountId, conversationId);
+          if (removedEntry) removed.push(toSessionBindingRecord(removedEntry));
+        }
+      }
+
+      if (removed.length > 0 || !input.targetSessionKey) return removed;
+
+      const targetSessionKey = input.targetSessionKey.trim();
+      if (!targetSessionKey) return removed;
+
+      for (const entry of listBindingsForAccount(accountId)) {
+        if (entry.targetSessionKey !== targetSessionKey) continue;
+        const removedEntry = deleteBinding(accountId, entry.conversationId);
+        if (removedEntry) removed.push(toSessionBindingRecord(removedEntry));
+      }
+
+      return removed;
+    },
+  };
+}
+
+export function resolveFeishuConversationId(params: {
+  chatId?: string | null;
+  rootId?: string | null;
+  threadId?: string | number | null;
+}): string | null {
+  const rootId = normalizeConversationId(params.rootId);
+  if (rootId) return rootId;
+
+  const threadId = params.threadId != null ? normalizeConversationId(String(params.threadId)) : undefined;
+  if (threadId) return threadId;
+
+  const chatId = normalizeConversationId(params.chatId);
+  if (chatId) return chatId;
+
+  return null;
+}
+
+export function buildFeishuConversationRef(params: {
+  accountId: string;
+  chatId?: string | null;
+  rootId?: string | null;
+  threadId?: string | number | null;
+}): ConversationRef | null {
+  const conversationId = resolveFeishuConversationId(params);
+  const chatId = normalizeConversationId(params.chatId);
+  if (!conversationId || !chatId) return null;
+  return {
+    channel: 'feishu',
+    accountId: normalizeAccountId(params.accountId),
+    conversationId,
+    parentConversationId: chatId,
+  };
+}
+
+function registerFeishuSessionBindingAdapterForAccount(accountId: string): void {
+  try {
+    registerSessionBindingAdapter(createFeishuSessionBindingAdapter(accountId));
+    log.info(`registered Feishu session binding adapter for ${accountId}`);
+  } catch (error) {
+    const message = String(error);
+    if (!message.includes('already registered')) {
+      throw error;
+    }
+  }
+}
+
+export function registerFeishuSessionBindingAdapters(cfg: ClawdbotConfig): void {
+  for (const accountId of getLarkAccountIds(cfg)) {
+    registerFeishuSessionBindingAdapterForAccount(normalizeAccountId(accountId));
+  }
+}
+
+export function unregisterFeishuSessionBindingAdapters(cfg: ClawdbotConfig): void {
+  for (const accountId of getLarkAccountIds(cfg)) {
+    unregisterSessionBindingAdapter({ channel: 'feishu', accountId: normalizeAccountId(accountId) });
+  }
+}
+
+function resolveThreadBindingsEnabled(cfg: ClawdbotConfig, accountId: string): boolean {
+  const account = getLarkAccount(cfg, accountId);
+  return account.enabled !== false && account.configured !== false;
+}
+
+export function registerFeishuSubagentHooks(api: OpenClawPluginApi): void {
+  api.on('gateway_start', () => {
+    registerFeishuSessionBindingAdapters(api.config);
+  });
+
+  api.on('subagent_spawning', async (event) => {
+    if (!event.threadRequested) return;
+    const channel = event.requester?.channel?.trim().toLowerCase();
+    if (channel !== 'feishu') return;
+
+    const accountId = normalizeAccountId(event.requester?.accountId);
+    if (!resolveThreadBindingsEnabled(api.config, accountId)) {
+      return {
+        status: 'error' as const,
+        error: 'Feishu thread bindings are unavailable for this account.',
+      };
+    }
+
+    const bindingService = getSessionBindingService();
+
+    const conversationRef = buildFeishuConversationRef({
+      accountId,
+      chatId: resolveConversationParentTarget(event.requester?.to),
+      threadId: event.requester?.threadId,
+      rootId: typeof event.requester?.threadId === 'string' && event.requester.threadId.startsWith('om_')
+        ? event.requester.threadId
+        : undefined,
+    });
+
+    if (!conversationRef) {
+      return {
+        status: 'error' as const,
+        error: 'Unable to resolve Feishu conversation for thread binding.',
+      };
+    }
+
+    await bindingService.bind({
+      targetSessionKey: event.childSessionKey,
+      targetKind: 'subagent',
+      conversation: conversationRef,
+      placement: 'current',
+      metadata: {
+        agentId: event.agentId,
+        label: event.label,
+        boundBy: 'system',
+      },
+    });
+
+    return { status: 'ok' as const, threadBindingReady: true };
+  });
+
+  api.on('subagent_delivery_target', (event) => {
+    if (!event.expectsCompletionMessage) return;
+    const requesterChannel = event.requesterOrigin?.channel?.trim().toLowerCase();
+    if (requesterChannel !== 'feishu') return;
+
+    const bindingService = getSessionBindingService();
+
+    const accountId = normalizeAccountId(event.requesterOrigin?.accountId);
+    const binding = bindingService
+      .listBySession(event.childSessionKey)
+      .find((entry) => entry.conversation.channel === 'feishu' && entry.conversation.accountId === accountId && entry.status === 'active');
+
+    if (!binding) return;
+
+    return {
+      origin: {
+        channel: 'feishu',
+        accountId: binding.conversation.accountId,
+        to: `channel:${binding.conversation.parentConversationId ?? binding.conversation.conversationId}`,
+        threadId: binding.conversation.conversationId,
+      },
+    };
+  });
+
+  api.on('subagent_ended', async (event) => {
+    const bindingService = getSessionBindingService();
+
+    const bindings = bindingService.listBySession(event.targetSessionKey);
+    if (bindings.length === 0) return;
+
+    await bindingService.unbind({
+      targetSessionKey: event.targetSessionKey,
+      reason: event.reason,
+    });
+  });
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -31,6 +31,9 @@ const T: Record<FeishuLocale, {
   helpAuth: string;
   helpDoctor: string;
   helpHelp: string;
+  helpSession: string;
+  helpSessionAlt: string;
+  helpSessionIntent: string;
   // errors
   diagFailed: (msg: string) => string;
   authFailed: (msg: string) => string;
@@ -56,6 +59,9 @@ const T: Record<FeishuLocale, {
     helpAuth: '/feishu auth - 批量授权用户权限',
     helpDoctor: '/feishu doctor - 运行诊断',
     helpHelp: '/feishu help - 显示此帮助',
+    helpSession: '/codex_thread [task] - 在当前话题开启 Codex ACP 持久会话',
+    helpSessionAlt: '/feishu session [task] - 同上，走统一命令入口',
+    helpSessionIntent: '自然语言也可触发：明确要求“实际调用 sessions_spawn，在当前话题开启 Codex ACP 持久会话”',
     diagFailed: (msg) => `诊断执行失败: ${msg}`,
     authFailed: (msg) => `授权执行失败: ${msg}`,
     execFailed: (msg) => `执行失败: ${msg}`,
@@ -80,6 +86,9 @@ const T: Record<FeishuLocale, {
     helpAuth: '/feishu auth - Batch authorize user permissions',
     helpDoctor: '/feishu doctor - Run diagnostics',
     helpHelp: '/feishu help - Show this help',
+    helpSession: '/codex_thread [task] - Start a persistent Codex ACP session in the current thread',
+    helpSessionAlt: '/feishu session [task] - Same as above through the unified Feishu command',
+    helpSessionIntent: 'Natural language also works when you explicitly ask it to actually call sessions_spawn and bind a persistent Codex ACP session to the current thread',
     diagFailed: (msg) => `Diagnostics failed: ${msg}`,
     authFailed: (msg) => `Authorization failed: ${msg}`,
     execFailed: (msg) => `Execution failed: ${msg}`,
@@ -149,7 +158,10 @@ export function getFeishuHelp(locale: FeishuLocale = 'zh_cn'): string {
     `  ${t.helpStart}\n` +
     `  ${t.helpAuth}\n` +
     `  ${t.helpDoctor}\n` +
-    `  ${t.helpHelp}`
+    `  ${t.helpHelp}\n` +
+    `  ${t.helpSession}\n` +
+    `  ${t.helpSessionAlt}\n\n` +
+    `${t.helpSessionIntent}`
   );
 }
 

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -23,7 +23,9 @@ const EXPLICIT_COMMAND_PATTERNS = [
 const START_PATTERN = /(开启|启动|创建|发起|开一个|开个|拉起|spawn|start|open|create)/i;
 const SESSION_PATTERN = /(acp|codex|persistent|persist|持久|session|会话)/i;
 const THREAD_PATTERN = /(thread|话题|线程|当前话题|当前线程|绑定到当前|绑定当前|在这个会话里|在当前会话里)/i;
-const EXECUTION_PATTERN = /(实际调用|实际创建|真的创建|立即创建|must call|actually call|call sessions_spawn|使用\s*codex\s*开|用\s*codex\s*开)/i;
+const STRICT_EXECUTION_PATTERN =
+  /(实际调用\s*sessions_spawn|call\s+sessions_spawn|must call\s+sessions_spawn|actually call\s+sessions_spawn|使用\s*codex\s*开\s*(?:一个)?\s*(?:persistent|持久)?\s*(?:acp)?\s*会话|用\s*codex\s*开\s*(?:一个)?\s*(?:persistent|持久)?\s*(?:acp)?\s*会话)/i;
+const CONTINUATION_PATTERN = /^(继续|继续吧|接着|然后|下一步|先实现|继续实现|开始实现)/i;
 
 function normalizeWhitespace(input: string): string {
   return input.replace(/\s+/g, ' ').trim();
@@ -51,11 +53,13 @@ export function parseCodexThreadSpawnRequest(text: string): CodexThreadSpawnRequ
     };
   }
 
+  if (CONTINUATION_PATTERN.test(trimmed)) return null;
+
   if (
+    STRICT_EXECUTION_PATTERN.test(trimmed) &&
     START_PATTERN.test(trimmed) &&
     SESSION_PATTERN.test(trimmed) &&
-    THREAD_PATTERN.test(trimmed) &&
-    (EXECUTION_PATTERN.test(trimmed) || /sessions_spawn/i.test(trimmed))
+    THREAD_PATTERN.test(trimmed)
   ) {
     return {
       task: truncateTask(trimmed),

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Helpers for explicit and natural-language Codex ACP session spawning.
+ */
+
+export interface CodexThreadSpawnRequest {
+  task: string;
+  trigger: 'command' | 'intent';
+  source: string;
+}
+
+const DEFAULT_SPAWN_TASK =
+  'Start a persistent ACP Codex session bound to the current Feishu thread and wait for follow-up instructions from this thread.';
+
+const EXPLICIT_COMMAND_PATTERNS = [
+  /^\/codex[_ -]?thread(?:\s+(?<task>[\s\S]+))?$/i,
+  /^\/acp[_ -]?session(?:\s+(?<task>[\s\S]+))?$/i,
+  /^\/feishu[_ ]session(?:\s+codex)?(?:\s+(?<task>[\s\S]+))?$/i,
+];
+
+const START_PATTERN = /(开启|启动|创建|发起|开一个|开个|拉起|spawn|start|open|create)/i;
+const SESSION_PATTERN = /(acp|codex|persistent|persist|持久|session|会话)/i;
+const THREAD_PATTERN = /(thread|话题|线程|当前话题|当前线程|绑定到当前|绑定当前|在这个会话里|在当前会话里)/i;
+const EXECUTION_PATTERN = /(实际调用|实际创建|真的创建|立即创建|must call|actually call|call sessions_spawn|使用\s*codex\s*开|用\s*codex\s*开)/i;
+
+function normalizeWhitespace(input: string): string {
+  return input.replace(/\s+/g, ' ').trim();
+}
+
+function truncateTask(input: string, maxLength = 900): string {
+  const normalized = normalizeWhitespace(input);
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, maxLength - 3).trimEnd()}...`;
+}
+
+export function parseCodexThreadSpawnRequest(text: string): CodexThreadSpawnRequest | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+
+  for (const pattern of EXPLICIT_COMMAND_PATTERNS) {
+    const match = trimmed.match(pattern);
+    if (!match) continue;
+    const rawTask = typeof match.groups?.task === 'string' ? match.groups.task : '';
+    const task = truncateTask(rawTask || DEFAULT_SPAWN_TASK);
+    return {
+      task,
+      trigger: 'command',
+      source: trimmed,
+    };
+  }
+
+  if (
+    START_PATTERN.test(trimmed) &&
+    SESSION_PATTERN.test(trimmed) &&
+    THREAD_PATTERN.test(trimmed) &&
+    (EXECUTION_PATTERN.test(trimmed) || /sessions_spawn/i.test(trimmed))
+  ) {
+    return {
+      task: truncateTask(trimmed),
+      trigger: 'intent',
+      source: trimmed,
+    };
+  }
+
+  return null;
+}
+
+export function buildCodexThreadSpawnPrompt(task: string): string {
+  const normalizedTask = truncateTask(task || DEFAULT_SPAWN_TASK);
+  return [
+    'Do not infer the result from prior conversation. Actually call sessions_spawn now.',
+    'Required arguments:',
+    'runtime=acp',
+    'agentId=codex',
+    'thread=true',
+    'mode=session',
+    `task=${JSON.stringify(normalizedTask)}`,
+    'If the tool call succeeds, reply only with the spawned session id.',
+    'If the tool call fails, reply only with the real error message.',
+  ].join('\n');
+}

--- a/src/core/targets.ts
+++ b/src/core/targets.ts
@@ -23,6 +23,7 @@ const CHAT_PREFIX = 'oc_';
 const OPEN_ID_PREFIX = 'ou_';
 
 // Canonical routing prefixes used inside OpenClaw (not Feishu-native).
+const TAG_CHANNEL = 'channel:';
 const TAG_CHAT = 'chat:';
 const TAG_USER = 'user:';
 const TAG_OPEN_ID = 'open_id:';
@@ -73,6 +74,7 @@ export function normalizeFeishuTarget(raw: string): string | null {
     if (inner) return inner;
   }
 
+  if (trimmed.startsWith(TAG_CHANNEL)) return trimmed.slice(TAG_CHANNEL.length);
   if (trimmed.startsWith(TAG_CHAT)) return trimmed.slice(TAG_CHAT.length);
   if (trimmed.startsWith(TAG_USER)) return trimmed.slice(TAG_USER.length);
   if (trimmed.startsWith(TAG_OPEN_ID)) return trimmed.slice(TAG_OPEN_ID.length);
@@ -184,6 +186,7 @@ export function normalizeMessageId(messageId: string | undefined): string | unde
 export function looksLikeFeishuId(raw: string): boolean {
   if (!raw) return false;
   return (
+    raw.startsWith(TAG_CHANNEL) ||
     raw.startsWith(TAG_CHAT) ||
     raw.startsWith(TAG_USER) ||
     raw.startsWith(TAG_OPEN_ID) ||

--- a/src/messaging/inbound/dispatch-builders.ts
+++ b/src/messaging/inbound/dispatch-builders.ts
@@ -119,6 +119,8 @@ export function buildInboundPayload(
     extraFields?: Record<string, unknown>;
   },
 ): ReturnType<typeof LarkClient.runtime.channel.reply.finalizeInboundContext> {
+  const originatingTo = opts.originatingTo ?? (dc.isGroup ? `channel:${dc.ctx.chatId}` : dc.feishuTo);
+
   return dc.core.channel.reply.finalizeInboundContext({
     // extraFields first — fixed fields below always take precedence
     ...opts.extraFields,
@@ -143,7 +145,8 @@ export function buildInboundPayload(
     WasMentioned: opts.wasMentioned,
     CommandAuthorized: dc.commandAuthorized,
     OriginatingChannel: 'feishu' as const,
-    OriginatingTo: opts.originatingTo ?? dc.feishuTo,
+    OriginatingTo: originatingTo,
+    ...(dc.ctx.threadId ? { MessageThreadId: dc.ctx.rootId ?? dc.ctx.threadId } : {}),
   });
 }
 

--- a/src/messaging/inbound/dispatch-builders.ts
+++ b/src/messaging/inbound/dispatch-builders.ts
@@ -130,7 +130,7 @@ export function buildInboundPayload(
     CommandBody: opts.commandBody,
     From: dc.feishuFrom,
     To: dc.feishuTo,
-    SessionKey: dc.threadSessionKey ?? dc.route.sessionKey,
+        SessionKey: dc.boundSessionKey ?? dc.threadSessionKey ?? dc.route.sessionKey,
     AccountId: dc.route.accountId,
     ChatType: dc.isGroup ? 'group' : 'direct',
     GroupSubject: dc.isGroup ? dc.ctx.chatId : undefined,

--- a/src/messaging/inbound/dispatch-commands.ts
+++ b/src/messaging/inbound/dispatch-commands.ts
@@ -61,7 +61,7 @@ export async function dispatchPermissionNotification(
     markFullyComplete: markPermComplete,
   } = createFeishuReplyDispatcher({
     cfg: dc.accountScopedCfg,
-    agentId: dc.route.agentId,
+    agentId: dc.boundAgentId ?? dc.route.agentId,
     chatId: dc.ctx.chatId,
     replyToMessageId: replyToMessageId ?? dc.ctx.messageId,
     accountId: dc.account.accountId,

--- a/src/messaging/inbound/dispatch-context.ts
+++ b/src/messaging/inbound/dispatch-context.ts
@@ -10,12 +10,13 @@
  */
 
 import type { ClawdbotConfig, RuntimeEnv } from 'openclaw/plugin-sdk';
-import { resolveThreadSessionKeys } from 'openclaw/plugin-sdk';
+import { getSessionBindingService, resolveThreadSessionKeys } from 'openclaw/plugin-sdk';
 import type { MessageContext } from '../types';
 import type { LarkAccount } from '../../core/types';
 import { LarkClient } from '../../core/lark-client';
 import { larkLogger } from '../../core/lark-logger';
 import { isThreadCapableGroup } from '../../core/chat-info-cache';
+import { buildFeishuConversationRef } from '../../channel/thread-bindings';
 
 const log = larkLogger('inbound/dispatch-context');
 
@@ -39,6 +40,8 @@ export interface DispatchContext {
   envelopeFrom: string;
   envelopeOptions: ReturnType<typeof LarkClient.runtime.channel.reply.resolveEnvelopeFormatOptions>;
   route: ReturnType<typeof LarkClient.runtime.channel.routing.resolveAgentRoute>;
+  boundSessionKey?: string;
+  boundAgentId?: string;
   threadSessionKey?: string;
   commandAuthorized?: boolean;
 }
@@ -102,6 +105,23 @@ export function buildDispatchContext(params: {
     },
   });
 
+  const boundConversation = buildFeishuConversationRef({
+    accountId: account.accountId,
+    chatId: ctx.chatId,
+    rootId: ctx.rootId,
+    threadId: ctx.threadId,
+  });
+  const binding = boundConversation ? getSessionBindingService().resolveByConversation(boundConversation) : null;
+  const boundSessionKey = binding?.status === 'active' ? binding.targetSessionKey : undefined;
+  const boundAgentId = boundSessionKey ? extractAgentIdFromSessionKey(boundSessionKey) : undefined;
+  const effectiveRoute = boundSessionKey
+    ? {
+        ...route,
+        sessionKey: boundSessionKey,
+        agentId: boundAgentId ?? route.agentId,
+      }
+    : route;
+
   // ---- System event ----
   const sender = ctx.senderName ? `${ctx.senderName} (${ctx.senderId})` : ctx.senderId;
   const location = isGroup ? `group ${ctx.chatId}` : 'DM';
@@ -118,7 +138,7 @@ export function buildDispatchContext(params: {
   const tagStr = tags.length > 0 ? ` [${tags.join(', ')}]` : '';
 
   core.system.enqueueSystemEvent(`Feishu[${account.accountId}] ${location} | ${sender}${tagStr}`, {
-    sessionKey: route.sessionKey,
+    sessionKey: effectiveRoute.sessionKey,
     contextKey: `feishu:message:${ctx.chatId}:${ctx.messageId}`,
   });
 
@@ -136,10 +156,17 @@ export function buildDispatchContext(params: {
     feishuTo,
     envelopeFrom,
     envelopeOptions,
-    route,
+    route: effectiveRoute,
+    boundSessionKey,
+    boundAgentId,
     threadSessionKey: undefined,
     commandAuthorized: params.commandAuthorized,
   };
+}
+
+function extractAgentIdFromSessionKey(sessionKey: string): string | undefined {
+  const match = sessionKey.match(/^agent:([^:]+):/);
+  return typeof match?.[1] === 'string' && match[1].trim() ? match[1].trim() : undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/messaging/inbound/dispatch-context.ts
+++ b/src/messaging/inbound/dispatch-context.ts
@@ -114,6 +114,15 @@ export function buildDispatchContext(params: {
   const binding = boundConversation ? getSessionBindingService().resolveByConversation(boundConversation) : null;
   const boundSessionKey = binding?.status === 'active' ? binding.targetSessionKey : undefined;
   const boundAgentId = boundSessionKey ? extractAgentIdFromSessionKey(boundSessionKey) : undefined;
+  if (boundSessionKey) {
+    log.info(
+      `resolved Feishu bound session ${boundSessionKey} for chat=${ctx.chatId} thread=${ctx.rootId ?? ctx.threadId ?? '-'} message=${ctx.messageId}`,
+    );
+  } else if (boundConversation) {
+    log.info(
+      `no Feishu bound session for chat=${ctx.chatId} conversation=${boundConversation.conversationId} parent=${boundConversation.parentConversationId ?? '-'} message=${ctx.messageId}`,
+    );
+  }
   const effectiveRoute = boundSessionKey
     ? {
         ...route,

--- a/src/messaging/inbound/dispatch.ts
+++ b/src/messaging/inbound/dispatch.ts
@@ -122,7 +122,7 @@ async function dispatchNormalMessage(
 
   const { dispatcher, replyOptions, markDispatchIdle, markFullyComplete, abortCard } = createFeishuReplyDispatcher({
     cfg: dc.accountScopedCfg,
-    agentId: dc.route.agentId,
+    agentId: dc.boundAgentId ?? dc.route.agentId,
     chatId: dc.ctx.chatId,
     replyToMessageId: replyToMessageId ?? dc.ctx.messageId,
     accountId: dc.account.accountId,
@@ -140,7 +140,7 @@ async function dispatchNormalMessage(
   const queueKey = buildQueueKey(dc.account.accountId, dc.ctx.chatId, dc.ctx.threadId);
   registerActiveDispatcher(queueKey, { abortCard, abortController });
 
-  const effectiveSessionKey = dc.threadSessionKey ?? dc.route.sessionKey;
+  const effectiveSessionKey = dc.boundSessionKey ?? dc.threadSessionKey ?? dc.route.sessionKey;
   dc.log(`feishu[${dc.account.accountId}]: dispatching to agent (session=${effectiveSessionKey})`);
   log.info(`dispatching to agent (session=${effectiveSessionKey})`);
 
@@ -217,7 +217,7 @@ export async function dispatchToAgent(params: {
   const dc = buildDispatchContext(params);
 
   // 1b. Resolve thread session isolation (async: may query group info API)
-  if (dc.isThread && dc.ctx.threadId) {
+  if (!dc.boundSessionKey && dc.isThread && dc.ctx.threadId) {
     dc.threadSessionKey = await resolveThreadSessionKey({
       accountScopedCfg: dc.accountScopedCfg,
       account: dc.account,

--- a/src/messaging/inbound/dispatch.ts
+++ b/src/messaging/inbound/dispatch.ts
@@ -45,9 +45,48 @@ import { LarkClient } from '../../core/lark-client';
 import { runFeishuDoctorI18n } from '../../commands/doctor';
 import { runFeishuAuthI18n } from '../../commands/auth';
 import { runFeishuStartI18n, getFeishuHelpI18n } from '../../commands/index';
+import { buildCodexThreadSpawnPrompt, parseCodexThreadSpawnRequest } from '../../commands/session';
 import { sendCardFeishu, buildI18nMarkdownCard, sendMessageFeishu } from '../outbound/send';
 
 const log = larkLogger('inbound/dispatch');
+
+async function dispatchCodexThreadSpawn(
+  dc: DispatchContext,
+  params: {
+    trigger: 'command' | 'intent';
+    source: string;
+    task: string;
+    replyToMessageId?: string;
+  },
+): Promise<void> {
+  const prompt = buildCodexThreadSpawnPrompt(params.task);
+  const body = dc.core.channel.reply.formatAgentEnvelope({
+    channel: 'Feishu',
+    from: dc.envelopeFrom,
+    timestamp: new Date(),
+    envelope: dc.envelopeOptions,
+    body: prompt,
+  });
+
+  const ctxPayload = buildInboundPayload(dc, {
+    body,
+    bodyForAgent: prompt,
+    rawBody: params.source,
+    commandBody: prompt,
+    senderName: dc.ctx.senderName ?? dc.ctx.senderId,
+    senderId: dc.ctx.senderId,
+    messageSid: dc.ctx.messageId,
+    wasMentioned: false,
+    extraFields: {
+      ...(dc.ctx.threadId ? { MessageThreadId: dc.ctx.rootId ?? dc.ctx.threadId } : {}),
+    },
+  });
+
+  dc.log(`feishu[${dc.account.accountId}]: codex thread spawn ${params.trigger} detected, dispatching stable sessions_spawn request`);
+  log.info(`codex thread spawn ${params.trigger} detected, dispatching stable sessions_spawn request`);
+
+  await dispatchSystemCommand(dc, ctxPayload, false, params.replyToMessageId);
+}
 
 // ---------------------------------------------------------------------------
 // Internal: normal message dispatch
@@ -264,6 +303,18 @@ export async function dispatchToAgent(params: {
   //     plugin-registered commands via isControlCommandMessage, so
   //     /feishu_* falls through to the AI agent otherwise.
   const contentTrimmed = (params.ctx.content ?? '').trim();
+  const codexThreadSpawnRequest = parseCodexThreadSpawnRequest(contentTrimmed);
+
+  if (codexThreadSpawnRequest) {
+    await dispatchCodexThreadSpawn(dc, {
+      trigger: codexThreadSpawnRequest.trigger,
+      source: codexThreadSpawnRequest.source,
+      task: codexThreadSpawnRequest.task,
+      replyToMessageId: params.replyToMessageId,
+    });
+    return;
+  }
+
   const isDoctorCommand = /^\/feishu[_ ]doctor\s*$/i.test(contentTrimmed);
   const isAuthCommand = /^\/feishu[_ ](?:auth|onboarding)\s*$/i.test(contentTrimmed);
   const isStartCommand = /^\/feishu[_ ]start\s*$/i.test(contentTrimmed);

--- a/src/types/openclaw-session-binding-public-shim.d.ts
+++ b/src/types/openclaw-session-binding-public-shim.d.ts
@@ -1,0 +1,86 @@
+declare module 'openclaw/plugin-sdk' {
+  export type BindingTargetKind = 'subagent' | 'session';
+  export type BindingStatus = 'active' | 'ending' | 'ended';
+  export type SessionBindingPlacement = 'current' | 'child';
+
+  export type ConversationRef = {
+    channel: string;
+    accountId: string;
+    conversationId: string;
+    parentConversationId?: string;
+  };
+
+  export type SessionBindingRecord = {
+    bindingId: string;
+    targetSessionKey: string;
+    targetKind: BindingTargetKind;
+    conversation: ConversationRef;
+    status: BindingStatus;
+    boundAt: number;
+    expiresAt?: number;
+    metadata?: Record<string, unknown>;
+  };
+
+  export type SessionBindingBindInput = {
+    targetSessionKey: string;
+    targetKind: BindingTargetKind;
+    conversation: ConversationRef;
+    placement?: SessionBindingPlacement;
+    metadata?: Record<string, unknown>;
+    ttlMs?: number;
+  };
+
+  export type SessionBindingUnbindInput = {
+    bindingId?: string;
+    targetSessionKey?: string;
+    reason: string;
+  };
+
+  export type SessionBindingCapabilities = {
+    adapterAvailable: boolean;
+    bindSupported: boolean;
+    unbindSupported: boolean;
+    placements: SessionBindingPlacement[];
+  };
+
+  export type SessionBindingSpawnConversationInput = {
+    channel: string;
+    accountId: string;
+    to?: string;
+    threadId?: string | number;
+  };
+
+  export type SessionBindingAdapter = {
+    channel: string;
+    accountId: string;
+    capabilities?: {
+      placements?: SessionBindingPlacement[];
+      bindSupported?: boolean;
+      unbindSupported?: boolean;
+    };
+    resolveConversationForSpawn?: (input: SessionBindingSpawnConversationInput) => ConversationRef | null;
+    bind?: (input: SessionBindingBindInput) => Promise<SessionBindingRecord | null>;
+    listBySession: (targetSessionKey: string) => SessionBindingRecord[];
+    resolveByConversation: (ref: ConversationRef) => SessionBindingRecord | null;
+    touch?: (bindingId: string, at?: number) => void;
+    unbind?: (input: SessionBindingUnbindInput) => Promise<SessionBindingRecord[]>;
+  };
+
+  export type SessionBindingService = {
+    bind: (input: SessionBindingBindInput) => Promise<SessionBindingRecord>;
+    getCapabilities: (params: { channel: string; accountId: string }) => SessionBindingCapabilities;
+    resolveConversationForSpawn?: (input: SessionBindingSpawnConversationInput) => ConversationRef | null;
+    listBySession: (targetSessionKey: string) => SessionBindingRecord[];
+    resolveByConversation: (ref: ConversationRef) => SessionBindingRecord | null;
+    touch: (bindingId: string, at?: number) => void;
+    unbind: (input: SessionBindingUnbindInput) => Promise<SessionBindingRecord[]>;
+  };
+
+  export function registerSessionBindingAdapter(adapter: SessionBindingAdapter): void;
+  export function unregisterSessionBindingAdapter(params: { channel: string; accountId: string }): void;
+  export function getSessionBindingService(): SessionBindingService;
+  export function resolveConversationIdFromTargets(params: {
+    threadId?: string | number;
+    targets: Array<string | undefined | null>;
+  }): string | undefined;
+}


### PR DESCRIPTION
## Summary

This PR adds minimal Feishu thread-binding support on the plugin side so ACP persistent sessions can stay bound to the current Feishu topic/thread.

Plugin-side changes in this PR:

- register a Feishu `SessionBindingAdapter`
- register Feishu subagent lifecycle hooks
- normalize inbound routing metadata for ACP thread spawn
- keep completion delivery targeted at the original Feishu topic

This PR is intended to pair with an OpenClaw core change that exposes stable session-binding APIs from `openclaw/plugin-sdk` and supports adapter-driven spawn conversation resolution.

## Why

Feishu already exposes thread/topic context and this plugin already carries `thread_id` / `root_id` in inbound handling, but ACP thread-bound sessions still fail at the OpenClaw policy layer without a binding adapter and matching routing metadata.

The target flow is:

- spawn an ACP persistent session from a Feishu topic
- bind that session to the current topic
- route follow-up messages in the same topic to the bound session
- send completion/end messages back to the original topic

## Changes

### 1. Register Feishu thread-binding support

Files:

- `index.ts`
- `src/channel/thread-bindings.ts`

Adds:

- Feishu session-binding adapter registration
- Feishu `subagent_spawning` hook
- Feishu `subagent_delivery_target` hook
- Feishu `subagent_ended` hook

The adapter uses Feishu-native conversation semantics:

- `conversationId = root_id ?? thread_id ?? chat_id`
- `parentConversationId = chat_id`

### 2. Align inbound metadata for ACP thread spawn

File:

- `src/messaging/inbound/dispatch-builders.ts`

Changes:

- group messages now set `OriginatingTo` to `channel:<chatId>`
- `MessageThreadId` prefers `rootId ?? threadId`

This matches current ACP spawn expectations more closely than the previous `chat:<chatId>` form.

### 3. Accept `channel:` in Feishu target parsing

File:

- `src/core/targets.ts`

Changes:

- `normalizeFeishuTarget()` now accepts `channel:`
- `looksLikeFeishuId()` now accepts `channel:`

This keeps outbound routing and completion delivery aligned with the updated inbound representation.

### 4. Add temporary type shim for public session-binding API

File:

- `src/types/openclaw-session-binding-public-shim.d.ts`

This keeps the plugin code typed against the intended `openclaw/plugin-sdk` public surface while the core API is being upstreamed.

## Verification

Static checks run for the changed plugin files:

- `npx eslint index.ts src/channel/thread-bindings.ts src/core/targets.ts src/messaging/inbound/dispatch-builders.ts`

Runtime validation was done against a locally patched OpenClaw instance with the corresponding core-side API shape:

- ACP thread-bound session spawn succeeded in Feishu
- follow-up messages in the same topic resolved to the same ACP session
- ending the session replied back in the same Feishu topic

## Notes for Review

This PR does not by itself provide the OpenClaw core runtime changes required for:

- stable public session-binding exports from `openclaw/plugin-sdk`
- adapter-driven `resolveConversationForSpawn(...)`

It should be reviewed as the Feishu plugin half of a stacked change.
