### PR TITLE
fix: improve UAT token refresh logic and user name resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/openclaw-lark",
-  "version": "2026.3.16",
+  "version": "2026.3.17",
   "description": "OpenClaw Lark/Feishu channel plugin",
   "type": "module",
   "bin": {

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -14,7 +14,7 @@ import { getTicket } from '../core/lark-ticket';
 import { getLarkAccount } from '../core/accounts';
 import { LarkClient } from '../core/lark-client';
 import { getAppInfo, getAppGrantedScopes } from '../core/app-scope-checker';
-import { getStoredToken } from '../core/token-store';
+import { getStoredToken, tokenStatus } from '../core/token-store';
 import { filterSensitiveScopes } from '../core/tool-scopes';
 import { assertOwnerAccessStrict, OwnerAccessDeniedError } from '../core/owner-policy';
 import { openPlatformDomain } from '../core/domains';
@@ -167,7 +167,8 @@ async function executeFeishuAuth(config: OpenClawConfig): Promise<AuthResult> {
   }
 
   const existing = await getStoredToken(appId, senderOpenId);
-  const grantedScopes = new Set(existing?.scope?.split(/\s+/).filter(Boolean) ?? []);
+  const tokenValid = existing && tokenStatus(existing) !== 'expired';
+  const grantedScopes = new Set(tokenValid ? (existing.scope?.split(/\s+/).filter(Boolean) ?? []) : []);
   const missingScopes = appScopes.filter((s) => !grantedScopes.has(s));
 
   if (missingScopes.length === 0) {

--- a/src/core/auth-errors.ts
+++ b/src/core/auth-errors.ts
@@ -23,27 +23,26 @@ export const LARK_ERROR = {
   /** access_token 无效 */
   TOKEN_INVALID: 99991668,
   /** access_token 已过期 */
-  TOKEN_EXPIRED: 99991669,
-  /** refresh_token 无效 */
-  REFRESH_TOKEN_INVALID: 20003,
-  /** refresh_token 已过期 */
-  REFRESH_TOKEN_EXPIRED: 20004,
-  /** refresh_token 缺失 */
-  REFRESH_TOKEN_MISSING: 20024,
+  TOKEN_EXPIRED: 99991677,
+  /** refresh_token 本身无效（格式非法或来自 v1 API） */
+  REFRESH_TOKEN_INVALID: 20026,
+  /** refresh_token 已过期（超过 365 天） */
+  REFRESH_TOKEN_EXPIRED: 20037,
   /** refresh_token 已被吊销 */
-  REFRESH_TOKEN_REVOKED: 20063,
+  REFRESH_TOKEN_REVOKED: 20064,
+  /** refresh_token 已被使用（单次消费，rotation 场景） */
+  REFRESH_TOKEN_ALREADY_USED: 20073,
+  /** refresh token 端点服务端内部错误，可重试 */
+  REFRESH_SERVER_ERROR: 20050,
   /** 消息已被撤回 */
   MESSAGE_RECALLED: 230011,
   /** 消息已被删除 */
   MESSAGE_DELETED: 231003,
 } as const;
 
-/** 不可恢复的 refresh_token 错误码集合，遇到后需要重新授权。 */
-export const REFRESH_TOKEN_IRRECOVERABLE: ReadonlySet<number> = new Set([
-  LARK_ERROR.REFRESH_TOKEN_INVALID,
-  LARK_ERROR.REFRESH_TOKEN_EXPIRED,
-  LARK_ERROR.REFRESH_TOKEN_MISSING,
-  LARK_ERROR.REFRESH_TOKEN_REVOKED,
+/** refresh token 端点可重试的错误码集合（服务端瞬时故障）。遇到后重试一次，仍失败则清 token。 */
+export const REFRESH_TOKEN_RETRYABLE: ReadonlySet<number> = new Set([
+  LARK_ERROR.REFRESH_SERVER_ERROR,
 ]);
 
 /** 消息终止错误码集合（撤回/删除），遇到后应停止对该消息的后续操作。 */

--- a/src/core/tool-scopes.ts
+++ b/src/core/tool-scopes.ts
@@ -117,6 +117,7 @@ export type ToolActionKey =
   | 'feishu_drive_file.move'
   | 'feishu_drive_file.upload'
   | 'feishu_fetch_doc.default'
+  | 'feishu_get_user.basic_batch'
   | 'feishu_get_user.default'
   | 'feishu_im_user_fetch_resource.default'
   | 'feishu_im_user_get_messages.default'
@@ -296,6 +297,7 @@ export const TOOL_SCOPES: ToolScopeMapping = {
     'search:message',
   ],
   'feishu_search_doc_wiki.search': ['search:docs:read'],
+  'feishu_get_user.basic_batch': ['contact:user.basic_profile:readonly'],
   'feishu_get_user.default': ['contact:contact.base:readonly', 'contact:user.base:readonly'],
   'feishu_search_user.default': ['contact:user:search'],
   'feishu_create_doc.default': [
@@ -460,8 +462,8 @@ export function filterSensitiveScopes(scopes: string[]): string[] {
 // ===== 统计信息 =====
 
 /**
- * 工具动作总数: 98
- * 唯一 scope 总数: 66
+ * 工具动作总数: 99
+ * 唯一 scope 总数: 67
  * 必需应用权限总数: 20
  * 高敏感权限总数: 1
  */

--- a/src/core/uat-client.ts
+++ b/src/core/uat-client.ts
@@ -23,7 +23,7 @@ import { larkLogger } from './lark-logger';
 
 const log = larkLogger('core/uat-client');
 import { feishuFetch } from './feishu-fetch';
-import { REFRESH_TOKEN_IRRECOVERABLE, TOKEN_RETRY_CODES, NeedAuthorizationError } from './auth-errors';
+import { REFRESH_TOKEN_RETRYABLE, TOKEN_RETRY_CODES, NeedAuthorizationError } from './auth-errors';
 
 // Re-export for backward compatibility
 export { NeedAuthorizationError };
@@ -75,19 +75,23 @@ async function doRefreshToken(opts: UATCallOptions, stored: StoredUAToken): Prom
   }
 
   const endpoints = resolveOAuthEndpoints(opts.domain);
+  const requestBody = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: stored.refreshToken,
+    client_id: opts.appId,
+    client_secret: opts.appSecret,
+  }).toString();
 
-  const resp = await feishuFetch(endpoints.token, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      grant_type: 'refresh_token',
-      refresh_token: stored.refreshToken,
-      client_id: opts.appId,
-      client_secret: opts.appSecret,
-    }).toString(),
-  });
+  const callEndpoint = async () => {
+    const resp = await feishuFetch(endpoints.token, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: requestBody,
+    });
+    return (await resp.json()) as Record<string, unknown>;
+  };
 
-  const data = (await resp.json()) as Record<string, unknown>;
+  let data = await callEndpoint();
 
   // Feishu v2 token endpoint returns `code: 0` on success.
   // Some responses use `error` field instead (standard OAuth).
@@ -96,16 +100,25 @@ async function doRefreshToken(opts: UATCallOptions, stored: StoredUAToken): Prom
 
   if ((code !== undefined && code !== 0) || error) {
     const errCode = code ?? error;
-    const errMsg = (data.error_description as string) ?? (data.msg as string) ?? 'unknown';
 
-    // Known irrecoverable codes: invalid/expired/missing refresh_token
-    if (REFRESH_TOKEN_IRRECOVERABLE.has(code as number)) {
+    // Transient server error: retry once, then clear.
+    if (REFRESH_TOKEN_RETRYABLE.has(code as number)) {
+      log.warn(`refresh transient error (code=${errCode}) for ${opts.userOpenId}, retrying once`);
+      data = await callEndpoint();
+      const retryCode = data.code as number | undefined;
+      const retryError = data.error as string | undefined;
+      if ((retryCode !== undefined && retryCode !== 0) || retryError) {
+        const retryErrCode = retryCode ?? retryError;
+        log.warn(`refresh failed after retry (code=${retryErrCode}), clearing token for ${opts.userOpenId}`);
+        await removeStoredToken(opts.appId, opts.userOpenId);
+        return null;
+      }
+    } else {
+      // Any other error (invalid/expired/revoked token, or unknown): clear and force re-auth.
       log.warn(`refresh failed (code=${errCode}), clearing token for ${opts.userOpenId}`);
       await removeStoredToken(opts.appId, opts.userOpenId);
       return null;
     }
-
-    throw new Error(`Token refresh failed (code=${errCode}): ${errMsg}`);
   }
 
   if (!data.access_token) {

--- a/src/tools/oapi/im/message-read.ts
+++ b/src/tools/oapi/im/message-read.ts
@@ -212,7 +212,7 @@ function registerGetMessages(api: OpenClawPluginApi) {
           );
           assertLarkOk(res);
 
-          return formatAndReturn(res, config, log, client);
+          return await formatAndReturn(res, config, log, client);
         } catch (err) {
           return await handleInvokeErrorWithAutoAuth(err, config);
         }
@@ -292,7 +292,7 @@ function registerGetThreadMessages(api: OpenClawPluginApi) {
           );
           assertLarkOk(res);
 
-          return formatAndReturn(res, config, log, client);
+          return await formatAndReturn(res, config, log, client);
         } catch (err) {
           return await handleInvokeErrorWithAutoAuth(err, config);
         }

--- a/src/tools/oapi/im/user-name-uat.ts
+++ b/src/tools/oapi/im/user-name-uat.ts
@@ -10,6 +10,9 @@
  * 设计动机：TAT 调用 contact/v3/users/batch 缺少权限导致返回的用户
  * 条目不含 name 字段，而工具层搜索消息等场景运行在 UAT 上下文中，
  * 用户 token 可以读取其他用户的名称。
+ *
+ * 底层使用 contact/v3/users/basic_batch 接口（scope: contact:user.basic_profile:readonly），
+ * 每次最多查询 10 个用户。
  */
 
 import type { ToolClient } from '../../../core/tool-client';
@@ -76,7 +79,7 @@ export function setUATUserNames(accountId: string, entries: Map<string, string>)
 // 以 UAT 身份批量解析用户名
 // ---------------------------------------------------------------------------
 
-const BATCH_SIZE = 50;
+const BATCH_SIZE = 10; // basic_batch API 限制每次最多 10 个
 
 export async function batchResolveUserNamesAsUser(params: {
   client: ToolClient;
@@ -107,20 +110,24 @@ export async function batchResolveUserNamesAsUser(params: {
   const uniqueMissing = [...new Set(missing)];
   if (uniqueMissing.length === 0) return result;
 
-  // 2. 分批通过 SDK 调用 contact/v3/users/batch（UAT）
+  // 2. 分批通过 SDK 调用 contact/v3/users/basic_batch（UAT）
+  const totalBatches = Math.ceil(uniqueMissing.length / BATCH_SIZE);
+  log(`batchResolveUserNamesAsUser: resolving ${uniqueMissing.length} user(s) in ${totalBatches} batch(es), ${result.size} cache hit(s)`);
+
   for (let i = 0; i < uniqueMissing.length; i += BATCH_SIZE) {
     const chunk = uniqueMissing.slice(i, i + BATCH_SIZE);
+    const batchIndex = Math.floor(i / BATCH_SIZE) + 1;
     try {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const res: any = await client.invoke(
-        'feishu_get_user.default', // 注：实际调用 batch API，共享 get_user 的 scope
+        'feishu_get_user.basic_batch',
         (sdk, opts) =>
-          sdk.contact.user.batch(
+          (sdk as any).request(
             {
-              params: {
-                user_ids: chunk,
-                user_id_type: 'open_id',
-              },
+              method: 'POST',
+              url: '/open-apis/contact/v3/users/basic_batch',
+              data: { user_ids: chunk },
+              params: { user_id_type: 'open_id' },
             },
             opts,
           ),
@@ -130,15 +137,24 @@ export async function batchResolveUserNamesAsUser(params: {
       );
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const items: any[] = res?.data?.items ?? [];
-      for (const item of items) {
-        const openId: string | undefined = item.open_id;
-        const name: string | undefined = item.name || item.display_name || item.nickname || item.en_name;
+      const users: any[] = res?.data?.users ?? [];
+      let resolved = 0;
+      for (const user of users) {
+        const openId: string | undefined = user.user_id;
+        // 实际返回 name 为字符串，兼容文档中 name.value 的对象结构
+        const rawName = user.name;
+        const name: string | undefined =
+          typeof rawName === 'string' ? rawName : rawName?.value;
         if (openId && name) {
           cache.delete(openId);
           cache.set(openId, { name, expireAt: Date.now() + UAT_TTL_MS });
           result.set(openId, name);
+          resolved++;
         }
+      }
+      const unresolvedCount = chunk.length - resolved;
+      if (unresolvedCount > 0) {
+        log(`batchResolveUserNamesAsUser: batch ${batchIndex}/${totalBatches}: ${resolved} resolved, ${unresolvedCount} missing name`);
       }
     } catch (err) {
       // 授权/权限错误向上冒泡，由上层 handleInvokeErrorWithAutoAuth 处理自动授权

--- a/src/tools/oauth.ts
+++ b/src/tools/oauth.ts
@@ -50,16 +50,15 @@ const FeishuOAuthSchema = Type.Object(
         Type.Literal('revoke'),
       ],
       {
-        description: 'revoke: 撤销当前用户的授权',
+        description: 'revoke: 撤销当前用户已保存的授权凭据',
       },
     ),
   },
   {
     description:
-      '飞书用户授权管理工具。' +
-      '【注意】授权流程由系统自动发起，不要主动调用此工具触发授权！' +
-      '此工具仅用于撤销授权（revoke）。' +
-      '不需要传入 user_open_id，系统自动识别当前用户。',
+      '飞书用户撤销授权工具。' +
+      '仅在用户明确说"撤销授权"、"取消授权"、"退出登录"、"清除授权"时调用。' +
+      '【严禁调用场景】用户说"重新授权"、"发起授权"、"重新发起"、"授权失败"、"授权过期"时，绝对不要调用此工具，授权流程由系统自动处理。',
   },
 );
 
@@ -145,11 +144,10 @@ export function registerFeishuOAuthTool(api: OpenClawPluginApi) {
       name: 'feishu_oauth',
       label: 'Feishu OAuth',
       description:
-        '飞书用户授权（OAuth）管理工具。' +
-        '【注意】授权流程由系统自动发起，不要主动调用此工具触发授权！' +
-        '此工具仅用于 revoke（撤销当前用户的授权）。' +
-        '不需要传入 user_open_id，系统自动从消息上下文获取当前用户。' +
-        '【Token 过期处理】当返回 token_expired 错误时，调用 revoke 撤销后，系统会自动重新发起授权流程。',
+        '飞书用户撤销授权工具。' +
+        '仅在用户明确说"撤销授权"、"取消授权"、"退出登录"、"清除授权"时调用 revoke。' +
+        '【严禁调用场景】用户说"重新授权"、"发起授权"、"重新发起"、"授权失败"、"授权过期"时，绝对不要调用此工具，授权流程由系统自动处理，无需人工干预。' +
+        '不需要传入 user_open_id，系统自动从消息上下文获取当前用户。',
       parameters: FeishuOAuthSchema,
 
       async execute(_toolCallId: string, params: unknown) {


### PR DESCRIPTION
- Fix token refresh: replace irrecoverable set with retryable set, retry on transient server errors and clear on all other failures
- Fix auth.ts: skip expired token's granted scopes to avoid skipping re-auth
- Update auth error codes to match latest Feishu v2 API (TOKEN_EXPIRED, REFRESH_TOKEN_*)
- Switch user name batch resolution from contact/v3/users/batch to contact/v3/users/basic_batch (scope: contact:user.basic_profile:readonly, limit 10/batch)
- Add feishu_get_user.basic_batch tool action key and scope mapping
- Fix message-read.ts: await formatAndReturn calls
- Refine feishu_oauth tool description to prevent LLM from calling revoke on re-auth scenarios

Change-Id: Ic89ab220a459e6ef0b3f984070f14b8c46e569f9