### PR TITLE
fix: skip reactions on other bots' messages in all mode for multi-agent groups

### DIFF
--- a/src/messaging/inbound/reaction-handler.ts
+++ b/src/messaging/inbound/reaction-handler.ts
@@ -114,13 +114,13 @@ export async function resolveReactionContext(params: {
     return null;
   }
 
-  // The mget API returns app_id (cli_xxx) as sender.id for bot messages,
-  // not the bot's open_id (ou_xxx). Match against the account's appId.
+  // mget API returns app_id (cli_xxx) as sender.id for bot messages.
   const isBotMessage = msg.senderType === 'app' && msg.senderId === account.appId;
-  if (reactionMode === 'own' && !isBotMessage) {
-    log(
-      `feishu[${accountId}]: reaction on non-bot message ${messageId}, skipping (senderId=${msg.senderId}, senderType=${msg.senderType}, botOpenId=${botOpenId}, appId=${account.appId})`,
-    );
+  const isOtherBotMessage = msg.senderType === 'app' && account.appId && msg.senderId !== account.appId;
+
+  // 'own': only react to this bot's messages; 'all': also skip other bots' messages.
+  if ((reactionMode === 'own' && !isBotMessage) || (reactionMode === 'all' && isOtherBotMessage)) {
+    log(`feishu[${accountId}]: reaction on ${isOtherBotMessage ? 'other bot' : 'non-bot'} message ${messageId}, skipping`);
     return null;
   }
 


### PR DESCRIPTION
## Problem

When `reactionNotifications` is set to `all` and multiple bots share the
same group, Feishu fans the reaction event out to every bot in the group.
This caused all agents to trigger when a user reacted to any single bot's
message — only the bot whose message was reacted to should respond.

## Root Cause

In `own` mode, the existing `!isBotMessage` check already rejects reactions
on other bots' messages. In `all` mode that check is skipped entirely, so
every bot in the group would process the reaction.

## Fix

Add an explicit guard for `all` mode: skip the reaction if the original
message was sent by a different bot (`msg.senderType === 'app' &&
msg.senderId !== account.appId`). The `account.appId` presence check
prevents false-rejecting when the account is not fully configured (where
`undefined !== 'cli_xxx'` would otherwise be `true`).

| mode  | human msg | this bot's msg | other bot's msg |
|-------|-----------|----------------|-----------------|
| `own` | skip (existing `!isBotMessage`) | process | skip (existing) |
| `all` | process   | process        | **skip (new)**  |
