### PR TITLE
feat: add partial comment support with block_id and range

### DIFF
--- a/src/core/tool-scopes.ts
+++ b/src/core/tool-scopes.ts
@@ -104,6 +104,8 @@ export type ToolActionKey =
   | 'feishu_chat.search'
   | 'feishu_chat_members.default'
   | 'feishu_create_doc.default'
+  | 'feishu_doc_blocks.get'
+  | 'feishu_doc_blocks.list'
   | 'feishu_doc_comments.create'
   | 'feishu_doc_comments.list'
   | 'feishu_doc_comments.patch'
@@ -261,6 +263,8 @@ export const TOOL_SCOPES: ToolScopeMapping = {
   'feishu_drive_file.download': ['drive:file:download'],
   'feishu_doc_media.download': ['board:whiteboard:node:read', 'docs:document.media:download'],
   'feishu_doc_media.insert': ['docx:document:write_only', 'docs:document.media:upload'],
+  'feishu_doc_blocks.list': ['wiki:node:read', 'docx:document:readonly'],
+  'feishu_doc_blocks.get': ['wiki:node:read', 'docx:document:readonly'],
   'feishu_doc_comments.list': ['wiki:node:read', 'docs:document.comment:read'],
   'feishu_doc_comments.create': ['wiki:node:read', 'docs:document.comment:create'],
   'feishu_doc_comments.patch': ['docs:document.comment:update'],

--- a/src/tools/oapi/drive/doc-blocks.ts
+++ b/src/tools/oapi/drive/doc-blocks.ts
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * feishu_doc_blocks tool -- 获取云文档块结构
+ *
+ * 用于获取文档的块(Block)结构，每个块有唯一的block_id
+ * 支持 wiki token 自动转换
+ */
+
+import type { OpenClawPluginApi } from 'openclaw/plugin-sdk';
+import { Type } from '@sinclair/typebox';
+import {
+  json,
+  createToolContext,
+  assertLarkOk,
+  handleInvokeErrorWithAutoAuth,
+  registerTool,
+  StringEnum,
+} from '../helpers';
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+const DocBlocksSchema = Type.Object({
+  file_token: Type.String({
+    description: '云文档token或wiki节点token(可从文档URL获取)。如果是wiki token，会自动转换为实际文档的obj_token',
+  }),
+  file_type: StringEnum(['docx', 'wiki'], {
+    description: '文档类型。wiki类型会自动解析为docx',
+  }),
+  block_id: Type.Optional(
+    Type.String({
+      description: '块ID(可选)。如果提供，则只获取该块的信息；否则获取所有块',
+    }),
+  ),
+  page_size: Type.Optional(
+    Type.Integer({
+      description: '分页大小(默认500)',
+      minimum: 1,
+      maximum: 500,
+    }),
+  ),
+  page_token: Type.Optional(
+    Type.String({
+      description: '分页标记',
+    }),
+  ),
+});
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerDocBlocksTool(api: OpenClawPluginApi) {
+  if (!api.config) return;
+
+  const { toolClient, log } = createToolContext(api, 'feishu_doc_blocks');
+
+  registerTool(
+    api,
+    {
+      name: 'feishu_doc_blocks',
+      label: 'Feishu: Doc Blocks',
+      description:
+        '【以用户身份】获取云文档的块结构。返回文档中所有块的block_id列表，用于局部评论等操作。支持 wiki token。',
+      parameters: DocBlocksSchema,
+      async execute(_toolCallId, params) {
+        const p = params;
+        try {
+          const client = toolClient();
+
+          // 如果是 wiki token，先转换为实际的 obj_token
+          let actualFileToken = p.file_token;
+          let actualFileType = p.file_type;
+
+          if (p.file_type === 'wiki') {
+            log.info(`doc_blocks: detected wiki token="${p.file_token}", converting to obj_token...`);
+            try {
+              const wikiNodeRes: any = await client.invoke(
+                'feishu_wiki_space_node.get',
+                (sdk: any, opts: any) =>
+                  sdk.wiki.space.getNode(
+                    {
+                      params: {
+                        token: p.file_token,
+                        obj_type: 'wiki',
+                      },
+                    },
+                    opts,
+                  ),
+                { as: 'user' },
+              );
+              assertLarkOk(wikiNodeRes);
+              const node = wikiNodeRes.data?.node;
+              if (!node || !node.obj_token || !node.obj_type) {
+                return json({
+                  error: `failed to resolve wiki token "${p.file_token}" to document object`,
+                  wiki_node: node,
+                });
+              }
+              actualFileToken = node.obj_token;
+              actualFileType = node.obj_type;
+              log.info(`doc_blocks: wiki token converted: obj_token="${actualFileToken}", obj_type="${actualFileType}"`);
+            } catch (err) {
+              log.error(`doc_blocks: failed to convert wiki token: ${err}`);
+              return json({
+                error: `failed to resolve wiki token "${p.file_token}": ${err}`,
+              });
+            }
+          }
+
+          // 如果提供了 block_id，获取单个块
+          if (p.block_id) {
+            log.info(`doc_blocks: getting block "${p.block_id}" from document "${actualFileToken}"`);
+            const res: any = await client.invoke(
+              'feishu_doc_blocks.get',
+              (sdk: any, opts: any) =>
+                sdk.docx.v1.documentBlock.get(
+                  {
+                    path: {
+                      document_id: actualFileToken,
+                      block_id: p.block_id,
+                    },
+                  },
+                  opts,
+                ),
+              { as: 'user' },
+            );
+            assertLarkOk(res);
+            return json({
+              block: res.data?.block,
+            });
+          }
+
+          // 否则获取所有块
+          log.info(`doc_blocks: listing blocks from document "${actualFileToken}"`);
+          const res: any = await client.invoke(
+            'feishu_doc_blocks.list',
+            (sdk: any, opts: any) =>
+              sdk.docx.v1.documentBlock.list(
+                {
+                  path: {
+                    document_id: actualFileToken,
+                  },
+                  params: {
+                    page_size: p.page_size || 500,
+                    page_token: p.page_token,
+                  },
+                },
+                opts,
+              ),
+            { as: 'user' },
+          );
+          assertLarkOk(res);
+
+          const items = res.data?.items || [];
+          log.info(`doc_blocks: found ${items.length} blocks`);
+
+          return json({
+            blocks: items,
+            has_more: res.data?.has_more ?? false,
+            page_token: res.data?.page_token,
+          });
+        } catch (err) {
+          return handleInvokeErrorWithAutoAuth(err, api, log);
+        }
+      },
+    },
+    { name: 'feishu_doc_blocks' },
+  );
+}

--- a/src/tools/oapi/drive/doc-comments.ts
+++ b/src/tools/oapi/drive/doc-comments.ts
@@ -66,6 +66,22 @@ const DocCommentsSchema = Type.Object({
       description: '评论内容元素数组(action=create时必填)。' + '支持text(纯文本)、mention(@用户)、link(超链接)三种类型',
     }),
   ),
+  block_id: Type.Optional(
+    Type.String({
+      description: '文档块ID(action=create时可选，用于局部评论)。指定后评论将锚定到该块。与range互斥。',
+    }),
+  ),
+  range: Type.Optional(
+    Type.Object(
+      {
+        index: Type.Integer({ description: '范围起始位置(从0开始的字符索引)' }),
+        length: Type.Integer({ description: '范围长度(字符数)' }),
+      },
+      {
+        description: '文本范围定位(action=create时可选，用于局部评论)。指定评论锚定的字符范围。与block_id互斥。',
+      },
+    ),
+  ),
   // patch action参数
   comment_id: Type.Optional(
     Type.String({
@@ -220,7 +236,7 @@ export function registerDocCommentsTool(api: OpenClawPluginApi) {
       description:
         '【以用户身份】管理云文档评论。支持: ' +
         '(1) list - 获取评论列表(含完整回复); ' +
-        '(2) create - 添加全文评论(支持文本、@用户、超链接); ' +
+        '(2) create - 添加全文评论或局部评论(支持文本、@用户、超链接；可通过block_id或range定位); ' +
         '(3) patch - 解决/恢复评论。' +
         '支持 wiki token。',
       parameters: DocCommentsSchema,
@@ -329,9 +345,42 @@ export function registerDocCommentsTool(api: OpenClawPluginApi) {
               });
             }
 
-            log.info(`doc_comments.create: file_token="${actualFileToken}", elements=${p.elements.length}`);
+            // 验证 block_id 和 range 互斥
+            if (p.block_id && p.range) {
+              return json({
+                error: 'block_id 和 range 参数互斥，只能指定其中一个',
+              });
+            }
+
+            log.info(
+              `doc_comments.create: file_token="${actualFileToken}", elements=${p.elements.length}, block_id=${p.block_id || 'none'}, range=${p.range ? JSON.stringify(p.range) : 'none'}`,
+            );
 
             const sdkElements = convertElementsToSDKFormat(p.elements);
+
+            // 构建请求数据
+            const requestData: any = {
+              reply_list: {
+                replies: [
+                  {
+                    content: {
+                      elements: sdkElements,
+                    },
+                  },
+                ],
+              },
+            };
+
+            // 如果提供了 block_id 或 range，添加到请求中
+            if (p.block_id) {
+              requestData.block_id = p.block_id;
+            }
+            if (p.range) {
+              requestData.range = {
+                index: p.range.index,
+                length: p.range.length,
+              };
+            }
 
             const res = await client.invoke(
               'feishu_doc_comments.create',
@@ -343,17 +392,7 @@ export function registerDocCommentsTool(api: OpenClawPluginApi) {
                       file_type: actualFileType,
                       user_id_type: userIdType,
                     },
-                    data: {
-                      reply_list: {
-                        replies: [
-                          {
-                            content: {
-                              elements: sdkElements,
-                            },
-                          },
-                        ],
-                      },
-                    },
+                    data: requestData,
                   },
                   opts,
                 ),

--- a/src/tools/oapi/drive/index.ts
+++ b/src/tools/oapi/drive/index.ts
@@ -12,6 +12,7 @@ import { resolveAnyEnabledToolsConfig } from '../../../core/tools-config';
 import { registerFeishuDriveFileTool } from './file';
 import { registerDocCommentsTool } from './doc-comments';
 import { registerDocMediaTool } from './doc-media';
+import { registerDocBlocksTool } from './doc-blocks';
 
 /**
  * 注册所有 Drive 工具
@@ -38,6 +39,7 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
   registerFeishuDriveFileTool(api);
   registerDocCommentsTool(api);
   registerDocMediaTool(api);
+  registerDocBlocksTool(api);
 
-  api.logger.info?.('feishu_drive: Registered feishu_drive_file, feishu_doc_comments, feishu_doc_media');
+  api.logger.info?.('feishu_drive: Registered feishu_drive_file, feishu_doc_comments, feishu_doc_media, feishu_doc_blocks');
 }


### PR DESCRIPTION
- Add support for partial comments (局部评论) in feishu_doc_comments tool
- New parameters: block_id (anchor to specific block) and range (text range)
- Add new feishu_doc_blocks tool to retrieve document block structure
- Update tool descriptions and scope configurations
- Supports wiki token auto-conversion

Resolves the need for localized document comments beyond full-document comments.