### PR TITLE
fix: replace enqueueSystemEvent with log to prevent timestamp cache busting

### DIFF
--- a/src/messaging/inbound/dispatch-context.ts
+++ b/src/messaging/inbound/dispatch-context.ts
@@ -117,10 +117,10 @@ export function buildDispatchContext(params: {
   }
   const tagStr = tags.length > 0 ? ` [${tags.join(', ')}]` : '';
 
-  core.system.enqueueSystemEvent(`Feishu[${account.accountId}] ${location} | ${sender}${tagStr}`, {
-    sessionKey: route.sessionKey,
-    contextKey: `feishu:message:${ctx.chatId}:${ctx.messageId}`,
-  });
+  // Log the event for debugging, but do NOT enqueue it as a system event.
+  // enqueueSystemEvent injects dynamic timestamps into the prompt pipeline,
+  // which busts Anthropic system prompt caching on every turn.
+  log(`Feishu[${account.accountId}] ${location} | ${sender}${tagStr}`);
 
   return {
     ctx,


### PR DESCRIPTION
## 插件层 `enqueueSystemEvent` 动态内容注入导致 Prompt Cache 命中率骤降

### 🔍 问题背景

在 OpenClaw 生态中，渠道插件（Channel Plugin）可通过框架提供的 `core.system.enqueueSystemEvent(...)` API 向运行时注入系统事件，用于记录消息来源、发送者身份、时间戳等上下文信息。

在老版本中，当飞书插件调用 `enqueueSystemEvent(...)` 时，框架层面会把捕捉到的这句包含发件人与时间戳的系统事件抓取出来（老版本的函数叫 `buildQueuedSystemPrompt`），然后通过类似 `extraSystemPromptParts.push(...)` 的代码，将其直接硬塞进了大模型的「系统提示词（System Prompt）」大块内部。

### ⚠️ 问题本质

主流大模型厂商（Anthropic / OpenAI / Google 等）的 Prompt Caching 机制均依赖**前缀匹配（Prefix Matching）**原则：

- **Anthropic**：对标记了 `cache_control` 的文本块计算哈希，块内容任何变动都会导致整个缓存块失效并触发全量重写；
- **OpenAI / Google Gemini**：采用隐式前缀缓存，从第 0 个 Token 开始逐一比对，一旦遇到分歧点，分歧点之后的所有内容（即使完全相同）都无法命中缓存。

致命问题：Anthropic 等大模型的 Prompt Cache 其实依赖于消息体的“最前缀”。如果高达几万 Token 的系统提示词哪怕变动了一个字符（比如变动了发件人的时间戳），整个 System Cache 都会宣告无效被重新计算。当插件注入的内容包含**每次请求都会变化的动态字段**（如消息时间戳 `14:32:01`、消息 ID 等），这些字段一旦被编入 System Prompt，就会导致：

1. 数万至数十万 Token 的 System Prompt 在每一轮对话中都被视为“全新内容”；
2. 缓存写入率高达 96%，但**读取命中率仅约 10%**——系统几乎每次都在付费创建缓存，却从未享受到缓存带来的降本加速；
3. 随着对话轮数增长，每轮请求需从头处理的上下文急剧膨胀，响应延迟不断攀升。

**该问题并非特定于某一渠道插件，而是所有通过 `enqueueSystemEvent` 注入动态上下文的通用性问题。** 只要插件注入的事件内容包含随请求变化的字段，就会破坏 System Prompt 的稳定性。

### ✅ 社区修复方案

在 3.13 版本中，为了彻底避免这一痛点，OpenClaw 团队做出了极其关键的重构：

1. **停止往 System Prompt 里塞入任何会随着单次请求而改变的变量**（如 message_id、发送者 ID、以及动态时间戳）；
2. **将通过 `enqueueSystemEvent` 搜罗来的日志的去向进行了转移**：从系统提示词降级、转移拼接到了「用户提示词」。

从 3.13 架构开始，最为庞大复杂的 System Prompt 真正做到了绝对静态（完全不变），所有变动的变量被移后了。即便飞书插件依然像以前那样往外推动态时间戳，这个时间戳如今也只能躺在用户发送的具体聊天气泡的最顶端（例如显示为 `System: [14:32:01] Feishu... \n\n User: 你好`）。大模型处理到用户层级时，前面的庞大系统设定早已利用 Cache 命中了。

修复后的数据流如下：

```
修复前：Plugin → enqueueSystemEvent → buildQueuedSystemPrompt → System Prompt[动态] → ❌ Cache Miss
修复后：Plugin → enqueueSystemEvent → drainFormattedSystemEvents → User Message Body → ✅ System Prompt 稳定命中缓存
```

### 📌 对插件开发者的建议

尽管核心框架已完成修复，但对于仍需兼容旧版本 OpenClaw（< 3.13）的插件、或希望进一步减少不必要开销的场景，建议：

- 审视插件中 `enqueueSystemEvent` 的调用点，评估其注入的内容是否确实需要被大模型感知；
- 对于纯调试 / 日志类信息（如消息路由追踪），可改用 `log()` / `debug()` 等日志机制，彻底避免进入 Prompt 管线；
- 参考本次飞书插件的改动，在 `dispatch-context` 中将非必要的系统事件降级为本地日志记录。

### 🔗 相关链接

- OpenClaw Issue [#49700](https://github.com/openclaw/openclaw/issues/49700) — System prompt dynamic content invalidates Anthropic prompt caching
