### PR TITLE
fix: make tool registration logs reflect actual registered tools (fixes #122)

### DIFF
--- a/src/tools/helpers.ts
+++ b/src/tools/helpers.ts
@@ -255,23 +255,24 @@ export function registerTool(
   api: OpenClawPluginApi,
   tool: Parameters<OpenClawPluginApi['registerTool']>[0],
   opts?: Parameters<OpenClawPluginApi['registerTool']>[1],
-): void {
+): boolean {
   // 提取工具名称
   const toolName = typeof tool === 'function' ? tool.name : (tool as { name?: string }).name;
 
   if (!toolName) {
     // 如果无法提取工具名，直接注册（不拦截）
     api.registerTool(tool, opts);
-    return;
+    return true;
   }
 
   // 检查是否应该注册
   if (!checkToolRegistration(api, toolName)) {
-    return;
+    return false;
   }
 
   // 通过检查，调用原始的 registerTool
   api.registerTool(tool, opts);
+  return true;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/mcp/doc/create.ts
+++ b/src/tools/mcp/doc/create.ts
@@ -37,8 +37,8 @@ function validateCreateDocParams(p: CreateDocParams): void {
 /**
  * 注册 create-doc 工具
  */
-export function registerCreateDocTool(api: OpenClawPluginApi) {
-  registerMcpTool<CreateDocParams>(api, {
+export function registerCreateDocTool(api: OpenClawPluginApi): boolean {
+  return registerMcpTool<CreateDocParams>(api, {
     name: 'feishu_create_doc',
     mcpToolName: 'create-doc',
     toolActionKey: 'feishu_create_doc.default',

--- a/src/tools/mcp/doc/fetch.ts
+++ b/src/tools/mcp/doc/fetch.ts
@@ -34,8 +34,8 @@ type FetchDocParams = Static<typeof FetchDocSchema>;
 /**
  * 注册 fetch-doc 工具
  */
-export function registerFetchDocTool(api: OpenClawPluginApi) {
-  registerMcpTool<FetchDocParams>(api, {
+export function registerFetchDocTool(api: OpenClawPluginApi): boolean {
+  return registerMcpTool<FetchDocParams>(api, {
     name: 'feishu_fetch_doc',
     mcpToolName: 'fetch-doc',
     toolActionKey: 'feishu_fetch_doc.default',

--- a/src/tools/mcp/doc/index.ts
+++ b/src/tools/mcp/doc/index.ts
@@ -41,9 +41,11 @@ export function registerFeishuMcpDocTools(api: OpenClawPluginApi) {
   setMcpEndpointOverride(mcpEndpoint);
 
   // 注册工具（search/list 已由 OAPI 版本替代，不再注册）
-  registerFetchDocTool(api);
-  registerCreateDocTool(api);
-  registerUpdateDocTool(api);
-
-  api.logger.info?.('feishu_doc: Registered feishu_fetch_doc, feishu_create_doc, feishu_update_doc');
+  const registered: string[] = [];
+  if (registerFetchDocTool(api)) registered.push('feishu_fetch_doc');
+  if (registerCreateDocTool(api)) registered.push('feishu_create_doc');
+  if (registerUpdateDocTool(api)) registered.push('feishu_update_doc');
+  if (registered.length > 0) {
+    api.logger.info?.(`feishu_doc: Registered ${registered.join(', ')}`);
+  }
 }

--- a/src/tools/mcp/doc/update.ts
+++ b/src/tools/mcp/doc/update.ts
@@ -66,8 +66,8 @@ function validateUpdateDocParams(p: UpdateDocParams): void {
 /**
  * 注册 update-doc 工具
  */
-export function registerUpdateDocTool(api: OpenClawPluginApi) {
-  registerMcpTool<UpdateDocParams>(api, {
+export function registerUpdateDocTool(api: OpenClawPluginApi): boolean {
+  return registerMcpTool<UpdateDocParams>(api, {
     name: 'feishu_update_doc',
     mcpToolName: 'update-doc',
     toolActionKey: 'feishu_update_doc.default',

--- a/src/tools/mcp/shared.ts
+++ b/src/tools/mcp/shared.ts
@@ -225,10 +225,10 @@ export async function callMcpTool(
 export function registerMcpTool<T extends Record<string, unknown>>(
   api: OpenClawPluginApi,
   config: McpToolConfig<T>,
-): void {
+): boolean {
   const { toolClient, log } = createToolContext(api, config.name);
 
-  registerTool(
+  return registerTool(
     api,
     {
       name: config.name,

--- a/src/tools/oapi/chat/chat.ts
+++ b/src/tools/oapi/chat/chat.ts
@@ -83,13 +83,13 @@ type FeishuChatParams =
 // Registration
 // ---------------------------------------------------------------------------
 
-export function registerChatSearchTool(api: OpenClawPluginApi) {
-  if (!api.config) return;
+export function registerChatSearchTool(api: OpenClawPluginApi): boolean {
+  if (!api.config) return false;
   const cfg = api.config;
 
   const { toolClient, log } = createToolContext(api, 'feishu_chat');
 
-  registerTool(
+  return registerTool(
     api,
     {
       name: 'feishu_chat',
@@ -184,5 +184,4 @@ export function registerChatSearchTool(api: OpenClawPluginApi) {
     },
     { name: 'feishu_chat' },
   );
-
 }

--- a/src/tools/oapi/chat/index.ts
+++ b/src/tools/oapi/chat/index.ts
@@ -12,8 +12,10 @@ import { registerChatSearchTool } from './chat';
 import { registerChatMembersTool } from './members';
 
 export function registerFeishuChatTools(api: OpenClawPluginApi) {
-  registerChatSearchTool(api);
-  registerChatMembersTool(api);
-
-  api.logger.info?.('feishu_chat: Registered feishu_chat, feishu_chat_members');
+  const registered: string[] = [];
+  if (registerChatSearchTool(api)) registered.push('feishu_chat');
+  if (registerChatMembersTool(api)) registered.push('feishu_chat_members');
+  if (registered.length > 0) {
+    api.logger.info?.(`feishu_chat: Registered ${registered.join(', ')}`);
+  }
 }

--- a/src/tools/oapi/chat/members.ts
+++ b/src/tools/oapi/chat/members.ts
@@ -52,13 +52,13 @@ interface ChatMembersParams {
 // Registration
 // ---------------------------------------------------------------------------
 
-export function registerChatMembersTool(api: OpenClawPluginApi) {
-  if (!api.config) return;
+export function registerChatMembersTool(api: OpenClawPluginApi): boolean {
+  if (!api.config) return false;
   const cfg = api.config;
 
   const { toolClient, log } = createToolContext(api, 'feishu_chat_members');
 
-  registerTool(
+  return registerTool(
     api,
     {
       name: 'feishu_chat_members',
@@ -119,5 +119,4 @@ export function registerChatMembersTool(api: OpenClawPluginApi) {
     },
     { name: 'feishu_chat_members' },
   );
-
 }

--- a/src/tools/oapi/drive/doc-comments.ts
+++ b/src/tools/oapi/drive/doc-comments.ts
@@ -206,13 +206,13 @@ async function assembleCommentsWithReplies(
 // Registration
 // ---------------------------------------------------------------------------
 
-export function registerDocCommentsTool(api: OpenClawPluginApi) {
-  if (!api.config) return;
+export function registerDocCommentsTool(api: OpenClawPluginApi): boolean {
+  if (!api.config) return false;
   const cfg = api.config;
 
   const { toolClient, log } = createToolContext(api, 'feishu_doc_comments');
 
-  registerTool(
+  return registerTool(
     api,
     {
       name: 'feishu_doc_comments',
@@ -418,5 +418,4 @@ export function registerDocCommentsTool(api: OpenClawPluginApi) {
     },
     { name: 'feishu_doc_comments' },
   );
-
 }

--- a/src/tools/oapi/drive/doc-media.ts
+++ b/src/tools/oapi/drive/doc-media.ts
@@ -401,13 +401,13 @@ async function handleDownload(
 // Registration
 // ---------------------------------------------------------------------------
 
-export function registerDocMediaTool(api: OpenClawPluginApi) {
-  if (!api.config) return;
+export function registerDocMediaTool(api: OpenClawPluginApi): boolean {
+  if (!api.config) return false;
   const cfg = api.config;
 
   const { toolClient, log } = createToolContext(api, 'feishu_doc_media');
 
-  registerTool(
+  return registerTool(
     api,
     {
       name: 'feishu_doc_media',
@@ -437,5 +437,4 @@ export function registerDocMediaTool(api: OpenClawPluginApi) {
     },
     { name: 'feishu_doc_media' },
   );
-
 }

--- a/src/tools/oapi/drive/file.ts
+++ b/src/tools/oapi/drive/file.ts
@@ -296,13 +296,13 @@ type FeishuDriveFileParams =
 // Registration
 // ---------------------------------------------------------------------------
 
-export function registerFeishuDriveFileTool(api: OpenClawPluginApi) {
-  if (!api.config) return;
+export function registerFeishuDriveFileTool(api: OpenClawPluginApi): boolean {
+  if (!api.config) return false;
   const cfg = api.config;
 
   const { toolClient, log } = createToolContext(api, 'feishu_drive_file');
 
-  registerTool(
+  return registerTool(
     api,
     {
       name: 'feishu_drive_file',
@@ -743,5 +743,4 @@ export function registerFeishuDriveFileTool(api: OpenClawPluginApi) {
     },
     { name: 'feishu_drive_file' },
   );
-
 }

--- a/src/tools/oapi/drive/index.ts
+++ b/src/tools/oapi/drive/index.ts
@@ -35,9 +35,11 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
   }
 
   // 注册所有工具
-  registerFeishuDriveFileTool(api);
-  registerDocCommentsTool(api);
-  registerDocMediaTool(api);
-
-  api.logger.info?.('feishu_drive: Registered feishu_drive_file, feishu_doc_comments, feishu_doc_media');
+  const registered: string[] = [];
+  if (registerFeishuDriveFileTool(api)) registered.push('feishu_drive_file');
+  if (registerDocCommentsTool(api)) registered.push('feishu_doc_comments');
+  if (registerDocMediaTool(api)) registered.push('feishu_doc_media');
+  if (registered.length > 0) {
+    api.logger.info?.(`feishu_drive: Registered ${registered.join(', ')}`);
+  }
 }

--- a/src/tools/oapi/im/index.ts
+++ b/src/tools/oapi/im/index.ts
@@ -13,11 +13,11 @@ import { registerFeishuImUserFetchResourceTool } from './resource';
 import { registerMessageReadTools } from './message-read';
 
 export function registerFeishuImTools(api: OpenClawPluginApi) {
-  registerFeishuImUserMessageTool(api);
-  registerFeishuImUserFetchResourceTool(api);
-  registerMessageReadTools(api);
-
-  api.logger.info?.(
-    'feishu_im: Registered feishu_im_user_message, feishu_im_user_fetch_resource, feishu_im_user_get_messages, feishu_im_user_get_thread_messages, feishu_im_user_search_messages',
-  );
+  const registered: string[] = [];
+  if (registerFeishuImUserMessageTool(api)) registered.push('feishu_im_user_message');
+  if (registerFeishuImUserFetchResourceTool(api)) registered.push('feishu_im_user_fetch_resource');
+  registered.push(...registerMessageReadTools(api));
+  if (registered.length > 0) {
+    api.logger.info?.(`feishu_im: Registered ${registered.join(', ')}`);
+  }
 }

--- a/src/tools/oapi/im/message-read.ts
+++ b/src/tools/oapi/im/message-read.ts
@@ -139,12 +139,12 @@ interface GetMessagesParams {
   end_time?: string;
 }
 
-function registerGetMessages(api: OpenClawPluginApi) {
-  if (!api.config) return;
+function registerGetMessages(api: OpenClawPluginApi): boolean {
+  if (!api.config) return false;
   const config = api.config;
   const { toolClient, log } = createToolContext(api, 'feishu_im_user_get_messages');
 
-  registerTool(
+  return registerTool(
     api,
     {
       name: 'feishu_im_user_get_messages',
@@ -244,12 +244,12 @@ interface GetThreadMessagesParams {
   page_token?: string;
 }
 
-function registerGetThreadMessages(api: OpenClawPluginApi) {
-  if (!api.config) return;
+function registerGetThreadMessages(api: OpenClawPluginApi): boolean {
+  if (!api.config) return false;
   const config = api.config;
   const { toolClient, log } = createToolContext(api, 'feishu_im_user_get_thread_messages');
 
-  registerTool(
+  return registerTool(
     api,
     {
       name: 'feishu_im_user_get_thread_messages',
@@ -479,12 +479,12 @@ function enrichMessages(
   });
 }
 
-function registerSearchMessages(api: OpenClawPluginApi) {
-  if (!api.config) return;
+function registerSearchMessages(api: OpenClawPluginApi): boolean {
+  if (!api.config) return false;
   const config = api.config;
   const { toolClient, log } = createToolContext(api, 'feishu_im_user_search_messages');
 
-  registerTool(
+  return registerTool(
     api,
     {
       name: 'feishu_im_user_search_messages',
@@ -602,8 +602,10 @@ function registerSearchMessages(api: OpenClawPluginApi) {
 // Unified registration
 // ===========================================================================
 
-export function registerMessageReadTools(api: OpenClawPluginApi) {
-  registerGetMessages(api);
-  registerGetThreadMessages(api);
-  registerSearchMessages(api);
+export function registerMessageReadTools(api: OpenClawPluginApi): string[] {
+  const registered: string[] = [];
+  if (registerGetMessages(api)) registered.push('feishu_im_user_get_messages');
+  if (registerGetThreadMessages(api)) registered.push('feishu_im_user_get_thread_messages');
+  if (registerSearchMessages(api)) registered.push('feishu_im_user_search_messages');
+  return registered;
 }

--- a/src/tools/oapi/im/message.ts
+++ b/src/tools/oapi/im/message.ts
@@ -107,12 +107,12 @@ type FeishuImMessageParams =
 // Registration
 // ---------------------------------------------------------------------------
 
-export function registerFeishuImUserMessageTool(api: OpenClawPluginApi) {
-  if (!api.config) return;
+export function registerFeishuImUserMessageTool(api: OpenClawPluginApi): boolean {
+  if (!api.config) return false;
   const cfg = api.config;
   const { toolClient, log } = createToolContext(api, 'feishu_im_user_message');
 
-  registerTool(
+  return registerTool(
     api,
     {
       name: 'feishu_im_user_message',

--- a/src/tools/oapi/im/resource.ts
+++ b/src/tools/oapi/im/resource.ts
@@ -87,13 +87,13 @@ interface FetchResourceParams {
 // Registration
 // ---------------------------------------------------------------------------
 
-export function registerFeishuImUserFetchResourceTool(api: OpenClawPluginApi) {
-  if (!api.config) return;
+export function registerFeishuImUserFetchResourceTool(api: OpenClawPluginApi): boolean {
+  if (!api.config) return false;
   const cfg = api.config;
 
   const { toolClient, log } = createToolContext(api, 'feishu_im_user_fetch_resource');
 
-  registerTool(
+  return registerTool(
     api,
     {
       name: 'feishu_im_user_fetch_resource',
@@ -189,5 +189,4 @@ export function registerFeishuImUserFetchResourceTool(api: OpenClawPluginApi) {
     },
     { name: 'feishu_im_user_fetch_resource' },
   );
-
 }

--- a/src/tools/oapi/search/doc-search.ts
+++ b/src/tools/oapi/search/doc-search.ts
@@ -176,13 +176,13 @@ function normalizeSearchResultTimeFields<T>(value: T, converted: { count: number
 // Registration
 // ---------------------------------------------------------------------------
 
-export function registerFeishuSearchDocWikiTool(api: OpenClawPluginApi) {
-  if (!api.config) return;
+export function registerFeishuSearchDocWikiTool(api: OpenClawPluginApi): boolean {
+  if (!api.config) return false;
   const cfg = api.config;
 
   const { toolClient, log } = createToolContext(api, 'feishu_search_doc_wiki');
 
-  registerTool(
+  return registerTool(
     api,
     {
       name: 'feishu_search_doc_wiki',
@@ -291,5 +291,4 @@ export function registerFeishuSearchDocWikiTool(api: OpenClawPluginApi) {
     },
     { name: 'feishu_search_doc_wiki' },
   );
-
 }

--- a/src/tools/oapi/search/index.ts
+++ b/src/tools/oapi/search/index.ts
@@ -34,7 +34,7 @@ export function registerFeishuSearchTools(api: OpenClawPluginApi) {
   }
 
   // 注册所有工具
-  registerFeishuSearchDocWikiTool(api);
-
-  api.logger.info?.('feishu_search: Registered feishu_search_doc_wiki');
+  if (registerFeishuSearchDocWikiTool(api)) {
+    api.logger.info?.('feishu_search: Registered feishu_search_doc_wiki');
+  }
 }

--- a/src/tools/oapi/sheets/index.ts
+++ b/src/tools/oapi/sheets/index.ts
@@ -32,7 +32,7 @@ export function registerFeishuSheetsTools(api: OpenClawPluginApi) {
     return;
   }
 
-  registerFeishuSheetTool(api);
-
-  api.logger.info?.('feishu_sheets: Registered feishu_sheet tool');
+  if (registerFeishuSheetTool(api)) {
+    api.logger.info?.('feishu_sheets: Registered feishu_sheet');
+  }
 }

--- a/src/tools/oapi/sheets/sheet.ts
+++ b/src/tools/oapi/sheets/sheet.ts
@@ -472,13 +472,13 @@ type FeishuSheetParams =
 // Registration
 // ---------------------------------------------------------------------------
 
-export function registerFeishuSheetTool(api: OpenClawPluginApi) {
-  if (!api.config) return;
+export function registerFeishuSheetTool(api: OpenClawPluginApi): boolean {
+  if (!api.config) return false;
   const cfg = api.config;
 
   const { toolClient, log } = createToolContext(api, 'feishu_sheet');
 
-  registerTool(
+  return registerTool(
     api,
     {
       name: 'feishu_sheet',
@@ -955,5 +955,4 @@ export function registerFeishuSheetTool(api: OpenClawPluginApi) {
     },
     { name: 'feishu_sheet' },
   );
-
 }

--- a/src/tools/oapi/wiki/index.ts
+++ b/src/tools/oapi/wiki/index.ts
@@ -34,8 +34,10 @@ export function registerFeishuWikiTools(api: OpenClawPluginApi) {
   }
 
   // 注册所有工具
-  registerFeishuWikiSpaceTool(api);
-  registerFeishuWikiSpaceNodeTool(api);
-
-  api.logger.info?.('feishu_wiki: Registered feishu_wiki_space, feishu_wiki_space_node');
+  const registered: string[] = [];
+  if (registerFeishuWikiSpaceTool(api)) registered.push('feishu_wiki_space');
+  if (registerFeishuWikiSpaceNodeTool(api)) registered.push('feishu_wiki_space_node');
+  if (registered.length > 0) {
+    api.logger.info?.(`feishu_wiki: Registered ${registered.join(', ')}`);
+  }
 }

--- a/src/tools/oapi/wiki/space-node.ts
+++ b/src/tools/oapi/wiki/space-node.ts
@@ -191,13 +191,13 @@ type FeishuWikiSpaceNodeParams =
 // Registration
 // ---------------------------------------------------------------------------
 
-export function registerFeishuWikiSpaceNodeTool(api: OpenClawPluginApi) {
-  if (!api.config) return;
+export function registerFeishuWikiSpaceNodeTool(api: OpenClawPluginApi): boolean {
+  if (!api.config) return false;
   const cfg = api.config;
 
   const { toolClient, log } = createToolContext(api, 'feishu_wiki_space_node');
 
-  registerTool(
+  return registerTool(
     api,
     {
       name: 'feishu_wiki_space_node',
@@ -390,5 +390,4 @@ export function registerFeishuWikiSpaceNodeTool(api: OpenClawPluginApi) {
     },
     { name: 'feishu_wiki_space_node' },
   );
-
 }

--- a/src/tools/oapi/wiki/space.ts
+++ b/src/tools/oapi/wiki/space.ts
@@ -94,13 +94,13 @@ type FeishuWikiSpaceParams =
 // Registration
 // ---------------------------------------------------------------------------
 
-export function registerFeishuWikiSpaceTool(api: OpenClawPluginApi) {
-  if (!api.config) return;
+export function registerFeishuWikiSpaceTool(api: OpenClawPluginApi): boolean {
+  if (!api.config) return false;
   const cfg = api.config;
 
   const { toolClient, log } = createToolContext(api, 'feishu_wiki_space');
 
-  registerTool(
+  return registerTool(
     api,
     {
       name: 'feishu_wiki_space',
@@ -212,5 +212,4 @@ export function registerFeishuWikiSpaceTool(api: OpenClawPluginApi) {
     },
     { name: 'feishu_wiki_space' },
   );
-
 }

--- a/src/tools/tat/im/index.ts
+++ b/src/tools/tat/im/index.ts
@@ -16,6 +16,7 @@ import { registerFeishuImBotImageTool } from './resource';
  * 其功能由 ChannelMessageActionAdapter (actions.ts) 的 react/delete action 统一覆盖。
  */
 export function registerFeishuImTools(api: OpenClawPluginApi) {
-  registerFeishuImBotImageTool(api);
-  api.logger.info?.('feishu_im: Registered feishu_im_bot_image');
+  if (registerFeishuImBotImageTool(api)) {
+    api.logger.info?.('feishu_im: Registered feishu_im_bot_image');
+  }
 }

--- a/src/tools/tat/im/resource.ts
+++ b/src/tools/tat/im/resource.ts
@@ -127,12 +127,12 @@ interface FeishuImBotImageParams {
   type: 'image' | 'file';
 }
 
-export function registerFeishuImBotImageTool(api: OpenClawPluginApi) {
-  if (!api.config) return;
+export function registerFeishuImBotImageTool(api: OpenClawPluginApi): boolean {
+  if (!api.config) return false;
 
   const { getClient, log } = createToolContext(api, 'feishu_im_bot_image');
 
-  registerTool(
+  return registerTool(
     api,
     {
       name: 'feishu_im_bot_image',
@@ -183,6 +183,4 @@ export function registerFeishuImBotImageTool(api: OpenClawPluginApi) {
     },
     { name: 'feishu_im_bot_image' },
   );
-
-  api.logger.info?.('feishu_im_bot_image: Registered feishu_im_bot_image tool');
 }


### PR DESCRIPTION
## Summary

When tools are in `channels.feishu.tools.deny`, the `registerTool` wrapper correctly skips them, but the module-level `index.ts` files unconditionally log `"Registered feishu_xxx, feishu_yyy"` — misleading users into thinking denied tools are still active.

## Changes

1. **`src/tools/helpers.ts`** — `registerTool()` now returns `boolean` (`true` = registered, `false` = denied/skipped)
2. **`src/tools/mcp/shared.ts`** — `registerMcpTool()` returns `boolean`
3. **16 registration sub-functions** — All return `boolean` (except `registerMessageReadTools` → `string[]`)
4. **8 module `index.ts` files** — Log only actually-registered tool names; suppress log entirely if all tools in the module are denied

## Before vs After

**Before** (deny `feishu_doc_comments`):
```
feishu_drive: Registered feishu_drive_file, feishu_doc_comments, feishu_doc_media
```

**After**:
```
feishu_drive: Registered feishu_drive_file, feishu_doc_media
```

If all tools in a module are denied, no log line is emitted at all.

## Files changed (26)

- `src/tools/helpers.ts`
- `src/tools/mcp/shared.ts`
- `src/tools/mcp/doc/index.ts`, `fetch.ts`, `create.ts`, `update.ts`
- `src/tools/oapi/chat/index.ts`, `chat.ts`, `members.ts`
- `src/tools/oapi/im/index.ts`, `message.ts`, `resource.ts`, `message-read.ts`
- `src/tools/oapi/drive/index.ts`, `doc-comments.ts`, `doc-media.ts`, `file.ts`
- `src/tools/oapi/wiki/index.ts`, `space.ts`, `space-node.ts`
- `src/tools/oapi/sheets/index.ts`, `sheet.ts`
- `src/tools/oapi/search/index.ts`, `doc-search.ts`
- `src/tools/tat/im/index.ts`, `resource.ts`

Fixes #122