### PR TITLE
feat: add structured reasoning display with trace-first architecture

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -26,6 +26,7 @@ import {
 import { registerCommands } from './src/commands/index';
 import { larkLogger } from './src/core/lark-logger';
 import { emitSecurityWarnings } from './src/core/security-check';
+import { recordReasoningToolEnd, recordReasoningToolStart } from './src/card/reasoning-trace-store';
 
 const log = larkLogger('plugin');
 
@@ -123,15 +124,29 @@ const plugin = {
 
     // ---- Tool call hooks (auto-trace AI tool invocations) ----
 
-    api.on('before_tool_call', (event) => {
-      log.info(`tool call: ${event.toolName} params=${JSON.stringify(event.params)}`);
+    api.on('before_tool_call', (event, ctx) => {
+      recordReasoningToolStart({
+        sessionKey: ctx.sessionKey,
+        toolName: event.toolName,
+        toolParams: event.params,
+      });
+      const paramsPreview = JSON.stringify(event.params)?.slice(0, 200) ?? '';
+      log.info(`tool call: ${event.toolName} session=${ctx.sessionKey ?? '-'} params=${paramsPreview}`);
     });
 
-    api.on('after_tool_call', (event) => {
+    api.on('after_tool_call', (event, ctx) => {
+      recordReasoningToolEnd({
+        sessionKey: ctx.sessionKey,
+        toolName: event.toolName,
+        toolParams: event.params,
+        result: event.result,
+        error: event.error,
+        durationMs: event.durationMs,
+      });
       if (event.error) {
-        log.error(`tool fail: ${event.toolName} ${event.error} (${event.durationMs ?? 0}ms)`);
+        log.error(`tool fail: ${event.toolName} session=${ctx.sessionKey ?? '-'} ${event.error} (${event.durationMs ?? 0}ms)`);
       } else {
-        log.info(`tool done: ${event.toolName} ok (${event.durationMs ?? 0}ms)`);
+        log.info(`tool done: ${event.toolName} session=${ctx.sessionKey ?? '-'} ok (${event.durationMs ?? 0}ms)`);
       }
     });
 

--- a/src/card/builder.ts
+++ b/src/card/builder.ts
@@ -9,6 +9,7 @@
  */
 
 import { optimizeMarkdownStyle } from './markdown-style';
+import { EMPTY_REASONING_PLACEHOLDER, type ReasoningDisplayStep } from './reasoning-display';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -20,7 +21,6 @@ import { optimizeMarkdownStyle } from './markdown-style';
  * streaming updates.
  */
 export const STREAMING_ELEMENT_ID = 'streaming_content';
-export const REASONING_ELEMENT_ID = 'reasoning_content';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -206,7 +206,10 @@ export function buildCardContent(
   data: {
     text?: string;
     reasoningText?: string;
+    reasoningSteps?: ReasoningDisplayStep[];
+    reasoningTitleSuffix?: { zh: string; en: string };
     reasoningElapsedMs?: number;
+    showReasoning?: boolean;
     toolCalls?: ToolCallInfo[];
     confirmData?: ConfirmData;
     elapsedMs?: number;
@@ -219,15 +222,16 @@ export function buildCardContent(
     case 'thinking':
       return buildThinkingCard();
     case 'streaming':
-      return buildStreamingCard(data.text ?? '', data.toolCalls ?? [], data.reasoningText);
+      return buildStreamingCard(data.text ?? '', data.showReasoning);
     case 'complete':
       return buildCompleteCard({
         text: data.text ?? '',
-        toolCalls: data.toolCalls ?? [],
         elapsedMs: data.elapsedMs,
         isError: data.isError,
-        reasoningText: data.reasoningText,
+        reasoningSteps: data.reasoningSteps,
+        reasoningTitleSuffix: data.reasoningTitleSuffix,
         reasoningElapsedMs: data.reasoningElapsedMs,
+        showReasoning: data.showReasoning,
         isAborted: data.isAborted,
         footer: data.footer,
       });
@@ -255,38 +259,34 @@ function buildThinkingCard(): FeishuCard {
   };
 }
 
-function buildStreamingCard(partialText: string, toolCalls: ToolCallInfo[], reasoningText?: string): FeishuCard {
+function buildStreamingCard(
+  partialText: string,
+  showReasoning = true,
+): FeishuCard {
   const elements: CardElement[] = [];
 
-  if (!partialText && reasoningText) {
-    // Reasoning phase: show reasoning content in notation style
-    elements.push({
-      tag: 'markdown',
-      content: `💭 **Thinking...**\n\n${reasoningText}`,
-      i18n_content: {
-        zh_cn: `💭 **思考中...**\n\n${reasoningText}`,
-        en_us: `💭 **Thinking...**\n\n${reasoningText}`,
-      },
-      text_size: 'notation',
-    });
-  } else if (partialText) {
-    // Answer phase: show answer content only
+  if (showReasoning) {
+    elements.push(buildStreamingReasoningPendingPanel());
+  }
+
+  if (partialText) {
     elements.push({
       tag: 'markdown',
       content: optimizeMarkdownStyle(partialText),
     });
-  }
-
-  // Tool calls in progress
-  if (toolCalls.length > 0) {
-    const toolLines = toolCalls.map((tc) => {
-      const statusIcon = tc.status === 'running' ? '\ud83d\udd04' : tc.status === 'complete' ? '\u2705' : '\u274c';
-      return `${statusIcon} ${tc.name} - ${tc.status}`;
-    });
+  } else if (!showReasoning) {
     elements.push({
       tag: 'markdown',
-      content: toolLines.join('\n'),
-      text_size: 'notation',
+      content: 'Thinking...',
+      i18n_content: {
+        zh_cn: '思考中...',
+        en_us: 'Thinking...',
+      },
+    });
+  } else {
+    elements.push({
+      tag: 'markdown',
+      content: '...',
     });
   }
 
@@ -298,54 +298,37 @@ function buildStreamingCard(partialText: string, toolCalls: ToolCallInfo[], reas
 
 function buildCompleteCard(params: {
   text: string;
-  toolCalls: ToolCallInfo[];
   elapsedMs?: number;
   isError?: boolean;
-  reasoningText?: string;
+  reasoningSteps?: ReasoningDisplayStep[];
+  reasoningTitleSuffix?: { zh: string; en: string };
   reasoningElapsedMs?: number;
+  showReasoning?: boolean;
   isAborted?: boolean;
   footer?: { status?: boolean; elapsed?: boolean };
 }): FeishuCard {
-  const { text, toolCalls, elapsedMs, isError, reasoningText, reasoningElapsedMs, isAborted, footer } = params;
+  const {
+    text,
+    elapsedMs,
+    isError,
+    reasoningSteps,
+    reasoningTitleSuffix,
+    reasoningElapsedMs,
+    showReasoning = true,
+    isAborted,
+    footer,
+  } = params;
   const elements: CardElement[] = [];
 
   // Collapsible reasoning panel (before main content)
-  if (reasoningText) {
-    const dur = reasoningElapsedMs ? formatReasoningDuration(reasoningElapsedMs) : null;
-    const zhLabel = dur ? dur.zh : '思考';
-    const enLabel = dur ? dur.en : 'Thought';
-    elements.push({
-      tag: 'collapsible_panel',
-      expanded: false,
-      header: {
-        title: {
-          tag: 'markdown',
-          content: `💭 ${enLabel}`,
-          i18n_content: {
-            zh_cn: `💭 ${zhLabel}`,
-            en_us: `💭 ${enLabel}`,
-          },
-        },
-        vertical_align: 'center',
-        icon: {
-          tag: 'standard_icon',
-          token: 'down-small-ccm_outlined',
-          size: '16px 16px',
-        },
-        icon_position: 'follow_text',
-        icon_expanded_angle: -180,
-      },
-      border: { color: 'grey', corner_radius: '5px' },
-      vertical_spacing: '8px',
-      padding: '8px 8px 8px 8px',
-      elements: [
-        {
-          tag: 'markdown',
-          content: reasoningText,
-          text_size: 'notation',
-        },
-      ],
-    });
+  if (showReasoning) {
+    elements.push(
+      buildReasoningPanel({
+        reasoningSteps,
+        reasoningElapsedMs,
+        titleSuffix: reasoningTitleSuffix,
+      }),
+    );
   }
 
   // Full text content
@@ -353,20 +336,6 @@ function buildCompleteCard(params: {
     tag: 'markdown',
     content: optimizeMarkdownStyle(text),
   });
-
-  // Tool calls summary
-  if (toolCalls.length > 0) {
-    const toolSummaryLines = toolCalls.map((tc) => {
-      const statusIcon = tc.status === 'complete' ? '\u2705' : '\u274c';
-      return `${statusIcon} **${tc.name}** - ${tc.status}`;
-    });
-
-    elements.push({
-      tag: 'markdown',
-      content: toolSummaryLines.join('\n'),
-      text_size: 'notation',
-    });
-  }
 
   // Footer meta-info: each metadata item is independently controlled via
   // the `footer` config. Both status and elapsed default to hidden.
@@ -494,6 +463,47 @@ function buildConfirmCard(confirmData: ConfirmData): FeishuCard {
  * Convert an old-format FeishuCard to CardKit JSON 2.0 format.
  * JSON 2.0 uses `body.elements` instead of top-level `elements`.
  */
+/**
+ * Build the initial CardKit 2.0 streaming card with a loading icon.
+ * Optionally includes a reasoning pending panel above the streaming area.
+ */
+export function buildStreamingThinkingCard(showReasoning = true): Record<string, unknown> {
+  return {
+    schema: '2.0',
+    config: {
+      streaming_mode: true,
+      locales: ['zh_cn', 'en_us'],
+      summary: {
+        content: 'Thinking...',
+        i18n_content: { zh_cn: '思考中...', en_us: 'Thinking...' },
+      },
+    },
+    body: {
+      elements: [
+        ...(showReasoning ? [buildStreamingReasoningPendingPanel()] : []),
+        {
+          tag: 'markdown',
+          content: '',
+          text_align: 'left',
+          text_size: 'normal_v2',
+          margin: '0px 0px 0px 0px',
+          element_id: STREAMING_ELEMENT_ID,
+        },
+        {
+          tag: 'markdown',
+          content: ' ',
+          icon: {
+            tag: 'custom_icon',
+            img_key: 'img_v3_02vb_496bec09-4b43-4773-ad6b-0cdd103cd2bg',
+            size: '16px 16px',
+          },
+          element_id: 'loading_icon',
+        },
+      ],
+    },
+  };
+}
+
 export function toCardKit2(card: FeishuCard): Record<string, unknown> {
   const result: Record<string, unknown> = {
     schema: '2.0',
@@ -502,4 +512,120 @@ export function toCardKit2(card: FeishuCard): Record<string, unknown> {
   };
   if (card.header) result.header = card.header;
   return result;
+}
+
+function buildStreamingReasoningPendingPanel(): CardElement {
+  return {
+    tag: 'collapsible_panel',
+    expanded: false,
+    header: {
+      title: {
+        tag: 'plain_text',
+        content: '💭 Thinking...',
+        i18n_content: {
+          zh_cn: '💭 思考中...',
+          en_us: '💭 Thinking...',
+        },
+        text_color: 'grey',
+        text_size: 'notation',
+      },
+      vertical_align: 'center',
+      icon: {
+        tag: 'standard_icon',
+        token: 'down-small-ccm_outlined',
+        color: 'grey',
+        size: '16px 16px',
+      },
+      icon_position: 'right',
+      icon_expanded_angle: -180,
+    },
+    border: { color: 'grey', corner_radius: '5px' },
+    vertical_spacing: '8px',
+    padding: '8px 8px 8px 8px',
+    elements: [],
+  };
+}
+
+function buildReasoningPanel(params: {
+  reasoningSteps?: ReasoningDisplayStep[];
+  reasoningElapsedMs?: number;
+  titleSuffix?: { zh: string; en: string };
+}): CardElement {
+  const { reasoningSteps = [], reasoningElapsedMs, titleSuffix } = params;
+  const duration = reasoningElapsedMs ? formatReasoningDuration(reasoningElapsedMs) : null;
+  const zhTitleParts = [duration?.zh ?? '思考过程'];
+  const enTitleParts = [duration?.en ?? 'Thought process'];
+  if (titleSuffix) {
+    zhTitleParts.push(titleSuffix.zh);
+    enTitleParts.push(titleSuffix.en);
+  }
+
+  const stepElements = reasoningSteps.length > 0
+    ? reasoningSteps.map((step) => buildReasoningStepElement(step))
+    : [buildReasoningPlaceholder()];
+
+  return {
+    tag: 'collapsible_panel',
+    expanded: false,
+    header: {
+      title: {
+        tag: 'plain_text',
+        content: `💭 ${enTitleParts.join(' · ')}`,
+        i18n_content: {
+          zh_cn: `💭 ${zhTitleParts.join(' · ')}`,
+          en_us: `💭 ${enTitleParts.join(' · ')}`,
+        },
+        text_color: 'grey',
+        text_size: 'notation',
+      },
+      vertical_align: 'center',
+      icon: {
+        tag: 'standard_icon',
+        token: 'down-small-ccm_outlined',
+        color: 'grey',
+        size: '16px 16px',
+      },
+      icon_position: 'right',
+      icon_expanded_angle: -180,
+    },
+    border: { color: 'grey', corner_radius: '5px' },
+    vertical_spacing: '8px',
+    padding: '8px 8px 8px 8px',
+    elements: stepElements,
+  };
+}
+
+function buildReasoningStepElement(step: ReasoningDisplayStep): CardElement {
+  return {
+    tag: 'div',
+    icon: {
+      tag: 'standard_icon',
+      token: step.iconToken,
+      color: 'grey',
+    },
+    text: {
+      tag: 'plain_text',
+      content: step.detail ? `${step.title}\n${step.detail}` : step.title,
+      text_color: 'grey',
+      text_size: 'notation',
+    },
+  };
+}
+
+function buildReasoningPlaceholder(labels?: { zh: string; en: string }): CardElement {
+  const zh = labels?.zh ?? '暂无可展示的思考内容';
+  const en = labels?.en ?? EMPTY_REASONING_PLACEHOLDER;
+  return {
+    tag: 'div',
+    text: {
+      tag: 'plain_text',
+      content: en,
+      i18n_content: {
+        zh_cn: zh,
+        en_us: en,
+      },
+      text_color: 'grey',
+      text_size: 'notation',
+    },
+  };
 }

--- a/src/card/reasoning-display.ts
+++ b/src/card/reasoning-display.ts
@@ -1,0 +1,550 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Structured reasoning step display for Lark/Feishu cards.
+ *
+ * This module is intentionally trace-first: it prefers structured tool traces
+ * from plugin hooks and only falls back to the reply callback summaries when
+ * richer data is unavailable.
+ */
+
+import type { ReasoningTraceStep } from './reasoning-trace-store';
+import { normalizeToolName, truncateText } from './reasoning-utils';
+
+export interface ReasoningDisplayStep {
+  title: string;
+  detail?: string;
+  iconToken: string;
+}
+
+export interface ReasoningDisplayResult {
+  content: string;
+  stepCount: number;
+  steps: ReasoningDisplayStep[];
+}
+
+export const EMPTY_REASONING_PLACEHOLDER = 'No reasoning text available';
+
+export interface ReasoningToolEvent {
+  kind: 'start' | 'summary';
+  name?: string;
+  phase?: string;
+  text?: string;
+}
+
+type SanitizerKind = 'skill' | 'path' | 'search' | 'url' | 'command' | 'generic';
+type SummarySource = 'matched' | 'code' | 'quoted' | 'url' | 'line';
+
+interface ToolDescriptor {
+  aliases: string[];
+  iconToken: string;
+  title: string;
+  sanitizer: SanitizerKind;
+  paramKeys?: string[];
+  summaryPatterns?: RegExp[];
+  summaryPreference?: SummarySource[];
+  detailFromParams?: (params: Record<string, unknown>) => string | undefined;
+}
+
+interface ToolStepSource {
+  toolName?: string;
+  params?: Record<string, unknown>;
+  summaryText?: string;
+  result?: unknown;
+  error?: string;
+  durationMs?: number;
+}
+
+interface SummarySignals {
+  line: string;
+  matched?: string;
+  code?: string;
+  quoted?: string;
+  url?: string;
+}
+
+const DEFAULT_SUMMARY_PREFERENCE: SummarySource[] = ['matched', 'code', 'quoted', 'url', 'line'];
+
+const TOOL_DESCRIPTORS: ToolDescriptor[] = [
+  {
+    aliases: ['skill'],
+    iconToken: 'app-default_outlined',
+    title: 'Load skill',
+    sanitizer: 'skill',
+    paramKeys: ['skill', 'name'],
+    summaryPatterns: [/^(?:load|use)\s+skill\s+(.+)$/i],
+  },
+  {
+    aliases: ['read', 'open'],
+    iconToken: 'file-link-text_outlined',
+    title: 'Read',
+    sanitizer: 'path',
+    paramKeys: ['file_path', 'path', 'file'],
+    summaryPatterns: [/^(?:read|open)\s+(?:file\s+)?(.+)$/i],
+    summaryPreference: ['code', 'quoted', 'matched', 'line'],
+  },
+  {
+    aliases: ['write', 'edit'],
+    iconToken: 'edit_outlined',
+    title: 'Edit',
+    sanitizer: 'path',
+    paramKeys: ['file_path', 'path', 'file'],
+    summaryPatterns: [/^(?:edit|write)\s+(?:file\s+)?(.+)$/i],
+    summaryPreference: ['code', 'quoted', 'matched', 'line'],
+  },
+  {
+    aliases: ['web_search', 'web-search', 'search'],
+    iconToken: 'search_outlined',
+    title: 'Search web',
+    sanitizer: 'search',
+    paramKeys: ['query', 'q'],
+    summaryPatterns: [/^(?:search\s+(?:web\s+)?(?:for|about)|query)\s+(.+)$/i],
+    summaryPreference: ['quoted', 'matched', 'line'],
+  },
+  {
+    aliases: ['web_fetch', 'web-fetch', 'fetch'],
+    iconToken: 'language_outlined',
+    title: 'Fetch web page',
+    sanitizer: 'url',
+    paramKeys: ['url'],
+    summaryPatterns: [/^(?:fetch|open)\s+(?:web\s+page\s+)?(?:from\s+)?(.+)$/i],
+    summaryPreference: ['url', 'matched', 'quoted', 'line'],
+  },
+  {
+    aliases: ['grep'],
+    iconToken: 'doc-search_outlined',
+    title: 'Search text',
+    sanitizer: 'generic',
+    detailFromParams: (params) => buildPatternDetail(params, { includeTarget: true }),
+    summaryPatterns: [/^(?:search\s+text(?:\s+by\s+pattern)?|grep)\s+(.+)$/i],
+  },
+  {
+    aliases: ['glob'],
+    iconToken: 'folder_outlined',
+    title: 'Search files',
+    sanitizer: 'generic',
+    paramKeys: ['pattern'],
+    summaryPatterns: [/^(?:search\s+files(?:\s+by\s+pattern)?|glob)\s+(.+)$/i],
+  },
+  {
+    aliases: ['exec', 'bash', 'command', 'run'],
+    iconToken: 'setting_outlined',
+    title: 'Run command',
+    sanitizer: 'command',
+    paramKeys: ['description', 'command', 'script'],
+    summaryPatterns: [/^(?:run|execute)\s+(?:command|script)?\s*(.+)$/i],
+    summaryPreference: ['code', 'quoted', 'matched', 'line'],
+  },
+  {
+    aliases: ['browser', 'playwright', 'navigate'],
+    iconToken: 'browser-mac_outlined',
+    title: 'Browser',
+    sanitizer: 'url',
+    paramKeys: ['url'],
+    summaryPatterns: [/^(?:open|browse|visit|navigate\s+to)\s+(.+)$/i],
+    summaryPreference: ['url', 'quoted', 'matched', 'line'],
+  },
+  {
+    aliases: ['agent', 'task', 'spawn'],
+    iconToken: 'robot_outlined',
+    title: 'Run sub-agent',
+    sanitizer: 'generic',
+    paramKeys: ['task', 'description', 'prompt'],
+    summaryPatterns: [/^(?:run\s+sub-?agent|spawn\s+agent)\s+(.+)$/i],
+  },
+  {
+    aliases: ['check', 'determine', 'verify'],
+    iconToken: 'list-check_outlined',
+    title: 'Check',
+    sanitizer: 'generic',
+    paramKeys: ['target', 'subject', 'description'],
+  },
+  {
+    aliases: ['summarize', 'analyze', 'prepare'],
+    iconToken: 'report_outlined',
+    title: 'Analyze',
+    sanitizer: 'generic',
+    paramKeys: ['target', 'subject', 'description'],
+  },
+];
+
+export function normalizeReasoningDisplay(params: {
+  traceSteps?: ReasoningTraceStep[];
+  toolEvents?: ReasoningToolEvent[];
+  showFullPaths?: boolean;
+}): ReasoningDisplayResult {
+  const traceSteps = params.traceSteps ?? [];
+  const toolEvents = params.toolEvents ?? [];
+  const showFullPaths = params.showFullPaths === true;
+  const sources = traceSteps.length > 0 ? traceSteps.map(toTraceSource) : buildToolStepSources(toolEvents);
+  const steps = sources
+    .map((source) => formatToolStep(source, { showFullPaths }))
+    .filter((step): step is ReasoningDisplayStep => !!step);
+
+  return {
+    content: steps
+      .map((step) => (step.detail ? `- ${step.title}: ${step.detail}` : `- ${step.title}`))
+      .join('\n'),
+    stepCount: steps.length,
+    steps,
+  };
+}
+
+export function buildReasoningTitleSuffix(params: { stepCount: number }): { zh: string; en: string } {
+  const { stepCount } = params;
+  return {
+    zh: `查看 ${stepCount} 个步骤`,
+    en: `Show ${stepCount} step${stepCount === 1 ? '' : 's'}`,
+  };
+}
+
+function toTraceSource(step: ReasoningTraceStep): ToolStepSource {
+  return {
+    toolName: step.toolName,
+    params: step.params,
+    result: step.result,
+    error: step.error,
+    durationMs: step.durationMs,
+  };
+}
+
+function buildToolStepSources(toolEvents: ReasoningToolEvent[]): ToolStepSource[] {
+  const steps: ToolStepSource[] = [];
+  const pendingIndexes: number[] = [];
+
+  for (const event of toolEvents) {
+    if (event.kind === 'start') {
+      if (event.phase && event.phase !== 'start') continue;
+      const toolName = event.name?.trim();
+      if (!toolName) continue;
+      steps.push({ toolName });
+      pendingIndexes.push(steps.length - 1);
+      continue;
+    }
+
+    if (event.kind !== 'summary') continue;
+    const summaryText = event.text?.trim();
+    if (!summaryText) continue;
+
+    // Try to match summary to a pending start by tool name (handles concurrent tools)
+    const matchedPendingPos = event.name
+      ? pendingIndexes.findIndex((idx) => {
+          const step = steps[idx];
+          return step && normalizeToolName(step.toolName) === normalizeToolName(event.name);
+        })
+      : -1;
+
+    if (matchedPendingPos >= 0) {
+      const pendingIndex = pendingIndexes[matchedPendingPos];
+      pendingIndexes.splice(matchedPendingPos, 1);
+      if (pendingIndex != null && steps[pendingIndex]) {
+        steps[pendingIndex].summaryText = summaryText;
+        continue;
+      }
+    }
+
+    // Fallback: match first pending (FIFO) when no name available
+    const pendingIndex = pendingIndexes.shift();
+    if (pendingIndex != null && steps[pendingIndex]) {
+      steps[pendingIndex].summaryText = summaryText;
+      continue;
+    }
+
+    steps.push({ summaryText });
+  }
+
+  return steps;
+}
+
+function formatToolStep(source: ToolStepSource, options: { showFullPaths: boolean }): ReasoningDisplayStep | undefined {
+  const descriptor = resolveToolDescriptor(source.toolName);
+  const rawDetail =
+    (descriptor ? extractDetailFromParams(source.params, descriptor) : undefined) ??
+    (descriptor ? extractDetailFromSummary(source.summaryText, descriptor) : cleanupLine(source.summaryText ?? '')) ??
+    (source.result != null ? cleanupLine(asDisplayText(source.result)) : undefined);
+  const detail = rawDetail
+    ? sanitizeToolDetail(descriptor?.sanitizer ?? 'generic', rawDetail, options)
+    : undefined;
+  const title = buildToolTitle(source, descriptor, rawDetail);
+  const meta = buildStepMeta(source);
+
+  return {
+    title,
+    detail: joinDetailParts(detail, meta),
+    iconToken: descriptor?.iconToken ?? 'setting-inter_outlined',
+  };
+}
+
+function buildToolTitle(
+  source: ToolStepSource,
+  descriptor: ToolDescriptor | undefined,
+  rawDetail?: string,
+): string {
+  const baseTitle =
+    descriptor?.title === 'Read' && rawDetail && isSkillPathValue(rawDetail)
+      ? 'Skill Read'
+      : descriptor?.title ?? humanizeToolName(source.toolName ?? 'tool');
+  const durationLabel = source.durationMs != null ? formatDurationLabel(source.durationMs) : undefined;
+  return durationLabel ? `${baseTitle} (${durationLabel})` : baseTitle;
+}
+
+function resolveToolDescriptor(toolName?: string): ToolDescriptor | undefined {
+  const normalizedName = normalizeToolName(toolName);
+  return TOOL_DESCRIPTORS.find((descriptor) =>
+    descriptor.aliases.some(
+      (alias) =>
+        normalizedName === alias ||
+        normalizedName.startsWith(`${alias}_`) ||
+        normalizedName.startsWith(`${alias}-`),
+    ),
+  );
+}
+
+function extractDetailFromParams(params: Record<string, unknown> | undefined, descriptor: ToolDescriptor): string | undefined {
+  if (!params) return undefined;
+  if (descriptor.detailFromParams) return descriptor.detailFromParams(params);
+
+  for (const key of descriptor.paramKeys ?? []) {
+    const value = params[key];
+    const text = extractScalarText(value);
+    if (text) return text;
+  }
+
+  return undefined;
+}
+
+function extractDetailFromSummary(summaryText: string | undefined, descriptor: ToolDescriptor): string | undefined {
+  if (!summaryText) return undefined;
+
+  const lines = summaryText
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .map((line) => cleanupLine(stripMarkdown(line)))
+    .filter((line) => line && !isNoiseLine(line));
+
+  for (const line of lines) {
+    const signals = buildSummarySignals(line, descriptor.summaryPatterns ?? []);
+    const detail = pickSummaryDetail(signals, descriptor.summaryPreference ?? DEFAULT_SUMMARY_PREFERENCE);
+    if (detail) return detail;
+  }
+
+  return undefined;
+}
+
+function buildSummarySignals(line: string, patterns: RegExp[]): SummarySignals {
+  const matched = patterns
+    .map((pattern) => line.match(pattern)?.[1]?.trim())
+    .find((value): value is string => Boolean(value));
+
+  return {
+    line,
+    matched,
+    code: extractFirstCodeSpan(line),
+    quoted: extractFirstQuotedText(line),
+    url: extractFirstUrl(line),
+  };
+}
+
+function pickSummaryDetail(signals: SummarySignals, preference: SummarySource[]): string | undefined {
+  for (const key of preference) {
+    const value = signals[key];
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function buildStepMeta(source: ToolStepSource): string | undefined {
+  const parts: string[] = [];
+  if (source.error) {
+    parts.push(`Failed: ${truncateText(source.error, 96)}`);
+  }
+  return parts.length > 0 ? parts.join(' · ') : undefined;
+}
+
+function joinDetailParts(detail?: string, meta?: string): string | undefined {
+  if (detail && meta) return `${detail} · ${meta}`;
+  return detail ?? meta;
+}
+
+function buildPatternDetail(
+  params: Record<string, unknown>,
+  options: { includeTarget: boolean },
+): string | undefined {
+  const pattern = extractScalarText(params.pattern);
+  const target = extractScalarText(params.glob ?? params.path ?? params.file_path);
+  if (pattern && target && options.includeTarget) {
+    return `${pattern} in ${target}`;
+  }
+  return pattern ?? target ?? undefined;
+}
+
+function extractScalarText(value: unknown): string | undefined {
+  if (typeof value === 'string') return value.trim() || undefined;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return undefined;
+}
+
+function sanitizeToolDetail(
+  kind: SanitizerKind,
+  value: string,
+  options: { showFullPaths: boolean },
+): string | undefined {
+  const cleaned = sanitizeGenericText(value);
+  if (!cleaned) return undefined;
+
+  switch (kind) {
+    case 'skill':
+      return truncateText(cleaned.replace(/^skill\s+/i, '').replace(/[-_]+/g, ' ').trim() || 'skill', 40);
+    case 'path':
+      return sanitizePathLike(cleaned, options);
+    case 'search':
+      return truncateText(stripQuotes(cleaned), 72);
+    case 'url':
+      return truncateText(stripQuotes(cleaned).replace(/^from\s+/i, ''), 72);
+    case 'command':
+      return sanitizeCommandLike(cleaned, options);
+    case 'generic':
+    default:
+      return truncateText(cleaned, 84);
+  }
+}
+
+function sanitizePathLike(value: string, options: { showFullPaths: boolean }): string {
+  const cleaned = sanitizeGenericText(value).replace(/^(?:from|file|path)\s+/i, '').trim();
+  if (options.showFullPaths) return truncateText(cleaned, 160);
+
+  const skillMatch = cleaned.match(/(?:^|\/)skills\/([^/]+)\//i);
+  if (skillMatch?.[1]) {
+    return truncateText(skillMatch[1].replace(/[-_]+/g, ' ').trim(), 40);
+  }
+
+  const segments = cleaned.split(/[\\/]/).filter(Boolean);
+  return truncateText(segments.at(-1) ?? cleaned, 48);
+}
+
+function sanitizeCommandLike(value: string, options: { showFullPaths: boolean }): string {
+  const cleaned = stripQuotes(value)
+    .replace(/^(?:command|script|description)\s+/i, '')
+    .replace(/^.*?\s+->\s+/i, '')
+    .trim();
+  if (!cleaned) return 'command';
+  const visible = options.showFullPaths ? cleaned : redactCommandPaths(cleaned);
+  return truncateText(visible, options.showFullPaths ? 180 : 120);
+}
+
+function redactCommandPaths(command: string): string {
+  return command
+    .split(/(\s+)/)
+    .map((segment) => {
+      if (!segment || /^\s+$/.test(segment)) return segment;
+      return redactCommandToken(segment);
+    })
+    .join('');
+}
+
+function redactCommandToken(token: string): string {
+  const match = token.match(/^([("'`]*)(.*?)([)"'`,;:]*)$/);
+  if (!match) return token;
+
+  const [, prefix, rawCore, suffix] = match;
+  const core = redactPathAssignment(rawCore);
+  return `${prefix}${core}${suffix}`;
+}
+
+function redactPathAssignment(value: string): string {
+  const equalsIndex = value.indexOf('=');
+  if (equalsIndex > 0) {
+    const left = value.slice(0, equalsIndex + 1);
+    const right = value.slice(equalsIndex + 1);
+    return `${left}${redactStandalonePath(right)}`;
+  }
+  return redactStandalonePath(value);
+}
+
+function redactStandalonePath(value: string): string {
+  if (!looksLikePathToken(value) || /^https?:\/\//i.test(value)) return value;
+  return basenameFromPath(value);
+}
+
+function looksLikePathToken(value: string): boolean {
+  return value.startsWith('~/') || value.startsWith('./') || value.startsWith('../') || value.startsWith('/') || value.includes('/');
+}
+
+function basenameFromPath(value: string): string {
+  const cleaned = value.replace(/\\/g, '/').replace(/\/+$/, '');
+  const segments = cleaned.split('/').filter(Boolean);
+  return segments.at(-1) ?? value;
+}
+
+function isSkillPathValue(value: string): boolean {
+  return /(?:^|\/)skills\/[^/]+\//i.test(value);
+}
+
+function sanitizeGenericText(value: string): string {
+  return value
+    .replace(/<[^>]+>/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function cleanupLine(line: string): string {
+  return line
+    .replace(/^[-*•]\s*/, '')
+    .replace(/^\d+[.)]\s*/, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function stripMarkdown(line: string): string {
+  return line
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/\*([^*]+)\*/g, '$1')
+    .replace(/^>\s*/, '')
+    .trim();
+}
+
+function isNoiseLine(line: string): boolean {
+  return /^(?:completed|complete|done|success|succeeded|running|started|finished|ok)$/i.test(line);
+}
+
+function humanizeToolName(name: string): string {
+  const cleaned = name.replace(/[-_]+/g, ' ').trim();
+  if (!cleaned) return 'Tool';
+  return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+}
+
+function formatDurationLabel(durationMs: number): string {
+  return durationMs < 1000 ? `${durationMs} ms` : `${(durationMs / 1000).toFixed(1)} s`;
+}
+
+function asDisplayText(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value == null) return '';
+  if (typeof value !== 'object') return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '';
+  }
+}
+
+function stripQuotes(value: string): string {
+  return value.replace(/^[`'"]+|[`'"]+$/g, '').trim();
+}
+
+function extractFirstCodeSpan(value: string): string | undefined {
+  const match = value.match(/`([^`]+)`/);
+  return match?.[1]?.trim() || undefined;
+}
+
+function extractFirstQuotedText(value: string): string | undefined {
+  const match = value.match(/["']([^"']+)["']/);
+  return match?.[1]?.trim() || undefined;
+}
+
+function extractFirstUrl(value: string): string | undefined {
+  const match = value.match(/\bhttps?:\/\/[^\s"'`]+/i);
+  return match?.[0]?.trim() || undefined;
+}

--- a/src/card/reasoning-trace-store.ts
+++ b/src/card/reasoning-trace-store.ts
@@ -1,0 +1,239 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Runtime trace store for structured tool execution steps.
+ *
+ * The Feishu card renderer reads from this store by session key so it can
+ * render observable, replayable execution steps without relying purely on
+ * lossy reply callbacks.
+ */
+
+import { normalizeToolName, truncateText } from './reasoning-utils';
+
+export interface ReasoningTraceStep {
+  id: string;
+  seq: number;
+  toolName: string;
+  params?: Record<string, unknown>;
+  result?: unknown;
+  error?: string;
+  durationMs?: number;
+  status: 'running' | 'success' | 'error';
+  startedAt: number;
+  finishedAt?: number;
+}
+
+interface SessionTraceState {
+  nextSeq: number;
+  updatedAt: number;
+  steps: ReasoningTraceStep[];
+}
+
+const TRACE_TTL_MS = 30 * 60 * 1000;
+const MAX_SESSION_TRACES = 128;
+const MAX_STEPS_PER_SESSION = 256;
+const STEP_RUNNING_TIMEOUT_MS = 5 * 60 * 1000;
+const sessionTraces = new Map<string, SessionTraceState>();
+
+export function startReasoningTraceRun(sessionKey: string): void {
+  if (!sessionKey) return;
+  pruneTraceStore();
+  sessionTraces.set(sessionKey, {
+    nextSeq: 1,
+    updatedAt: Date.now(),
+    steps: [],
+  });
+}
+
+export function recordReasoningToolStart(params: {
+  sessionKey?: string;
+  toolName: string;
+  toolParams?: Record<string, unknown>;
+}): void {
+  const { sessionKey, toolName, toolParams } = params;
+  if (!sessionKey || !toolName) return;
+
+  const state = ensureSessionTraceState(sessionKey);
+  const now = Date.now();
+  if (state.steps.length >= MAX_STEPS_PER_SESSION) {
+    state.steps.splice(0, state.steps.length - MAX_STEPS_PER_SESSION + 1);
+  }
+  state.steps.push({
+    id: `${state.nextSeq}`,
+    seq: state.nextSeq,
+    toolName,
+    params: sanitizeTraceValue(toolParams) as Record<string, unknown> | undefined,
+    status: 'running',
+    startedAt: now,
+  });
+  state.nextSeq += 1;
+  state.updatedAt = now;
+}
+
+export function recordReasoningToolEnd(params: {
+  sessionKey?: string;
+  toolName: string;
+  toolParams?: Record<string, unknown>;
+  result?: unknown;
+  error?: string;
+  durationMs?: number;
+}): void {
+  const { sessionKey, toolName, toolParams, result, error, durationMs } = params;
+  if (!sessionKey || !toolName) return;
+
+  const state = ensureSessionTraceState(sessionKey);
+  const now = Date.now();
+  const sanitizedParams = sanitizeTraceValue(toolParams) as Record<string, unknown> | undefined;
+  const pendingIndex = findPendingStepIndex(state.steps, toolName, sanitizedParams);
+
+  if (pendingIndex >= 0) {
+    const step = state.steps[pendingIndex];
+    if (!step) return;
+    step.status = error ? 'error' : 'success';
+    step.result = sanitizeTraceValue(result);
+    step.error = error ? truncateText(error, 160) : undefined;
+    step.durationMs = durationMs;
+    step.finishedAt = now;
+    if (!step.params && sanitizedParams) {
+      step.params = sanitizedParams;
+    }
+    state.updatedAt = now;
+    return;
+  }
+
+  state.steps.push({
+    id: `${state.nextSeq}`,
+    seq: state.nextSeq,
+    toolName,
+    params: sanitizedParams,
+    result: sanitizeTraceValue(result),
+    error: error ? truncateText(error, 160) : undefined,
+    durationMs,
+    status: error ? 'error' : 'success',
+    startedAt: now,
+    finishedAt: now,
+  });
+  state.nextSeq += 1;
+  state.updatedAt = now;
+}
+
+export function getReasoningTraceSteps(sessionKey?: string): ReasoningTraceStep[] {
+  if (!sessionKey) return [];
+  const state = sessionTraces.get(sessionKey);
+  if (!state) return [];
+  if (Date.now() - state.updatedAt > TRACE_TTL_MS) {
+    sessionTraces.delete(sessionKey);
+    return [];
+  }
+  const now = Date.now();
+  return state.steps.map((step) => {
+    // Mark stale running steps as timed out
+    if (step.status === 'running' && now - step.startedAt > STEP_RUNNING_TIMEOUT_MS) {
+      return { ...step, status: 'error' as const, error: 'timed out', finishedAt: now };
+    }
+    return { ...step };
+  });
+}
+
+function ensureSessionTraceState(sessionKey: string): SessionTraceState {
+  const existing = sessionTraces.get(sessionKey);
+  if (existing) return existing;
+
+  const state: SessionTraceState = {
+    nextSeq: 1,
+    updatedAt: Date.now(),
+    steps: [],
+  };
+  sessionTraces.set(sessionKey, state);
+  pruneTraceStore();
+  return state;
+}
+
+function findPendingStepIndex(steps: ReasoningTraceStep[], toolName: string, params?: Record<string, unknown>): number {
+  const normalizedToolName = normalizeToolName(toolName);
+  const paramsKey = fingerprintTraceValue(params);
+
+  // Exact match: toolName + params fingerprint
+  for (let index = steps.length - 1; index >= 0; index -= 1) {
+    const step = steps[index];
+    if (!step || step.status !== 'running') continue;
+    if (normalizeToolName(step.toolName) !== normalizedToolName) continue;
+    if (fingerprintTraceValue(step.params) !== paramsKey) continue;
+    return index;
+  }
+
+  // Fallback: toolName-only match (handles cases where params differ between start/end)
+  for (let index = steps.length - 1; index >= 0; index -= 1) {
+    const step = steps[index];
+    if (!step || step.status !== 'running') continue;
+    if (normalizeToolName(step.toolName) !== normalizedToolName) continue;
+    return index;
+  }
+
+  return -1;
+}
+
+function pruneTraceStore(): void {
+  const now = Date.now();
+  for (const [sessionKey, state] of sessionTraces) {
+    if (now - state.updatedAt > TRACE_TTL_MS) {
+      sessionTraces.delete(sessionKey);
+    }
+  }
+
+  if (sessionTraces.size <= MAX_SESSION_TRACES) return;
+
+  const overflow = sessionTraces.size - MAX_SESSION_TRACES;
+  const entries = [...sessionTraces.entries()].sort((a, b) => a[1].updatedAt - b[1].updatedAt);
+  for (const [sessionKey] of entries.slice(0, overflow)) {
+    sessionTraces.delete(sessionKey);
+  }
+}
+
+function sanitizeTraceValue(value: unknown, depth = 0): unknown {
+  if (value == null) return undefined;
+  if (typeof value === 'string') return truncateText(value, 180);
+  if (typeof value === 'number' || typeof value === 'boolean') return value;
+  if (depth >= 2) return '[truncated]';
+
+  if (Array.isArray(value)) {
+    return value.slice(0, 8).map((item) => sanitizeTraceValue(item, depth + 1));
+  }
+
+  if (typeof value === 'object') {
+    const input = value as Record<string, unknown>;
+    const output: Record<string, unknown> = {};
+
+    for (const [key, entryValue] of Object.entries(input).slice(0, 12)) {
+      output[key] = isSensitiveKey(key) ? '[redacted]' : sanitizeTraceValue(entryValue, depth + 1);
+    }
+
+    return output;
+  }
+
+  return truncateText(String(value), 180);
+}
+
+function isSensitiveKey(key: string): boolean {
+  return /(secret|token|password|authorization|cookie|api[-_]?key)/i.test(key);
+}
+
+function fingerprintTraceValue(value: unknown): string {
+  if (value == null) return '';
+  if (typeof value !== 'object') return String(value);
+  return JSON.stringify(sortTraceValue(value));
+}
+
+function sortTraceValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((item) => sortTraceValue(item));
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entryValue]) => [key, sortTraceValue(entryValue)]),
+    );
+  }
+  return value;
+}
+

--- a/src/card/reasoning-utils.ts
+++ b/src/card/reasoning-utils.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Shared utilities for the reasoning display subsystem.
+ */
+
+export function normalizeToolName(name?: string): string {
+  return name?.trim().toLowerCase() ?? '';
+}
+
+export function truncateText(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength - 3)}...`;
+}

--- a/src/card/reply-dispatcher-types.ts
+++ b/src/card/reply-dispatcher-types.ts
@@ -72,6 +72,7 @@ export interface StreamingTextState {
   completedText: string;
   streamingPrefix: string;
   lastPartialText: string;
+  lastFlushedText: string;
 }
 
 export interface CardKitState {
@@ -112,6 +113,7 @@ export interface CreateFeishuReplyDispatcherParams {
   cfg: ClawdbotConfig;
   agentId: string;
   chatId: string;
+  sessionKey?: string;
   replyToMessageId?: string;
   /** Account ID for multi-account support. */
   accountId?: string;
@@ -162,7 +164,9 @@ export interface StreamingCardDeps {
   cfg: ClawdbotConfig;
   accountId: string | undefined;
   chatId: string;
+  sessionKey?: string;
   replyToMessageId: string | undefined;
   replyInThread: boolean | undefined;
+  reasoning: { enable: boolean; showFullPaths: boolean };
   resolvedFooter: Required<FeishuFooterConfig>;
 }

--- a/src/card/reply-dispatcher.ts
+++ b/src/card/reply-dispatcher.ts
@@ -39,7 +39,7 @@ export type { CreateFeishuReplyDispatcherParams } from './reply-dispatcher-types
 
 export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherParams): FeishuReplyDispatcherResult {
   const core = LarkClient.runtime;
-  const { cfg, agentId, chatId, replyToMessageId, accountId, replyInThread } = params;
+  const { cfg, agentId, chatId, sessionKey, replyToMessageId, accountId, replyInThread } = params;
 
   // Resolve account so we can read per-account config (e.g. replyMode)
   const account = getLarkAccount(cfg, accountId);
@@ -59,6 +59,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
 
   // ---- Block streaming for static mode ----
   const enableBlockStreaming = feishuCfg?.blockStreaming === true && !useStreamingCards;
+  const reasoning = {
+    enable: feishuCfg?.reasoning?.enable !== false,
+    showFullPaths: feishuCfg?.reasoning?.showFullPaths === true,
+  };
 
   const resolvedFooter = resolveFooterConfig(feishuCfg?.footer);
 
@@ -82,8 +86,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         cfg,
         accountId,
         chatId,
+        sessionKey,
         replyToMessageId,
         replyInThread,
+        reasoning,
         resolvedFooter,
       })
     : null;
@@ -312,6 +318,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         ? {
             onReasoningStream: (payload: ReplyPayload) => controller.onReasoningStream(payload),
             onPartialReply: (payload: ReplyPayload) => controller.onPartialReply(payload),
+            onToolStart: (payload: { name?: string; phase?: string }) => controller.onToolStart(payload),
+            onToolResult: (payload: ReplyPayload) => controller.onToolResult(payload),
           }
         : {}),
     },

--- a/src/card/streaming-card-controller.ts
+++ b/src/card/streaming-card-controller.ts
@@ -22,8 +22,22 @@ import {
   updateCardKitCard,
   setCardStreamingMode,
 } from './cardkit';
-import { buildCardContent, splitReasoningText, stripReasoningTags, STREAMING_ELEMENT_ID, toCardKit2 } from './builder';
+import {
+  buildCardContent,
+  buildStreamingThinkingCard,
+  splitReasoningText,
+  STREAMING_ELEMENT_ID,
+  stripReasoningTags,
+  toCardKit2,
+} from './builder';
 import { optimizeMarkdownStyle } from './markdown-style';
+import {
+  buildReasoningTitleSuffix,
+  normalizeReasoningDisplay,
+  type ReasoningDisplayResult,
+  type ReasoningToolEvent,
+} from './reasoning-display';
+import { getReasoningTraceSteps } from './reasoning-trace-store';
 import { ImageResolver } from './image-resolver';
 import { registerShutdownHook } from '../core/shutdown-hooks';
 import { FlushController } from './flush-controller';
@@ -44,43 +58,7 @@ import {
 } from './reply-dispatcher-types';
 
 const log = larkLogger('card/streaming');
-// ---------------------------------------------------------------------------
-// CardKit 2.0 initial streaming payload
-// ---------------------------------------------------------------------------
 
-const STREAMING_THINKING_CARD = {
-  schema: '2.0',
-  config: {
-    streaming_mode: true,
-    locales: ['zh_cn', 'en_us'],
-    summary: {
-      content: 'Thinking...',
-      i18n_content: { zh_cn: '思考中...', en_us: 'Thinking...' },
-    },
-  },
-  body: {
-    elements: [
-      {
-        tag: 'markdown',
-        content: '',
-        text_align: 'left',
-        text_size: 'normal_v2',
-        margin: '0px 0px 0px 0px',
-        element_id: STREAMING_ELEMENT_ID,
-      },
-      {
-        tag: 'markdown',
-        content: ' ',
-        icon: {
-          tag: 'custom_icon',
-          img_key: 'img_v3_02vb_496bec09-4b43-4773-ad6b-0cdd103cd2bg',
-          size: '16px 16px',
-        },
-        element_id: 'loading_icon',
-      },
-    ],
-  },
-} as const;
 
 // ---------------------------------------------------------------------------
 // StreamingCardController
@@ -102,6 +80,7 @@ export class StreamingCardController {
     completedText: '',
     streamingPrefix: '',
     lastPartialText: '',
+    lastFlushedText: '',
   };
   private reasoning: ReasoningState = {
     accumulatedReasoningText: '',
@@ -109,6 +88,7 @@ export class StreamingCardController {
     reasoningElapsedMs: 0,
     isReasoningPhase: false,
   };
+  private readonly toolEvents: ReasoningToolEvent[] = [];
 
   // ---- Sub-controllers ----
   private readonly flush: FlushController;
@@ -201,6 +181,39 @@ export class StreamingCardController {
     return this.phase;
   }
 
+  private get shouldDisplayStepEvents(): boolean {
+    return this.deps.reasoning.enable;
+  }
+
+  private get visibleReasoningDisplay(): ReasoningDisplayResult | null {
+    if (!this.shouldDisplayStepEvents) return null;
+    const traceSteps = getReasoningTraceSteps(this.deps.sessionKey);
+    return normalizeReasoningDisplay({
+      traceSteps,
+      toolEvents: this.toolEvents,
+      showFullPaths: this.deps.reasoning.showFullPaths,
+    });
+  }
+
+  private get finalReasoningText(): string | undefined {
+    const content = this.visibleReasoningDisplay?.content.trim();
+    return content || undefined;
+  }
+
+  private get visibleReasoningElapsedMs(): number | undefined {
+    if (!this.shouldDisplayStepEvents || !this.reasoning.reasoningStartTime) {
+      return undefined;
+    }
+    return this.reasoning.reasoningElapsedMs || Date.now() - this.reasoning.reasoningStartTime;
+  }
+
+  private get visibleReasoningTitleSuffix(): { zh: string; en: string } | undefined {
+    if (!this.shouldDisplayStepEvents) return undefined;
+    return buildReasoningTitleSuffix({
+      stepCount: this.visibleReasoningDisplay?.stepCount ?? 0,
+    });
+  }
+
   // ------------------------------------------------------------------
   // Unified callback guard
   // ------------------------------------------------------------------
@@ -251,6 +264,46 @@ export class StreamingCardController {
     this.disposeShutdownHook = null;
   }
 
+  private markReasoningActivity(): void {
+    if (!this.reasoning.reasoningStartTime) {
+      this.reasoning.reasoningStartTime = Date.now();
+    }
+    this.reasoning.reasoningElapsedMs = Date.now() - this.reasoning.reasoningStartTime;
+  }
+
+  private captureReasoningElapsed(): void {
+    if (!this.reasoning.reasoningStartTime) return;
+    this.reasoning.reasoningElapsedMs = Date.now() - this.reasoning.reasoningStartTime;
+  }
+
+  private appendToolEvent(event: ReasoningToolEvent): boolean {
+    const normalized: ReasoningToolEvent = {
+      kind: event.kind,
+      name: event.name?.trim() || undefined,
+      phase: event.phase?.trim() || undefined,
+      text: event.text?.trim() || undefined,
+    };
+
+    if (!normalized.name && !normalized.text) return false;
+
+    const lastEvent = this.toolEvents.at(-1);
+    if (
+      lastEvent &&
+      lastEvent.kind === normalized.kind &&
+      lastEvent.name === normalized.name &&
+      lastEvent.phase === normalized.phase &&
+      lastEvent.text === normalized.text
+    ) {
+      return false;
+    }
+
+    this.toolEvents.push(normalized);
+    if (this.toolEvents.length > 200) {
+      this.toolEvents.splice(0, this.toolEvents.length - 200);
+    }
+    return true;
+  }
+
   // ------------------------------------------------------------------
   // SDK callback bindings
   // ------------------------------------------------------------------
@@ -276,11 +329,10 @@ export class StreamingCardController {
 
     if (split.reasoningText && !split.answerText) {
       // Pure reasoning payload
-      this.reasoning.reasoningElapsedMs = this.reasoning.reasoningStartTime
-        ? Date.now() - this.reasoning.reasoningStartTime
-        : 0;
+      this.markReasoningActivity();
       this.reasoning.accumulatedReasoningText = split.reasoningText;
       this.reasoning.isReasoningPhase = true;
+      if (!this.text.accumulatedText) return;
       await this.throttledCardUpdate();
       return;
     }
@@ -288,6 +340,7 @@ export class StreamingCardController {
     // Answer payload (may also contain inline reasoning from tags)
     this.reasoning.isReasoningPhase = false;
     if (split.reasoningText) {
+      this.markReasoningActivity();
       this.reasoning.accumulatedReasoningText = split.reasoningText;
     }
     const answerText = split.answerText ?? text;
@@ -313,12 +366,50 @@ export class StreamingCardController {
     const rawText = payload.text ?? '';
     if (!rawText) return;
 
-    if (!this.reasoning.reasoningStartTime) {
-      this.reasoning.reasoningStartTime = Date.now();
-    }
+    this.markReasoningActivity();
     this.reasoning.isReasoningPhase = true;
     const split = splitReasoningText(rawText);
     this.reasoning.accumulatedReasoningText = split.reasoningText ?? rawText;
+    if (!this.text.accumulatedText) return;
+    await this.throttledCardUpdate();
+  }
+
+  async onToolStart(payload: { name?: string; phase?: string }): Promise<void> {
+    if (!this.shouldProceed('onToolStart')) return;
+    if (!this.shouldDisplayStepEvents) return;
+    if (payload.phase && payload.phase !== 'start') return;
+
+    if (!this.appendToolEvent({ kind: 'start', name: payload.name, phase: payload.phase })) {
+      return;
+    }
+
+    this.markReasoningActivity();
+    this.reasoning.isReasoningPhase = true;
+
+    await this.ensureCardCreated();
+    if (!this.shouldProceed('onToolStart.postCreate')) return;
+    if (!this.cardKit.cardMessageId) return;
+    if (!this.text.accumulatedText) return;
+    await this.throttledCardUpdate();
+  }
+
+  async onToolResult(payload: ReplyPayload): Promise<void> {
+    if (!this.shouldProceed('onToolResult')) return;
+    if (!this.shouldDisplayStepEvents) return;
+
+    const text = payload.text?.trim();
+    if (!text) return;
+
+    if (!this.appendToolEvent({ kind: 'summary', text })) {
+      return;
+    }
+
+    this.markReasoningActivity();
+
+    await this.ensureCardCreated();
+    if (!this.shouldProceed('onToolResult.postCreate')) return;
+    if (!this.cardKit.cardMessageId) return;
+    if (!this.text.accumulatedText) return;
     await this.throttledCardUpdate();
   }
 
@@ -329,14 +420,10 @@ export class StreamingCardController {
     log.debug('onPartialReply', { len: text.length });
     if (!text) return;
 
-    if (!this.reasoning.reasoningStartTime) {
-      this.reasoning.reasoningStartTime = Date.now();
-    }
+    this.markReasoningActivity();
     if (this.reasoning.isReasoningPhase) {
       this.reasoning.isReasoningPhase = false;
-      this.reasoning.reasoningElapsedMs = this.reasoning.reasoningStartTime
-        ? Date.now() - this.reasoning.reasoningStartTime
-        : 0;
+      this.captureReasoningElapsed();
     }
 
     // 检测回复边界：文本长度缩短 → 新回复开始
@@ -363,6 +450,7 @@ export class StreamingCardController {
 
     log.error(`${info.kind} reply failed`, { error: String(err) });
 
+    this.captureReasoningElapsed();
     this.finalizeCard('onError', 'error');
 
     await this.flush.waitForFlush();
@@ -378,8 +466,11 @@ export class StreamingCardController {
         const errorText = this.imageResolver.resolveImages(rawErrorText);
         const errorCard = buildCardContent('complete', {
           text: errorText,
-          reasoningText: this.reasoning.accumulatedReasoningText || undefined,
-          reasoningElapsedMs: this.reasoning.reasoningElapsedMs || undefined,
+          reasoningText: this.finalReasoningText,
+          reasoningSteps: this.visibleReasoningDisplay?.steps,
+          reasoningTitleSuffix: this.visibleReasoningTitleSuffix,
+          reasoningElapsedMs: this.visibleReasoningElapsedMs,
+          showReasoning: this.deps.reasoning.enable,
           elapsedMs: this.elapsed(),
           isError: true,
           footer: this.deps.resolvedFooter,
@@ -406,6 +497,7 @@ export class StreamingCardController {
     if (!this.dispatchFullyComplete) return;
 
     if (this.isTerminalPhase) return;
+    this.captureReasoningElapsed();
     this.finalizeCard('onIdle', 'normal');
 
     await this.flush.waitForFlush();
@@ -447,8 +539,11 @@ export class StreamingCardController {
 
         const completeCard = buildCardContent('complete', {
           text: resolvedDisplayText,
-          reasoningText: this.reasoning.accumulatedReasoningText || undefined,
-          reasoningElapsedMs: this.reasoning.reasoningElapsedMs || undefined,
+          reasoningText: this.finalReasoningText,
+          reasoningSteps: this.visibleReasoningDisplay?.steps,
+          reasoningTitleSuffix: this.visibleReasoningTitleSuffix,
+          reasoningElapsedMs: this.visibleReasoningElapsedMs,
+          showReasoning: this.deps.reasoning.enable,
           elapsedMs: this.elapsed(),
           footer: this.deps.resolvedFooter,
         });
@@ -499,6 +594,7 @@ export class StreamingCardController {
 
   async abortCard(): Promise<void> {
     try {
+      this.captureReasoningElapsed();
       if (!this.transition('aborted', 'abortCard', 'abort')) return;
 
       // transition() already executed onEnterTerminalPhase (cancel + complete + dispose hook)
@@ -513,8 +609,11 @@ export class StreamingCardController {
         const abortText = this.imageResolver.resolveImages(this.text.accumulatedText || 'Aborted.');
         const abortCardContent = buildCardContent('complete', {
           text: abortText,
-          reasoningText: this.reasoning.accumulatedReasoningText || undefined,
-          reasoningElapsedMs: this.reasoning.reasoningElapsedMs || undefined,
+          reasoningText: this.finalReasoningText,
+          reasoningSteps: this.visibleReasoningDisplay?.steps,
+          reasoningTitleSuffix: this.visibleReasoningTitleSuffix,
+          reasoningElapsedMs: this.visibleReasoningElapsedMs,
+          showReasoning: this.deps.reasoning.enable,
           elapsedMs,
           isAborted: true,
           footer: this.deps.resolvedFooter,
@@ -527,8 +626,11 @@ export class StreamingCardController {
         const abortText = this.imageResolver.resolveImages(this.text.accumulatedText || 'Aborted.');
         const abortCard = buildCardContent('complete', {
           text: abortText,
-          reasoningText: this.reasoning.accumulatedReasoningText || undefined,
-          reasoningElapsedMs: this.reasoning.reasoningElapsedMs || undefined,
+          reasoningText: this.finalReasoningText,
+          reasoningSteps: this.visibleReasoningDisplay?.steps,
+          reasoningTitleSuffix: this.visibleReasoningTitleSuffix,
+          reasoningElapsedMs: this.visibleReasoningElapsedMs,
+          showReasoning: this.deps.reasoning.enable,
           elapsedMs,
           isAborted: true,
           footer: this.deps.resolvedFooter,
@@ -568,7 +670,7 @@ export class StreamingCardController {
           // Step 1: Create card entity
           const cId = await createCardEntity({
             cfg: this.deps.cfg,
-            card: STREAMING_THINKING_CARD,
+            card: buildStreamingThinkingCard(this.deps.reasoning.enable),
             accountId: this.deps.accountId,
           });
 
@@ -632,7 +734,9 @@ export class StreamingCardController {
           this.cardKit.cardKitCardId = null;
           this.cardKit.originalCardKitCardId = null;
 
-          const fallbackCard = buildCardContent('thinking');
+          const fallbackCard = buildCardContent('streaming', {
+            showReasoning: this.deps.reasoning.enable,
+          });
           const result = await sendCardFeishu({
             cfg: this.deps.cfg,
             to: this.deps.chatId,
@@ -693,26 +797,28 @@ export class StreamingCardController {
       const resolvedText = this.imageResolver.resolveImages(displayText);
 
       if (this.cardKit.cardKitCardId) {
-        // CardKit streaming — typewriter effect
-        const prevSeq = this.cardKit.cardKitSequence;
-        this.cardKit.cardKitSequence += 1;
-        log.debug('flushCardUpdate: seq bump', {
-          seqBefore: prevSeq,
-          seqAfter: this.cardKit.cardKitSequence,
-        });
-        await streamCardContent({
-          cfg: this.deps.cfg,
-          cardId: this.cardKit.cardKitCardId,
-          elementId: STREAMING_ELEMENT_ID,
-          content: optimizeMarkdownStyle(resolvedText),
-          sequence: this.cardKit.cardKitSequence,
-          accountId: this.deps.accountId,
-        });
+        if (resolvedText !== this.text.lastFlushedText) {
+          const prevSeq = this.cardKit.cardKitSequence;
+          this.cardKit.cardKitSequence += 1;
+          log.debug('flushCardUpdate: answer seq bump', {
+            seqBefore: prevSeq,
+            seqAfter: this.cardKit.cardKitSequence,
+          });
+          await streamCardContent({
+            cfg: this.deps.cfg,
+            cardId: this.cardKit.cardKitCardId,
+            elementId: STREAMING_ELEMENT_ID,
+            content: optimizeMarkdownStyle(resolvedText),
+            sequence: this.cardKit.cardKitSequence,
+            accountId: this.deps.accountId,
+          });
+          this.text.lastFlushedText = resolvedText;
+        }
       } else {
         log.debug('flushCardUpdate: IM patch fallback');
         const card = buildCardContent('streaming', {
-          text: this.reasoning.isReasoningPhase ? '' : resolvedText,
-          reasoningText: this.reasoning.isReasoningPhase ? this.reasoning.accumulatedReasoningText : undefined,
+          text: resolvedText,
+          showReasoning: this.deps.reasoning.enable,
         });
         await updateCardFeishu({
           cfg: this.deps.cfg,
@@ -747,10 +853,6 @@ export class StreamingCardController {
   }
 
   private buildDisplayText(): string {
-    if (this.reasoning.isReasoningPhase && this.reasoning.accumulatedReasoningText) {
-      const reasoningDisplay = `💭 **Thinking...**\n\n${this.reasoning.accumulatedReasoningText}`;
-      return this.text.accumulatedText ? this.text.accumulatedText + '\n\n' + reasoningDisplay : reasoningDisplay;
-    }
     return this.text.accumulatedText;
   }
 

--- a/src/core/config-schema.ts
+++ b/src/core/config-schema.ts
@@ -174,6 +174,12 @@ export const FeishuAccountConfigSchema = z.object({
   replyMode: ReplyModeSchema,
   streaming: z.boolean().optional(),
   blockStreaming: z.boolean().optional(),
+  reasoning: z
+    .object({
+      enable: z.boolean().optional(),
+      showFullPaths: z.boolean().optional(),
+    })
+    .optional(),
   tools: FeishuToolsFlagSchema,
   footer: FeishuFooterSchema,
   markdown: MarkdownConfigSchema,

--- a/src/messaging/inbound/dispatch-commands.ts
+++ b/src/messaging/inbound/dispatch-commands.ts
@@ -14,6 +14,7 @@ import { LarkClient } from '../../core/lark-client';
 import { larkLogger } from '../../core/lark-logger';
 import { ticketElapsed } from '../../core/lark-ticket';
 import { createFeishuReplyDispatcher } from '../../card/reply-dispatcher';
+import { startReasoningTraceRun } from '../../card/reasoning-trace-store';
 import { sendMessageFeishu } from '../outbound/send';
 import { buildInboundPayload } from './dispatch-builders';
 
@@ -54,6 +55,8 @@ export async function dispatchPermissionNotification(
     wasMentioned: false,
   });
 
+  startReasoningTraceRun(dc.threadSessionKey ?? dc.route.sessionKey);
+
   const {
     dispatcher: permDispatcher,
     replyOptions: permReplyOptions,
@@ -63,6 +66,7 @@ export async function dispatchPermissionNotification(
     cfg: dc.accountScopedCfg,
     agentId: dc.route.agentId,
     chatId: dc.ctx.chatId,
+    sessionKey: dc.threadSessionKey ?? dc.route.sessionKey,
     replyToMessageId: replyToMessageId ?? dc.ctx.messageId,
     accountId: dc.account.accountId,
     chatType: dc.ctx.chatType,

--- a/src/messaging/inbound/dispatch.ts
+++ b/src/messaging/inbound/dispatch.ts
@@ -30,6 +30,7 @@ import {
   registerActiveDispatcher,
   unregisterActiveDispatcher,
 } from '../../channel/chat-queue';
+import { startReasoningTraceRun } from '../../card/reasoning-trace-store';
 import { isLikelyAbortText } from '../../channel/abort-detect';
 import { type DispatchContext, buildDispatchContext, resolveThreadSessionKey } from './dispatch-context';
 import {
@@ -81,10 +82,14 @@ async function dispatchNormalMessage(
     return;
   }
 
+  const effectiveSessionKey = dc.threadSessionKey ?? dc.route.sessionKey;
+  startReasoningTraceRun(effectiveSessionKey);
+
   const { dispatcher, replyOptions, markDispatchIdle, markFullyComplete, abortCard } = createFeishuReplyDispatcher({
     cfg: dc.accountScopedCfg,
     agentId: dc.route.agentId,
     chatId: dc.ctx.chatId,
+    sessionKey: effectiveSessionKey,
     replyToMessageId: replyToMessageId ?? dc.ctx.messageId,
     accountId: dc.account.accountId,
     chatType: dc.ctx.chatType,
@@ -101,7 +106,6 @@ async function dispatchNormalMessage(
   const queueKey = buildQueueKey(dc.account.accountId, dc.ctx.chatId, dc.ctx.threadId);
   registerActiveDispatcher(queueKey, { abortCard, abortController });
 
-  const effectiveSessionKey = dc.threadSessionKey ?? dc.route.sessionKey;
   dc.log(`feishu[${dc.account.accountId}]: dispatching to agent (session=${effectiveSessionKey})`);
   log.info(`dispatching to agent (session=${effectiveSessionKey})`);
 


### PR DESCRIPTION
## Summary

- 新增 trace-first 架构的推理步骤展示功能，在飞书卡片中以可折叠面板渲染 AI 工具调用的结构化执行步骤，支持 i18n（zh_cn/en_us）
- 新增 `reasoning-trace-store`：session 级内存 trace 存储，具备 TTL（30min）、最大 session（128）/step（256）限制、运行超时（5min）检测、敏感数据脱敏
- 新增 `reasoning-display`：将 trace 数据 + 流式回调归一化为展示步骤，基于工具描述符（图标、标题、路径脱敏）
- 配置添加：`reasoning: { enable, showFullPaths }`

## Architecture

```
Tool hooks (index.ts) → reasoning-trace-store → reasoning-display → builder → card
                                                      ↑
StreamingCardController.toolEvents (callback fallback) ─┘
```

Trace-first 设计：优先使用 `before_tool_call`/`after_tool_call` hook 的结构化 trace 数据，流式回调（`onToolStart`/`onToolResult`）作为 fallback。

## Changed files

| File | Change |
|------|--------|
| `src/card/reasoning-trace-store.ts` | **New** — session 级 trace 存储，含内存安全保护 |
| `src/card/reasoning-display.ts` | **New** — trace 归一化 + 展示步骤渲染 |
| `src/card/reasoning-utils.ts` | **New** — 共享 `normalizeToolName`、`truncateText` |
| `src/card/builder.ts` | 推理折叠面板，移除旧的内联 reasoning/toolCalls 渲染 |
| `src/card/streaming-card-controller.ts` | 集成 reasoning display + tool event 追踪 |
| `src/card/reply-dispatcher-types.ts` | `StreamingCardDeps.reasoning` 分组配置 |
| `src/card/reply-dispatcher.ts` | `reasoning` 对象的配置解析 |
| `src/core/config-schema.ts` | `reasoning: { enable, showFullPaths }` schema |
| `index.ts` | 接入 `before_tool_call`/`after_tool_call` hook |
| `src/messaging/inbound/dispatch*.ts` | session key 透传 |

## Config

```yaml
reasoning:
  enable: true        # 默认 true，是否展示推理面板
  showFullPaths: false # 默认 false，是否在工具参数中展示完整文件路径
```
