### PR TITLE
Improve Feishu card layout splitting

### DIFF
--- a/src/card/markdown-splitter.ts
+++ b/src/card/markdown-splitter.ts
@@ -1,0 +1,124 @@
+import type { CardElement } from './builder';
+
+function normalizeBlockContent(content: string): string {
+  let s = String(content ?? '');
+  s = s.replace(/^\n+/, '').replace(/\n+$/, '');
+  s = s.replace(/[ \t]+$/gm, '');
+  s = s.replace(/\n{3,}/g, '\n\n');
+  return s.trim();
+}
+
+function isBoldTitleLine(line: string): boolean {
+  return /^\s*\*\*[^*]+\*\*\s*$/.test(line);
+}
+
+function isListLikeLine(line: string): boolean {
+  return /^\s*(?:[-*+]\s+|\d+\.\s+|\d+\)\s+|\d+、\s+|[•·]\s+)/.test(line);
+}
+
+function isTableLine(trimmed: string): boolean {
+  return trimmed.startsWith('|') && trimmed.endsWith('|');
+}
+
+function isFenceLine(trimmed: string): boolean {
+  return trimmed.startsWith('```');
+}
+
+function createMarkdownElement(content: string): CardElement {
+  return {
+    tag: 'markdown',
+    content: normalizeBlockContent(content),
+  };
+}
+
+export function splitMarkdownToElements(markdown: string): CardElement[] {
+  const text = String(markdown ?? '');
+  const lines = text.split('\n');
+
+  const elements: CardElement[] = [];
+  let current: string[] = [];
+
+  let inCodeBlock = false;
+  let inTable = false;
+  let inList = false;
+
+  const flush = () => {
+    if (current.length === 0) return;
+    const normalized = normalizeBlockContent(current.join('\n'));
+    if (normalized) elements.push(createMarkdownElement(normalized));
+    current = [];
+    inList = false;
+  };
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const trimmed = line.trim();
+
+    if (/^-{3,}$/.test(trimmed)) {
+      flush();
+      continue;
+    }
+
+    if (!inCodeBlock && isFenceLine(trimmed)) {
+      flush();
+      inCodeBlock = true;
+      current.push(line);
+      continue;
+    }
+
+    if (inCodeBlock) {
+      current.push(line);
+      if (isFenceLine(trimmed)) {
+        inCodeBlock = false;
+        flush();
+      }
+      continue;
+    }
+
+    const table = isTableLine(trimmed);
+    if (table && !inTable) {
+      flush();
+      inTable = true;
+      current.push(line);
+      continue;
+    }
+
+    if (inTable) {
+      if (table) {
+        current.push(line);
+        continue;
+      }
+      flush();
+      inTable = false;
+    }
+
+    if (!trimmed) {
+      flush();
+      continue;
+    }
+
+    const list = isListLikeLine(line);
+    if (list) {
+      if (!inList) {
+        if (current.length === 1 && isBoldTitleLine(current[0])) {
+          inList = true;
+          current.push(line);
+          continue;
+        }
+        flush();
+        inList = true;
+      }
+      current.push(line);
+      continue;
+    }
+
+    if (inList) {
+      flush();
+    }
+
+    current.push(line);
+  }
+
+  flush();
+  return elements;
+}

--- a/src/card/markdown-style.ts
+++ b/src/card/markdown-style.ts
@@ -75,6 +75,7 @@ function _optimizeMarkdownStyle(text: string, cardVersion = 2): string {
   }
 
   // ── 6. 压缩多余空行（3 个以上连续换行 → 2 个）────────────────────
+  r = r.replace(/^\s*-{3,}\s*$/gm, '');
   r = r.replace(/\n{3,}/g, '\n\n');
 
   return r;

--- a/src/card/reply-mode.ts
+++ b/src/card/reply-mode.ts
@@ -37,7 +37,7 @@ export function resolveReplyMode(params: {
   const replyMode = feishuCfg?.replyMode;
   if (!replyMode) return 'auto';
 
-  if (typeof replyMode === 'string') return replyMode;
+  if (typeof replyMode === 'string') return replyMode as ReplyModeValue;
 
   // Object form: pick scene-specific value
   const sceneMode = chatType === 'group' ? replyMode.group : chatType === 'p2p' ? replyMode.direct : undefined;
@@ -75,13 +75,14 @@ export function expandAutoMode(params: {
  * markdown tables).
  */
 export function shouldUseCard(text: string): boolean {
-  // Fenced code blocks
-  if (/```[\s\S]*?```/.test(text)) {
-    return true;
-  }
-  // Markdown tables (header + separator rows separated by pipes)
-  if (/\|.+\|[\r\n]+\|[-:| ]+\|/.test(text)) {
-    return true;
-  }
+  const t = String(text ?? '');
+
+  if (/```[\s\S]*?```/.test(t)) return true;
+  if (/\|.+\|[\r\n]+\|[-:| ]+\|/.test(t)) return true;
+  if (/^\s*(?:[-*+]\s+|[•·]\s+|\d+[.)]\s+|\d+、\s+)/m.test(t)) return true;
+
+  const newlines = (t.match(/\n/g) ?? []).length;
+  if (t.length >= 2000 && newlines >= 20) return true;
+
   return false;
 }

--- a/src/messaging/outbound/actions.ts
+++ b/src/messaging/outbound/actions.ts
@@ -23,10 +23,12 @@ import { extractToolSend, jsonResult, readStringParam, readReactionParams } from
 
 import { addReactionFeishu, removeReactionFeishu, listReactionsFeishu } from './reactions';
 import { sendTextLark, sendCardLark } from './deliver';
+import { sendMarkdownCardFeishu } from './send';
 import { uploadAndSendMediaLark } from './media';
 import { LarkClient } from '../../core/lark-client';
 import { getEnabledLarkAccounts } from '../../core/accounts';
 import { larkLogger } from '../../core/lark-logger';
+import { shouldUseCard } from '../../card/reply-mode';
 
 const log = larkLogger('outbound/actions');
 
@@ -257,6 +259,19 @@ async function deliverMessage(
   }
 
   // Text-only path.
+  if (shouldUseCard(text)) {
+    const result = await sendMarkdownCardFeishu({
+      cfg,
+      to,
+      text,
+      replyToMessageId,
+      replyInThread,
+      accountId,
+    });
+    log.info(`deliverMessage: markdown card sent, messageId=${result.messageId}`);
+    return jsonResult({ ok: true, messageId: result.messageId, chatId: result.chatId });
+  }
+
   const result = await sendTextLark({ ...sendCtx, text });
   log.info(`deliverMessage: text sent, messageId=${result.messageId}`);
   return jsonResult({ ok: true, messageId: result.messageId, chatId: result.chatId });

--- a/src/messaging/outbound/send.ts
+++ b/src/messaging/outbound/send.ts
@@ -13,6 +13,7 @@ import { normalizeFeishuTarget, normalizeMessageId, resolveReceiveIdType } from 
 import { runWithMessageUnavailableGuard } from '../../core/message-unavailable';
 import type { MentionInfo } from '../types';
 import { optimizeMarkdownStyle } from '../../card/markdown-style';
+import { splitMarkdownToElements } from '../../card/markdown-splitter';
 import { buildMentionedMessage, buildMentionedCardContent } from '../inbound/mention';
 
 // ---------------------------------------------------------------------------
@@ -334,7 +335,8 @@ export async function updateCardFeishu(params: {
  * @returns A card JSON object ready to be sent via {@link sendCardFeishu}.
  */
 export function buildMarkdownCard(text: string): Record<string, unknown> {
-  const optimizedText = optimizeMarkdownStyle(text);
+  const optimizedText = optimizeMarkdownStyle(text, 1);
+  const elements = splitMarkdownToElements(optimizedText);
 
   return {
     schema: '2.0',
@@ -342,12 +344,7 @@ export function buildMarkdownCard(text: string): Record<string, unknown> {
       wide_screen_mode: true,
     },
     body: {
-      elements: [
-        {
-          tag: 'markdown',
-          content: optimizedText,
-        },
-      ],
+      elements: elements.length > 0 ? elements : [{ tag: 'markdown', content: '' }],
     },
   };
 }


### PR DESCRIPTION
优雅解决 markdown 垂直间距问题：

1. **Markdown 预处理**：markdown 输出的时候压缩空行，禁止出现3个及以上的 \n
2. **多elements架构**：在 markdown  输出结束进行后处理**拆分多elements**：
3. 样式约束：
- 一个主题只允许出现一个 5 级标题，其余用 **加粗**替代标题；
- 不同类型 markdown 语法自成一个独立element，比如表格、代码块、文本段落，标题
- 限制 --- 分割内容，用卡片的垂直间距自然分割
- 小节标题+段落 （**标题** \n正文）或者 小节标题+列表（**标题** \n- 正文｜1. 正文）合并一个 element

4. 更新逻辑：如果开启streaming；流式结束后全量更新elements的卡片否则直接调用卡片发送接口发送后处理的多elements结构卡片目标：段落间距稳定、视觉层级清晰表格/代码块不再被横线分隔流式更新间可控，卡片结构更稳定同样的内容在静态/流式链路保持一致排版
