### PR TITLE
fix: migrate plugin-sdk imports for OpenClaw 2026.3.22 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "execa": "^9.6.0",
     "fs-extra": "^11.3.2",
     "minimist": "^1.2.8",
-    "openclaw": "2026.2.26",
+    "openclaw": "2026.3.22",
     "prettier": "^3.8.1",
     "typescript": "^5.9.3"
   },

--- a/src/card/reply-dispatcher.ts
+++ b/src/card/reply-dispatcher.ts
@@ -11,12 +11,9 @@
  * 4. Assembles and returns FeishuReplyDispatcherResult
  */
 
-import {
-  createReplyPrefixContext,
-  createTypingCallbacks,
-  logTypingFailure,
-  type ReplyPayload,
-} from 'openclaw/plugin-sdk';
+import type { ReplyPayload } from 'openclaw/plugin-sdk';
+import { createReplyPrefixContext, createTypingCallbacks } from 'openclaw/plugin-sdk/channel-runtime';
+import { logTypingFailure } from 'openclaw/plugin-sdk/channel-feedback';
 import { createAccountScopedConfig, getLarkAccount } from '../core/accounts';
 import { resolveFooterConfig } from '../core/footer-config';
 import { LarkClient } from '../core/lark-client';

--- a/src/card/streaming-card-controller.ts
+++ b/src/card/streaming-card-controller.ts
@@ -11,7 +11,8 @@
  * detection to UnavailableGuard.
  */
 
-import { SILENT_REPLY_TOKEN, type ReplyPayload } from 'openclaw/plugin-sdk';
+import type { ReplyPayload } from 'openclaw/plugin-sdk';
+import { SILENT_REPLY_TOKEN } from 'openclaw/plugin-sdk/reply-runtime';
 import { extractLarkApiCode } from '../core/api-error';
 import { larkLogger } from '../core/lark-logger';
 import { sendCardFeishu, updateCardFeishu } from '../messaging/outbound/send';

--- a/src/channel/config-adapter.ts
+++ b/src/channel/config-adapter.ts
@@ -11,7 +11,7 @@
  */
 
 import type { ClawdbotConfig } from 'openclaw/plugin-sdk';
-import { DEFAULT_ACCOUNT_ID } from 'openclaw/plugin-sdk';
+import { DEFAULT_ACCOUNT_ID } from 'openclaw/plugin-sdk/account-id';
 import type { FeishuConfig } from '../core/types';
 import { getLarkAccount, getLarkAccountIds } from '../core/accounts';
 import { collectIsolationWarnings } from '../core/security-check';

--- a/src/channel/monitor.ts
+++ b/src/channel/monitor.ts
@@ -9,7 +9,8 @@
  * appropriate handlers.
  */
 
-import type { ClawdbotConfig, RuntimeEnv, HistoryEntry } from 'openclaw/plugin-sdk';
+import type { ClawdbotConfig, RuntimeEnv } from 'openclaw/plugin-sdk';
+import type { HistoryEntry } from 'openclaw/plugin-sdk/reply-history';
 import { getLarkAccount, getEnabledLarkAccounts } from '../core/accounts';
 import { LarkClient } from '../core/lark-client';
 import { MessageDedup } from '../messaging/inbound/dedup';

--- a/src/channel/onboarding-config.ts
+++ b/src/channel/onboarding-config.ts
@@ -9,8 +9,11 @@
  * in CLI commands and other configuration flows.
  */
 
-import type { ClawdbotConfig, DmPolicy } from 'openclaw/plugin-sdk';
-import { addWildcardAllowFrom } from 'openclaw/plugin-sdk';
+import type { ClawdbotConfig } from 'openclaw/plugin-sdk';
+import { addWildcardAllowFrom } from 'openclaw/plugin-sdk/setup';
+
+// Mirrors openclaw DmPolicy values (removed from plugin-sdk exports in 2026.3.22)
+type DmPolicy = 'pairing' | 'allowlist' | 'open' | 'disabled';
 
 // ---------------------------------------------------------------------------
 // Config mutation helpers

--- a/src/channel/onboarding.ts
+++ b/src/channel/onboarding.ts
@@ -4,18 +4,18 @@
  *
  * Onboarding wizard adapter for the Lark/Feishu channel plugin.
  *
- * Implements the ChannelOnboardingAdapter interface so the `openclaw
+ * Implements the ChannelSetupWizardAdapter interface so the `openclaw
  * setup` wizard can configure Feishu credentials, domain, group
  * policies, and DM allowlists interactively.
  */
 
 import type {
-  ChannelOnboardingAdapter,
-  ChannelOnboardingDmPolicy,
   ClawdbotConfig,
   WizardPrompter,
 } from 'openclaw/plugin-sdk';
-import { DEFAULT_ACCOUNT_ID, formatDocsLink } from 'openclaw/plugin-sdk';
+import type { ChannelSetupWizardAdapter, ChannelSetupDmPolicy } from 'openclaw/plugin-sdk/setup';
+import { DEFAULT_ACCOUNT_ID } from 'openclaw/plugin-sdk/account-id';
+import { formatDocsLink } from 'openclaw/plugin-sdk/setup';
 import type { FeishuConfig } from '../core/types';
 import { getLarkCredentials } from '../core/accounts';
 import { probeFeishu } from './probe';
@@ -178,7 +178,7 @@ async function acquireCredentials(params: {
 // DM policy
 // ---------------------------------------------------------------------------
 
-const dmPolicy: ChannelOnboardingDmPolicy = {
+const dmPolicy: ChannelSetupDmPolicy = {
   label: 'Feishu',
   channel,
   policyKey: 'channels.feishu.dmPolicy',
@@ -192,7 +192,7 @@ const dmPolicy: ChannelOnboardingDmPolicy = {
 // Adapter
 // ---------------------------------------------------------------------------
 
-export const feishuOnboardingAdapter: ChannelOnboardingAdapter = {
+export const feishuOnboardingAdapter: ChannelSetupWizardAdapter = {
   channel,
 
   // -----------------------------------------------------------------------

--- a/src/channel/plugin.ts
+++ b/src/channel/plugin.ts
@@ -9,8 +9,10 @@
  * start the inbound event gateway.
  */
 
-import type { ChannelMeta, ChannelPlugin, ChannelThreadingToolContext, ClawdbotConfig } from 'openclaw/plugin-sdk';
-import { DEFAULT_ACCOUNT_ID, PAIRING_APPROVED_MESSAGE } from 'openclaw/plugin-sdk';
+import type { ChannelPlugin, ClawdbotConfig } from 'openclaw/plugin-sdk';
+import type { ChannelThreadingToolContext } from 'openclaw/plugin-sdk/channel-contract';
+import { DEFAULT_ACCOUNT_ID } from 'openclaw/plugin-sdk/account-id';
+import { PAIRING_APPROVED_MESSAGE } from 'openclaw/plugin-sdk/channel-status';
 import type { LarkAccount } from '../core/types';
 import { getLarkAccount, getLarkAccountIds, getDefaultLarkAccountId } from '../core/accounts';
 import {
@@ -19,7 +21,6 @@ import {
   listFeishuDirectoryPeersLive,
   listFeishuDirectoryGroupsLive,
 } from './directory';
-import { feishuOnboardingAdapter } from './onboarding';
 import { feishuOutbound } from '../messaging/outbound/outbound';
 import { feishuMessageActions } from '../messaging/outbound/actions';
 import { resolveFeishuGroupToolPolicy } from '../messaging/inbound/policy';
@@ -59,7 +60,7 @@ function adaptDirectoryParams(params: {
 // Meta
 // ---------------------------------------------------------------------------
 
-const meta: ChannelMeta = {
+const meta = {
   id: 'feishu',
   label: 'Feishu',
   selectionLabel: 'Lark/Feishu (\u98DE\u4E66)',
@@ -218,12 +219,6 @@ export const feishuPlugin: ChannelPlugin<LarkAccount> = {
       return applyAccountConfig(cfg, accountId, { enabled: true });
     },
   },
-
-  // -------------------------------------------------------------------------
-  // Onboarding
-  // -------------------------------------------------------------------------
-
-  onboarding: feishuOnboardingAdapter,
 
   // -------------------------------------------------------------------------
   // Messaging

--- a/src/channel/types.ts
+++ b/src/channel/types.ts
@@ -5,7 +5,8 @@
  * Channel type definitions for the Lark/Feishu channel plugin.
  */
 
-import type { ClawdbotConfig, RuntimeEnv, HistoryEntry } from 'openclaw/plugin-sdk';
+import type { ClawdbotConfig, RuntimeEnv } from 'openclaw/plugin-sdk';
+import type { HistoryEntry } from 'openclaw/plugin-sdk/reply-history';
 import type { LarkClient } from '../core/lark-client';
 import type { MessageDedup } from '../messaging/inbound/dedup';
 

--- a/src/core/accounts.ts
+++ b/src/core/accounts.ts
@@ -9,7 +9,7 @@
  * unset fields fall back to the top-level defaults.
  */
 
-import { DEFAULT_ACCOUNT_ID, normalizeAccountId as _sdkNormalizeAccountId } from 'openclaw/plugin-sdk';
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId as _sdkNormalizeAccountId } from 'openclaw/plugin-sdk/account-id';
 
 const normalizeAccountId: (id: string) => string | undefined =
     typeof _sdkNormalizeAccountId === 'function'

--- a/src/messaging/inbound/dispatch-builders.ts
+++ b/src/messaging/inbound/dispatch-builders.ts
@@ -9,8 +9,8 @@
  * never perform I/O, send messages, or mutate external state.
  */
 
-import type { HistoryEntry } from 'openclaw/plugin-sdk';
-import { buildPendingHistoryContextFromMap } from 'openclaw/plugin-sdk';
+import type { HistoryEntry } from 'openclaw/plugin-sdk/reply-history';
+import { buildPendingHistoryContextFromMap } from 'openclaw/plugin-sdk/reply-history';
 import type { MessageContext } from '../types';
 import type { DispatchContext } from './dispatch-context';
 import { LarkClient } from '../../core/lark-client';

--- a/src/messaging/inbound/dispatch-context.ts
+++ b/src/messaging/inbound/dispatch-context.ts
@@ -10,7 +10,7 @@
  */
 
 import type { ClawdbotConfig, RuntimeEnv } from 'openclaw/plugin-sdk';
-import { resolveThreadSessionKeys } from 'openclaw/plugin-sdk';
+import { resolveThreadSessionKeys } from 'openclaw/plugin-sdk/core';
 import type { MessageContext } from '../types';
 import type { LarkAccount } from '../../core/types';
 import { LarkClient } from '../../core/lark-client';

--- a/src/messaging/inbound/dispatch.ts
+++ b/src/messaging/inbound/dispatch.ts
@@ -14,8 +14,9 @@
  * - dispatch-commands.ts — system command & permission notification
  */
 
-import type { RuntimeEnv, HistoryEntry } from 'openclaw/plugin-sdk';
-import { clearHistoryEntriesIfEnabled } from 'openclaw/plugin-sdk';
+import type { RuntimeEnv } from 'openclaw/plugin-sdk';
+import type { HistoryEntry } from 'openclaw/plugin-sdk/reply-history';
+import { clearHistoryEntriesIfEnabled } from 'openclaw/plugin-sdk/reply-history';
 import type { MessageContext } from '../types';
 import type { LarkAccount } from '../../core/types';
 import type { FeishuGroupConfig } from '../../core/types';

--- a/src/messaging/inbound/gate.ts
+++ b/src/messaging/inbound/gate.ts
@@ -23,7 +23,8 @@
  *       `"disabled"` → block all senders
  */
 
-import type { ClawdbotConfig, HistoryEntry } from 'openclaw/plugin-sdk';
+import type { ClawdbotConfig } from 'openclaw/plugin-sdk';
+import type { HistoryEntry } from 'openclaw/plugin-sdk/reply-history';
 import type { MessageContext } from '../types';
 import type { FeishuConfig } from '../../core/types';
 import type { LarkAccount } from '../../core/types';

--- a/src/messaging/inbound/handler.ts
+++ b/src/messaging/inbound/handler.ts
@@ -15,13 +15,10 @@
  */
 
 import type { ClawdbotConfig, RuntimeEnv } from 'openclaw/plugin-sdk';
-import {
-  recordPendingHistoryEntryIfEnabled,
-  DEFAULT_GROUP_HISTORY_LIMIT,
-  resolveSenderCommandAuthorization,
-  isNormalizedSenderAllowed,
-  type HistoryEntry,
-} from 'openclaw/plugin-sdk';
+import type { HistoryEntry } from 'openclaw/plugin-sdk/reply-history';
+import { recordPendingHistoryEntryIfEnabled, DEFAULT_GROUP_HISTORY_LIMIT } from 'openclaw/plugin-sdk/reply-history';
+import { resolveSenderCommandAuthorization } from 'openclaw/plugin-sdk/command-auth';
+import { isNormalizedSenderAllowed } from 'openclaw/plugin-sdk/allow-from';
 import type { FeishuMessageEvent } from '../types';
 import { getLarkAccount } from '../../core/accounts';
 import { LarkClient } from '../../core/lark-client';

--- a/src/messaging/inbound/policy.ts
+++ b/src/messaging/inbound/policy.ts
@@ -8,7 +8,8 @@
  * extraction, and group access checks.
  */
 
-import type { ChannelGroupContext, GroupToolPolicyConfig } from 'openclaw/plugin-sdk';
+import type { ChannelGroupContext } from 'openclaw/plugin-sdk/channel-contract';
+import type { GroupToolPolicyConfig } from 'openclaw/plugin-sdk/channel-policy';
 import type { FeishuConfig, FeishuGroupConfig } from '../../core/types';
 import { getLarkAccount } from '../../core/accounts';
 

--- a/src/messaging/inbound/reaction-handler.ts
+++ b/src/messaging/inbound/reaction-handler.ts
@@ -15,8 +15,9 @@
  */
 
 import * as crypto from 'node:crypto';
-import type { ClawdbotConfig, RuntimeEnv, HistoryEntry } from 'openclaw/plugin-sdk';
-import { DEFAULT_GROUP_HISTORY_LIMIT } from 'openclaw/plugin-sdk';
+import type { ClawdbotConfig, RuntimeEnv } from 'openclaw/plugin-sdk';
+import type { HistoryEntry } from 'openclaw/plugin-sdk/reply-history';
+import { DEFAULT_GROUP_HISTORY_LIMIT } from 'openclaw/plugin-sdk/reply-history';
 import type { FeishuReactionCreatedEvent } from '../types';
 import type { MessageContext } from '../types';
 import { getLarkAccount } from '../../core/accounts';

--- a/src/messaging/outbound/actions.ts
+++ b/src/messaging/outbound/actions.ts
@@ -16,10 +16,12 @@
 import type {
   ChannelMessageActionAdapter,
   ChannelMessageActionName,
-  ChannelThreadingToolContext,
   OpenClawConfig,
 } from 'openclaw/plugin-sdk';
-import { extractToolSend, jsonResult, readStringParam, readReactionParams } from 'openclaw/plugin-sdk';
+import type { ChannelThreadingToolContext } from 'openclaw/plugin-sdk/channel-contract';
+import { extractToolSend } from 'openclaw/plugin-sdk/tool-send';
+import { readStringParam } from 'openclaw/plugin-sdk/param-readers';
+import { jsonResult, readReactionParams } from 'openclaw/plugin-sdk/agent-runtime';
 
 import { addReactionFeishu, removeReactionFeishu, listReactionsFeishu } from './reactions';
 import { sendTextLark, sendCardLark } from './deliver';
@@ -158,16 +160,19 @@ function readFeishuSendParams(
 // ---------------------------------------------------------------------------
 
 export const feishuMessageActions: ChannelMessageActionAdapter = {
-  listActions: ({ cfg }) => {
+  describeMessageTool: ({ cfg }) => {
     const accounts = getEnabledLarkAccounts(cfg);
-    if (accounts.length === 0) return [];
-    return Array.from(SUPPORTED_ACTIONS);
+    if (accounts.length === 0) {
+      return { actions: [], capabilities: [], schema: null };
+    }
+    return {
+      actions: Array.from(SUPPORTED_ACTIONS),
+      capabilities: ['cards'],
+      schema: null,
+    };
   },
 
   supportsAction: ({ action }) => SUPPORTED_ACTIONS.has(action),
-
-  supportsButtons: ({ cfg }) => getEnabledLarkAccounts(cfg).length > 0,
-  supportsCards: ({ cfg }) => getEnabledLarkAccounts(cfg).length > 0,
 
   extractToolSend: ({ args }) => extractToolSend(args, 'sendMessage'),
 

--- a/src/messaging/outbound/outbound.ts
+++ b/src/messaging/outbound/outbound.ts
@@ -11,7 +11,8 @@
  * parameters and delegates to standalone sending functions.
  */
 
-import type { ChannelOutboundAdapter, ClawdbotConfig } from 'openclaw/plugin-sdk';
+import type { ClawdbotConfig } from 'openclaw/plugin-sdk';
+import type { ChannelOutboundAdapter } from 'openclaw/plugin-sdk/channel-send-result';
 import type { FeishuSendResult } from '../types';
 import { LarkClient } from '../../core/lark-client';
 import { sendTextLark, sendMediaLark, sendCardLark } from './deliver';

--- a/src/tools/oapi/im/resource.ts
+++ b/src/tools/oapi/im/resource.ts
@@ -11,7 +11,7 @@
  */
 
 import type { OpenClawPluginApi } from 'openclaw/plugin-sdk';
-import { buildRandomTempFilePath } from 'openclaw/plugin-sdk';
+import { buildRandomTempFilePath } from 'openclaw/plugin-sdk/temp-path';
 import { Type } from '@sinclair/typebox';
 import { json, createToolContext, handleInvokeErrorWithAutoAuth, registerTool, StringEnum } from '../helpers';
 import * as fs from 'node:fs/promises';

--- a/src/tools/tat/im/resource.ts
+++ b/src/tools/tat/im/resource.ts
@@ -13,7 +13,7 @@
  */
 
 import type { OpenClawPluginApi } from 'openclaw/plugin-sdk';
-import { buildRandomTempFilePath } from 'openclaw/plugin-sdk';
+import { buildRandomTempFilePath } from 'openclaw/plugin-sdk/temp-path';
 import { Type } from '@sinclair/typebox';
 import { json, createToolContext, formatLarkError, registerTool, StringEnum } from '../../oapi/helpers';
 import * as fsPromises from 'node:fs/promises';


### PR DESCRIPTION
## Summary

OpenClaw 2026.3.22 split the `openclaw/plugin-sdk` barrel export into sub-path modules, causing runtime `Cannot find module` / `is not a function` errors for all plugins still importing from the main entry.

This PR:
- Migrates all runtime imports across 21 files to their correct sub-path exports (e.g. `openclaw/plugin-sdk/account-id`, `openclaw/plugin-sdk/reply-history`, `openclaw/plugin-sdk/channel-runtime`, etc.)
- Adapts to API changes: `listActions` -> `describeMessageTool` (new return shape with `actions`, `capabilities`, `schema`), removes deprecated `supportsButtons`/`supportsCards`
- Removes the `onboarding` property from `feishuPlugin` (replaced by `setup` wizard in 3.22), renames `ChannelOnboardingAdapter` -> `ChannelSetupWizardAdapter`
- Inlines `DmPolicy` type (no longer exported from any sub-path)
- Bumps `openclaw` devDependency from `2026.2.26` to `2026.3.22`

Type-only imports (`import type`) remain on the main `openclaw/plugin-sdk` entry where the `.d.ts` still exports them, maximizing backward compatibility.

Resolves #254, #256, #257, #258

## Files changed (21)

| Area | Files | Changes |
|------|-------|---------|
| Core | `accounts.ts` | `DEFAULT_ACCOUNT_ID`, `normalizeAccountId` -> `account-id` |
| Channel | `plugin.ts`, `config-adapter.ts`, `monitor.ts`, `types.ts` | Sub-path imports, remove `onboarding` property, remove `ChannelMeta` annotation |
| Onboarding | `onboarding.ts`, `onboarding-config.ts` | Rename types, inline `DmPolicy`, `addWildcardAllowFrom` -> `setup` |
| Inbound | `handler.ts`, `gate.ts`, `dispatch.ts`, `dispatch-builders.ts`, `dispatch-context.ts`, `reaction-handler.ts`, `policy.ts` | `reply-history`, `command-auth`, `allow-from`, `core`, `channel-contract`, `channel-policy` |
| Outbound | `actions.ts`, `outbound.ts` | `describeMessageTool` API, `tool-send`, `param-readers`, `agent-runtime`, `channel-send-result` |
| Card | `reply-dispatcher.ts`, `streaming-card-controller.ts` | `channel-runtime`, `channel-feedback`, `reply-runtime` |
| Tools | `oapi/im/resource.ts`, `tat/im/resource.ts` | `buildRandomTempFilePath` -> `temp-path` |

## Test plan

- [x] `npx tsc --noEmit` passes with zero errors
- [x] `npx tsc --declaration --outDir dist` compiles all 171 modules successfully
- [x] `esbuild` CJS build produces working dist output
- [x] Deploy to `~/.openclaw/extensions/openclaw-lark/`, restart gateway, plugin loads without errors
- [x] Send DM via Feishu, message received and replied normally