### PR TITLE
fix: reduce Feishu plugin registration log noise

### DIFF
--- a/src/tools/mcp/doc/index.ts
+++ b/src/tools/mcp/doc/index.ts
@@ -46,6 +46,6 @@ export function registerFeishuMcpDocTools(api: OpenClawPluginApi) {
   if (registerCreateDocTool(api)) registered.push('feishu_create_doc');
   if (registerUpdateDocTool(api)) registered.push('feishu_update_doc');
   if (registered.length > 0) {
-    api.logger.info?.(`feishu_doc: Registered ${registered.join(', ')}`);
+    api.logger.debug?.(`feishu_doc: Registered ${registered.join(', ')}`);
   }
 }

--- a/src/tools/oapi/chat/index.ts
+++ b/src/tools/oapi/chat/index.ts
@@ -16,6 +16,6 @@ export function registerFeishuChatTools(api: OpenClawPluginApi) {
   if (registerChatSearchTool(api)) registered.push('feishu_chat');
   if (registerChatMembersTool(api)) registered.push('feishu_chat_members');
   if (registered.length > 0) {
-    api.logger.info?.(`feishu_chat: Registered ${registered.join(', ')}`);
+    api.logger.debug?.(`feishu_chat: Registered ${registered.join(', ')}`);
   }
 }

--- a/src/tools/oapi/drive/index.ts
+++ b/src/tools/oapi/drive/index.ts
@@ -40,6 +40,6 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
   if (registerDocCommentsTool(api)) registered.push('feishu_doc_comments');
   if (registerDocMediaTool(api)) registered.push('feishu_doc_media');
   if (registered.length > 0) {
-    api.logger.info?.(`feishu_drive: Registered ${registered.join(', ')}`);
+    api.logger.debug?.(`feishu_drive: Registered ${registered.join(', ')}`);
   }
 }

--- a/src/tools/oapi/im/index.ts
+++ b/src/tools/oapi/im/index.ts
@@ -18,6 +18,6 @@ export function registerFeishuImTools(api: OpenClawPluginApi) {
   if (registerFeishuImUserFetchResourceTool(api)) registered.push('feishu_im_user_fetch_resource');
   registered.push(...registerMessageReadTools(api));
   if (registered.length > 0) {
-    api.logger.info?.(`feishu_im: Registered ${registered.join(', ')}`);
+    api.logger.debug?.(`feishu_im: Registered ${registered.join(', ')}`);
   }
 }

--- a/src/tools/oapi/index.ts
+++ b/src/tools/oapi/index.ts
@@ -85,5 +85,5 @@ export function registerOapiTools(api: OpenClawPluginApi) {
   // IM tools (bot identity)
   registerFeishuImBotTools(api);
 
-  api.logger.info?.('Registered all OAPI tools (calendar, task, bitable, search, drive, wiki, sheets, im)');
+  api.logger.debug?.('Registered all OAPI tools (calendar, task, bitable, search, drive, wiki, sheets, im)');
 }

--- a/src/tools/oapi/search/index.ts
+++ b/src/tools/oapi/search/index.ts
@@ -35,6 +35,6 @@ export function registerFeishuSearchTools(api: OpenClawPluginApi) {
 
   // 注册所有工具
   if (registerFeishuSearchDocWikiTool(api)) {
-    api.logger.info?.('feishu_search: Registered feishu_search_doc_wiki');
+    api.logger.debug?.('feishu_search: Registered feishu_search_doc_wiki');
   }
 }

--- a/src/tools/oapi/sheets/index.ts
+++ b/src/tools/oapi/sheets/index.ts
@@ -33,6 +33,6 @@ export function registerFeishuSheetsTools(api: OpenClawPluginApi) {
   }
 
   if (registerFeishuSheetTool(api)) {
-    api.logger.info?.('feishu_sheets: Registered feishu_sheet');
+    api.logger.debug?.('feishu_sheets: Registered feishu_sheet');
   }
 }

--- a/src/tools/oapi/wiki/index.ts
+++ b/src/tools/oapi/wiki/index.ts
@@ -38,6 +38,6 @@ export function registerFeishuWikiTools(api: OpenClawPluginApi) {
   if (registerFeishuWikiSpaceTool(api)) registered.push('feishu_wiki_space');
   if (registerFeishuWikiSpaceNodeTool(api)) registered.push('feishu_wiki_space_node');
   if (registered.length > 0) {
-    api.logger.info?.(`feishu_wiki: Registered ${registered.join(', ')}`);
+    api.logger.debug?.(`feishu_wiki: Registered ${registered.join(', ')}`);
   }
 }

--- a/src/tools/oauth-batch-auth.ts
+++ b/src/tools/oauth-batch-auth.ts
@@ -171,5 +171,5 @@ export function registerFeishuOAuthBatchAuthTool(api: OpenClawPluginApi) {
     { name: 'feishu_oauth_batch_auth' },
   );
 
-  api.logger.info?.('feishu_oauth_batch_auth: Registered feishu_oauth_batch_auth tool');
+  api.logger.debug?.('feishu_oauth_batch_auth: Registered feishu_oauth_batch_auth tool');
 }

--- a/src/tools/oauth.ts
+++ b/src/tools/oauth.ts
@@ -227,7 +227,7 @@ export function registerFeishuOAuthTool(api: OpenClawPluginApi) {
     { name: 'feishu_oauth' },
   );
 
-  api.logger.info?.('feishu_oauth: Registered feishu_oauth tool');
+  api.logger.debug?.('feishu_oauth: Registered feishu_oauth tool');
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/tat/im/index.ts
+++ b/src/tools/tat/im/index.ts
@@ -17,6 +17,6 @@ import { registerFeishuImBotImageTool } from './resource';
  */
 export function registerFeishuImTools(api: OpenClawPluginApi) {
   if (registerFeishuImBotImageTool(api)) {
-    api.logger.info?.('feishu_im: Registered feishu_im_bot_image');
+    api.logger.debug?.('feishu_im: Registered feishu_im_bot_image');
   }
 }


### PR DESCRIPTION
## Bug
https://github.com/larksuite/openclaw-lark/issues/213 — Feishu tool registration messages are emitted at info level on every OpenClaw command startup, which adds noisy output and unnecessary context churn.

## Fix
Downgraded Feishu tool registration logs from `info` to `debug` in all registration paths:
- OAPI tool modules (chat/search/drive/wiki/sheets/im + aggregate registration)
- MCP doc tool registration
- OAuth tool registration
- TAT IM registration

This keeps startup output clean at normal log level while preserving visibility when debug logging is enabled.

## Testing
- Confirmed the change is limited to log-level calls (`api.logger.info` → `api.logger.debug`) with no behavior changes.
- Tried to run `pnpm lint`, but lint tooling is not installed in this clean environment (`eslint: command not found`).

Happy to address any feedback.

Greetings, saschabuehrle
