### PR TITLE
Handle Feishu folder messages without invalid file downloads

### DIFF
--- a/src/messaging/converters/folder.ts
+++ b/src/messaging/converters/folder.ts
@@ -26,6 +26,6 @@ export const convertFolder: ContentConverterFn = (raw) => {
 
   return {
     content: `<folder key="${fileKey}"${nameAttr}/>`,
-    resources: [{ type: 'file', fileKey, fileName: fileName || undefined }],
+    resources: [],
   };
 };

--- a/tests/folder-converter.test.ts
+++ b/tests/folder-converter.test.ts
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { convertFolder } from '../src/messaging/converters/folder.ts';
+
+test('convertFolder keeps folder placeholders without exposing downloadable file resources', () => {
+  const result = convertFolder(
+    JSON.stringify({
+      file_key: 'file_v3_01100_b5a280c5-d69a-4b5b-bfd7-1c0d116824bg',
+      file_name: 'hr-analysis',
+    }),
+    {} as never,
+  );
+
+  assert.equal(result.content, '<folder key="file_v3_01100_b5a280c5-d69a-4b5b-bfd7-1c0d116824bg" name="hr-analysis"/>');
+  assert.deepEqual(result.resources, []);
+});


### PR DESCRIPTION
Supersedes the closed #220 branch for the folder-specific follow-up.

This change stops treating `folder` message payloads as downloadable `file` resources. In current production, folder messages are converted into file resources and incorrectly routed to `im/v1/messages/{id}/resources/{file_key}?type=file`, which returns HTTP 400 for folder attachments.

Changes:
- keep the `<folder .../>` placeholder in message content
- stop injecting folder attachments into `resources` for auto-download
- add a regression test covering folder conversion behavior

This avoids false 400 download failures and lets the agent respond with the correct user guidance instead of attempting an unsupported IM resource download.