### PR TITLE
fix(drive): don't log/return undefined task_id for sync move/delete

### DIFF
--- a/src/tools/oapi/drive/file.ts
+++ b/src/tools/oapi/drive/file.ts
@@ -458,11 +458,11 @@ export function registerFeishuDriveFileTool(api: OpenClawPluginApi) {
               assertLarkOk(res);
 
               const data = res.data as DriveTaskData | undefined;
-              log.info(`move: task_id=${data?.task_id}`);
+              log.info(`move: success${data?.task_id ? `, task_id=${data.task_id}` : ''}`);
 
               return json({
                 success: true,
-                task_id: data?.task_id,
+                ...(data?.task_id ? { task_id: data.task_id } : {}),
                 file_token: p.file_token,
                 target_folder_token: p.folder_token,
               });
@@ -491,11 +491,11 @@ export function registerFeishuDriveFileTool(api: OpenClawPluginApi) {
               assertLarkOk(res);
 
               const data = res.data as DriveTaskData | undefined;
-              log.info(`delete: task_id=${data?.task_id}`);
+              log.info(`delete: success${data?.task_id ? `, task_id=${data.task_id}` : ''}`);
 
               return json({
                 success: true,
-                task_id: data?.task_id,
+                ...(data?.task_id ? { task_id: data.task_id } : {}),
                 file_token: p.file_token,
               });
             }


### PR DESCRIPTION
## Problem

The Feishu Drive move/delete API only returns `task_id` for async operations (large files). For most synchronous moves/deletes, `task_id` is undefined, which produces noisy gateway logs:

```
2026-03-19T08:14:39.812Z [gateway] feishu_drive_file: move: task_id=undefined
```

This happens on every single file move/delete, making logs harder to read.

## Fix

- Conditionally log `task_id` only when present: `move: success` vs `move: success, task_id=xxx`
- Don't include `task_id: undefined` in the JSON response — only include it when the API actually returns one

## Changes

- `src/tools/oapi/drive/file.ts`: Fixed both `move` and `delete` handlers (4 lines changed)