### PR TITLE
fix: break circular dependency in converters

### DIFF
--- a/src/messaging/converters/content-converter.ts
+++ b/src/messaging/converters/content-converter.ts
@@ -14,26 +14,15 @@
 
 import type { MentionInfo } from '../types';
 import { converters } from './index';
-import { escapeRegExp } from './utils';
 import type { ApiMessageItem, ConvertContext, ConvertResult } from './types';
 import { getUserNameCache } from '../inbound/user-name-cache';
+import { extractMentionOpenId, resolveMentions } from './mention-utils';
 
 // Re-export types for convenience
 export type { ApiMessageItem, ConvertContext, ConvertResult, ContentConverterFn } from './types';
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/** 从 mention 的 id 字段提取 open_id（兼容事件推送的对象格式和 API 响应的字符串格式） */
-export function extractMentionOpenId(id: unknown): string {
-  if (typeof id === 'string') return id;
-  if (id != null && typeof id === 'object' && 'open_id' in id) {
-    const openId = (id as Record<string, unknown>).open_id;
-    return typeof openId === 'string' ? openId : '';
-  }
-  return '';
-}
+// Re-export mention utilities so existing consumers are not broken.
+export { extractMentionOpenId, resolveMentions } from './mention-utils';
 
 // ---------------------------------------------------------------------------
 // Convert
@@ -100,29 +89,3 @@ export function buildConvertContextFromItem(
   };
 }
 
-// ---------------------------------------------------------------------------
-// Mention resolution helper
-// ---------------------------------------------------------------------------
-
-/**
- * Resolve mention placeholders in text.
- *
- * - Bot mentions: remove the placeholder key and any preceding `@botName`
- *   entirely (with trailing whitespace).
- * - Non-bot mentions: replace the placeholder key with readable `@name`.
- */
-export function resolveMentions(text: string, ctx: ConvertContext): string {
-  if (ctx.mentions.size === 0) return text;
-
-  let result = text;
-  for (const [key, info] of ctx.mentions) {
-    if (info.isBot && ctx.stripBotMentions) {
-      // 仅在事件推送场景才删除 bot mention
-      result = result.replace(new RegExp(`@${escapeRegExp(info.name)}\\s*`, 'g'), '').trim();
-      result = result.replace(new RegExp(escapeRegExp(key) + '\\s*', 'g'), '').trim();
-    } else {
-      result = result.replace(new RegExp(escapeRegExp(key), 'g'), `@${info.name}`);
-    }
-  }
-  return result;
-}

--- a/src/messaging/converters/mention-utils.ts
+++ b/src/messaging/converters/mention-utils.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Mention extraction and resolution utilities.
+ *
+ * Extracted from content-converter.ts to break the circular dependency:
+ *   content-converter → index → {text, post} → content-converter
+ *
+ * Individual converters (text.ts, post.ts) import from this module
+ * instead of content-converter.ts.
+ */
+
+import type { MentionInfo } from '../types';
+import type { ConvertContext } from './types';
+import { escapeRegExp } from './utils';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** 从 mention 的 id 字段提取 open_id（兼容事件推送的对象格式和 API 响应的字符串格式） */
+export function extractMentionOpenId(id: unknown): string {
+  if (typeof id === 'string') return id;
+  if (id != null && typeof id === 'object' && 'open_id' in id) {
+    const openId = (id as Record<string, unknown>).open_id;
+    return typeof openId === 'string' ? openId : '';
+  }
+  return '';
+}
+
+// ---------------------------------------------------------------------------
+// Mention resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve mention placeholders in text.
+ *
+ * - Bot mentions: remove the placeholder key and any preceding `@botName`
+ *   entirely (with trailing whitespace).
+ * - Non-bot mentions: replace the placeholder key with readable `@name`.
+ */
+export function resolveMentions(text: string, ctx: ConvertContext): string {
+  if (ctx.mentions.size === 0) return text;
+
+  let result = text;
+  for (const [key, info] of ctx.mentions) {
+    if (info.isBot && ctx.stripBotMentions) {
+      // 仅在事件推送场景才删除 bot mention
+      result = result.replace(new RegExp(`@${escapeRegExp(info.name)}\\s*`, 'g'), '').trim();
+      result = result.replace(new RegExp(escapeRegExp(key) + '\\s*', 'g'), '').trim();
+    } else {
+      result = result.replace(new RegExp(escapeRegExp(key), 'g'), `@${info.name}`);
+    }
+  }
+  return result;
+}

--- a/src/messaging/converters/post.ts
+++ b/src/messaging/converters/post.ts
@@ -10,7 +10,7 @@
 
 import type { ResourceDescriptor } from '../types';
 import type { ContentConverterFn, ConvertContext, PostElement } from './types';
-import { resolveMentions } from './content-converter';
+import { resolveMentions } from './mention-utils';
 import { safeParse } from './utils';
 
 /** Preferred locale order for multi-language post unwrapping. */

--- a/src/messaging/converters/text.ts
+++ b/src/messaging/converters/text.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ContentConverterFn } from './types';
-import { resolveMentions } from './content-converter';
+import { resolveMentions } from './mention-utils';
 import { safeParse } from './utils';
 
 export const convertText: ContentConverterFn = (raw, ctx) => {

--- a/tests/circular-dep-cjs.test.ts
+++ b/tests/circular-dep-cjs.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Verify that the converter module graph can be loaded under CJS semantics
+ * (as Jiti / the openclaw framework would load it).
+ *
+ * Before the fix, this would throw:
+ *   ReferenceError: Cannot access 'utils_1' before initialization
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createJiti } from 'jiti';
+import { fileURLToPath } from 'node:url';
+import { resolve, dirname } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = resolve(dirname(__filename), '..');
+
+describe('circular dependency safety under CJS (jiti)', () => {
+  const jiti = createJiti(__filename, { interopDefault: true });
+
+  it('content-converter loads without ReferenceError', () => {
+    const mod = jiti(resolve(ROOT, 'src/messaging/converters/content-converter.ts'));
+    assert.strictEqual(typeof mod.convertMessageContent, 'function');
+    assert.strictEqual(typeof mod.resolveMentions, 'function');
+    assert.strictEqual(typeof mod.extractMentionOpenId, 'function');
+  });
+
+  it('text converter loads and can convert a simple message', () => {
+    const mod = jiti(resolve(ROOT, 'src/messaging/converters/text.ts'));
+    assert.strictEqual(typeof mod.convertText, 'function');
+
+    const ctx = {
+      mentions: new Map(),
+      mentionsByOpenId: new Map(),
+      messageId: 'test',
+    };
+    const result = mod.convertText('{"text":"hello"}', ctx);
+    assert.strictEqual(result.content, 'hello');
+  });
+
+  it('post converter loads and can convert a simple message', () => {
+    const mod = jiti(resolve(ROOT, 'src/messaging/converters/post.ts'));
+    assert.strictEqual(typeof mod.convertPost, 'function');
+
+    const ctx = {
+      mentions: new Map(),
+      mentionsByOpenId: new Map(),
+      messageId: 'test',
+    };
+    const result = mod.convertPost('{"title":"hi","content":[]}', ctx);
+    assert.ok(result.content.includes('hi'));
+  });
+});


### PR DESCRIPTION
## Summary

- Extract `resolveMentions` and `extractMentionOpenId` into `mention-utils.ts` to break the circular import chain: `content-converter → index → text/post → content-converter`
- Re-export from `content-converter.ts` to keep external API compatible
- Add jiti-based test to verify CJS loading works

## Root Cause

The converter modules had a circular dependency since the initial commit. This was safe under ESM (live bindings), but the 3.18 release changed the build output from ESM to CJS, exposing the cycle as `ReferenceError: Cannot access 'utils_1' before initialization` in group chat scenarios.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx tsx --test tests/circular-dep-cjs.test.ts` — loads converters via jiti (CJS semantics), verifies no ReferenceError
- [x] `npx tsx --test tests/folder-converter.test.ts` — existing test still passes

Fixes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)