### PR TITLE
Add Tenant Access Token (TAT) support for MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,41 +30,41 @@ Additionally, the plugin supports:
 - **🌊 Streaming Responses**: Live streaming text directly within message cards
 - **🔒 Permission Policies**: Flexible access control policies for DMs and group chats
 - **⚙️ Advanced Group Configuration**: Per-group settings including allowlists, skill bindings, and custom system prompts
-- **🔑 MCP Auth Mode** (This Fork): Support for `user`/`tenant`/`auto` authentication modes for MCP tools. See [TAT Support](#tat-support) below.
+- **🔑 MCP Auth Mode** (This Fork): Supports `user` / `tenant` / `auto`, while respecting per-tool compatibility (`UAT-only` / `UAT+TAT`). See [TAT Support](#tat-support) below.
 
 ---
 
 ## 🆕 TAT Support (This Fork)
 
-This fork adds **Tenant Access Token (TAT) support** for MCP tools, allowing them to operate with application-level permissions without requiring individual user authorization.
+This fork adds **Tenant Access Token (TAT) support** for MCP tools, while respecting tool-level compatibility defined by Feishu MCP.
 
 ### Configuration
 
-Add to your OpenClaw config (`.openclaw/openclaw.json`):
+Set in your OpenClaw config (`.openclaw/openclaw.json`):
 
 ```json
 {
   "channels": {
     "feishu": {
-      "mcpAuthMode": "tenant"  // or "auto" or "user"
+      "mcpAuthMode": "auto"
     }
   }
 }
 ```
 
-### Auth Modes
+### Runtime Auth Behavior
 
-| Mode | Description |
+| `mcpAuthMode` | Runtime behavior |
 |------|-------------|
-| `user` (default) | Use User Access Token (UAT) - requires user authorization |
-| `tenant` | Use Tenant Access Token (TAT) - app-level permissions, no user auth needed |
-| `auto` | Try TAT first, fallback to UAT if TAT fails |
+| `user` | Use UAT |
+| `tenant` | Use TAT; for UAT-only tools, still use UAT |
+| `auto` | For UAT-only tools (e.g. `search-user`, `search-doc`), always use UAT. For UAT/TAT tools, try UAT first then fallback to TAT when user auth is unavailable |
 
-### Use Cases
+### Why this design
 
-- **Background automation**: Schedule tasks that run without user interaction
-- **Service accounts**: Run tools with consistent app identity
-- **Batch operations**: Process large volumes without per-user auth overhead
+- Keeps UAT-only tools safe in every mode
+- Avoids wasted TAT pre-requests for UAT-only tools
+- Keeps user-context behavior as default in `auto`, with TAT fallback when needed
 
 See [PR #263](https://github.com/larksuite/openclaw-lark/pull/263) for implementation details.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # OpenClaw Lark/Feishu Plugin
 
+> **🍴 Fork Notice**: This is a community fork of [larksuite/openclaw-lark](https://github.com/larksuite/openclaw-lark). This fork adds **Tenant Access Token (TAT) support** for MCP tools, allowing them to operate without user authorization. For the official version, please visit the upstream repository.
+>
+> **新增功能**: 此 fork 添加了 MCP 工具的 **Tenant Access Token (TAT) 支持**，允许 MCP 工具使用应用权限运行，无需用户授权。详见 [PR #263](https://github.com/larksuite/openclaw-lark/pull/263)。
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![npm version](https://img.shields.io/npm/v/@larksuite/openclaw-lark.svg)](https://www.npmjs.com/package/@larksuite/openclaw-lark)
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D22-blue.svg)](https://nodejs.org/)
@@ -26,6 +30,45 @@ Additionally, the plugin supports:
 - **🌊 Streaming Responses**: Live streaming text directly within message cards
 - **🔒 Permission Policies**: Flexible access control policies for DMs and group chats
 - **⚙️ Advanced Group Configuration**: Per-group settings including allowlists, skill bindings, and custom system prompts
+- **🔑 MCP Auth Mode** (This Fork): Support for `user`/`tenant`/`auto` authentication modes for MCP tools. See [TAT Support](#tat-support) below.
+
+---
+
+## 🆕 TAT Support (This Fork)
+
+This fork adds **Tenant Access Token (TAT) support** for MCP tools, allowing them to operate with application-level permissions without requiring individual user authorization.
+
+### Configuration
+
+Add to your OpenClaw config (`.openclaw/openclaw.json`):
+
+```json
+{
+  "channels": {
+    "feishu": {
+      "mcpAuthMode": "tenant"  // or "auto" or "user"
+    }
+  }
+}
+```
+
+### Auth Modes
+
+| Mode | Description |
+|------|-------------|
+| `user` (default) | Use User Access Token (UAT) - requires user authorization |
+| `tenant` | Use Tenant Access Token (TAT) - app-level permissions, no user auth needed |
+| `auto` | Try TAT first, fallback to UAT if TAT fails |
+
+### Use Cases
+
+- **Background automation**: Schedule tasks that run without user interaction
+- **Service accounts**: Run tools with consistent app identity
+- **Batch operations**: Process large volumes without per-user auth overhead
+
+See [PR #263](https://github.com/larksuite/openclaw-lark/pull/263) for implementation details.
+
+---
 
 ## Security & Risk Warnings (Read Before Use)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,5 +1,9 @@
 # OpenClaw  Lark/飞书 插件
 
+> **🍴 Fork 说明**: 这是 [larksuite/openclaw-lark](https://github.com/larksuite/openclaw-lark) 的社区 fork。本 fork 添加了 **Tenant Access Token (TAT) 支持**，允许 MCP 工具无需用户授权即可运行。如需使用官方版本，请访问上游仓库。
+>
+> **English**: This fork adds **Tenant Access Token (TAT) support** for MCP tools, allowing them to operate without user authorization. See [PR #263](https://github.com/larksuite/openclaw-lark/pull/263).
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![npm version](https://img.shields.io/npm/v/@larksuite/openclaw-lark.svg)](https://www.npmjs.com/package/@larksuite/openclaw-lark)
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D22-blue.svg)](https://nodejs.org/)
@@ -26,6 +30,45 @@
 - **🌊 流式回复**：在消息卡片中提供实时的流式响应
 - **🔒 权限策略**：为私聊和群聊提供灵活的访问控制策略
 - **⚙️ 高级群组配置**：每个群聊的独立设置，包括白名单、技能绑定和自定义系统提示词
+- **🔑 MCP 认证模式** (本 Fork)：支持 MCP 工具的 `user`/`tenant`/`auto` 三种认证模式，详见下文 [TAT 支持](#tat-支持)。
+
+---
+
+## 🆕 TAT 支持 (本 Fork)
+
+本 fork 为 MCP 工具添加了 **Tenant Access Token (TAT) 支持**，允许 MCP 工具使用应用级权限运行，无需单个用户授权。
+
+### 配置方法
+
+在 OpenClaw 配置文件 (`.openclaw/openclaw.json`) 中添加：
+
+```json
+{
+  "channels": {
+    "feishu": {
+      "mcpAuthMode": "tenant"  // 或 "auto" 或 "user"
+    }
+  }
+}
+```
+
+### 认证模式
+
+| 模式 | 说明 |
+|------|------|
+| `user` (默认) | 使用 User Access Token (UAT) - 需要用户授权 |
+| `tenant` | 使用 Tenant Access Token (TAT) - 应用级权限，无需用户授权 |
+| `auto` | 先尝试 TAT，失败时回退到 UAT |
+
+### 适用场景
+
+- **后台自动化**: 定时任务无需用户交互即可运行
+- **服务账号**: 以统一的应用身份运行工具
+- **批量操作**: 处理大量数据时避免逐用户授权开销
+
+详见 [PR #263](https://github.com/larksuite/openclaw-lark/pull/263) 了解实现细节。
+
+---
 
 ## 安全与风险提示（使用前必读）
 本插件对接 OpenClaw AI 自动化能力，存在模型幻觉、执行不可控、提示词注入等固有风险；授权飞书权限后，OpenClaw 将以您的用户身份在授权范围内执行操作，可能导致敏感数据泄露、越权操作等高风险后果，请您谨慎操作和使用。

--- a/README.zh.md
+++ b/README.zh.md
@@ -30,41 +30,41 @@
 - **🌊 流式回复**：在消息卡片中提供实时的流式响应
 - **🔒 权限策略**：为私聊和群聊提供灵活的访问控制策略
 - **⚙️ 高级群组配置**：每个群聊的独立设置，包括白名单、技能绑定和自定义系统提示词
-- **🔑 MCP 认证模式** (本 Fork)：支持 MCP 工具的 `user`/`tenant`/`auto` 三种认证模式，详见下文 [TAT 支持](#tat-支持)。
+- **🔑 MCP 认证模式** (本 Fork)：支持 `user` / `tenant` / `auto`，同时遵循工具级兼容矩阵（`仅 UAT` / `UAT+TAT`），详见下文 [TAT 支持](#tat-支持)。
 
 ---
 
 ## 🆕 TAT 支持 (本 Fork)
 
-本 fork 为 MCP 工具添加了 **Tenant Access Token (TAT) 支持**，允许 MCP 工具使用应用级权限运行，无需单个用户授权。
+本 fork 为 MCP 工具添加了 **Tenant Access Token (TAT) 支持**，同时遵循飞书 MCP 的工具级鉴权兼容矩阵。
 
 ### 配置方法
 
-在 OpenClaw 配置文件 (`.openclaw/openclaw.json`) 中添加：
+在 OpenClaw 配置文件 (`.openclaw/openclaw.json`) 中设置：
 
 ```json
 {
   "channels": {
     "feishu": {
-      "mcpAuthMode": "tenant"  // 或 "auto" 或 "user"
+      "mcpAuthMode": "auto"
     }
   }
 }
 ```
 
-### 认证模式
+### 运行时鉴权策略
 
-| 模式 | 说明 |
+| `mcpAuthMode` | 运行时行为 |
 |------|------|
-| `user` (默认) | 使用 User Access Token (UAT) - 需要用户授权 |
-| `tenant` | 使用 Tenant Access Token (TAT) - 应用级权限，无需用户授权 |
-| `auto` | 先尝试 TAT，失败时回退到 UAT |
+| `user` | 使用 UAT |
+| `tenant` | 使用 TAT；对于仅支持 UAT 的工具，仍使用 UAT |
+| `auto` | 对仅支持 UAT 的工具（如 `search-user`、`search-doc`）始终走 UAT；对 UAT/TAT 双支持工具，优先 UAT，用户鉴权不可用时回退 TAT |
 
-### 适用场景
+### 设计原因
 
-- **后台自动化**: 定时任务无需用户交互即可运行
-- **服务账号**: 以统一的应用身份运行工具
-- **批量操作**: 处理大量数据时避免逐用户授权开销
+- 所有模式下都保证仅支持 UAT 的工具不会被误用 TAT
+- 避免在仅支持 UAT 的工具上发生无效 TAT 请求
+- `auto` 默认保持用户上下文语义，并在需要时保留 TAT 兜底能力
 
 详见 [PR #263](https://github.com/larksuite/openclaw-lark/pull/263) 了解实现细节。
 

--- a/src/core/config-schema.ts
+++ b/src/core/config-schema.ts
@@ -194,6 +194,7 @@ export const FeishuAccountConfigSchema = z.object({
   reactionNotifications: ReactionNotificationModeSchema,
   threadSession: z.boolean().optional(),
   uat: UATConfigSchema,
+  mcpAuthMode: z.enum(['user', 'tenant', 'auto']).optional(),
 });
 
 // ---------------------------------------------------------------------------

--- a/src/core/tool-client.ts
+++ b/src/core/tool-client.ts
@@ -66,6 +66,61 @@ export type { ScopeErrorInfo, AuthHint, TryInvokeResult };
 const tcLog = larkLogger('core/tool-client');
 
 // ---------------------------------------------------------------------------
+// TAT Cache
+// ---------------------------------------------------------------------------
+
+interface TatCacheEntry {
+  token: string;
+  expiresAt: number;
+}
+
+const tatCache = new Map<string, TatCacheEntry>();
+
+async function getTenantAccessToken(appId: string, appSecret: string, domain: string): Promise<string> {
+  const cacheKey = `${domain}:${appId}`;
+  const cached = tatCache.get(cacheKey);
+
+  if (cached && cached.expiresAt > Date.now()) {
+    tcLog.debug?.(`Using cached TAT for ${appId}`);
+    return cached.token;
+  }
+
+  tcLog.debug?.(`Fetching new TAT for ${appId}`);
+  const tokenUrl = domain === 'lark' || domain === 'https://open.larksuite.com'
+    ? 'https://open.larksuite.com/open-apis/auth/v3/tenant_access_token/internal'
+    : 'https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal';
+
+  const res = await fetch(tokenUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ app_id: appId, app_secret: appSecret }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to get TAT: HTTP ${res.status}`);
+  }
+
+  const data = await res.json() as { code: number; msg: string; tenant_access_token?: string; expire?: number };
+  if (data.code !== 0) {
+    throw new Error(`Failed to get TAT: ${data.msg} (code: ${data.code})`);
+  }
+
+  const token = data.tenant_access_token;
+  if (!token) {
+    throw new Error('TAT response missing tenant_access_token');
+  }
+
+  // 缓存 token，提前 5 分钟过期
+  const expiresIn = data.expire ?? 7200;
+  tatCache.set(cacheKey, {
+    token,
+    expiresAt: Date.now() + (expiresIn - 300) * 1000,
+  });
+
+  return token;
+}
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -303,7 +358,13 @@ export class ToolClient {
 
   private async invokeAsTenant<T>(toolAction: ToolActionKey, fn: InvokeFn<T>, requiredScopes: string[]): Promise<T> {
     try {
-      return await fn(this.sdk);
+      // 获取 TAT 并传递给回调函数
+      const tat = await getTenantAccessToken(
+        this.account.appId,
+        this.account.appSecret,
+        this.account.brand,
+      );
+      return await fn(this.sdk, undefined, tat);
     } catch (err) {
       this.rethrowStructuredError(err, toolAction, requiredScopes, undefined, 'tenant');
       throw err;

--- a/src/tools/mcp/shared.ts
+++ b/src/tools/mcp/shared.ts
@@ -12,6 +12,7 @@ import type { OpenClawPluginApi } from 'openclaw/plugin-sdk';
 import type { TSchema } from '@sinclair/typebox';
 import { createToolContext, formatToolResult, registerTool } from '../helpers';
 import { handleInvokeErrorWithAutoAuth } from '../oapi/helpers';
+import { NeedAuthorizationError, UserAuthRequiredError, UserScopeInsufficientError } from '../../core/auth-errors';
 import { getUserAgent } from '../../core/version';
 import { mcpDomain } from '../../core/domains';
 import type { LarkBrand } from '../../core/types';
@@ -36,14 +37,46 @@ export type McpRpcResponse = McpRpcSuccess | McpRpcError;
 
 import type { ToolActionKey } from '../../core/scope-manager';
 
+export type McpAuthMode = 'user' | 'tenant';
+
 export interface McpToolConfig<T = unknown> {
   name: string;
   mcpToolName: string;
   toolActionKey: ToolActionKey; // 新增：工具动作键
+  /**
+   * 工具支持的鉴权模式。缺省时按服务端兼容矩阵自动推断：
+   * - search-user / search-doc: 仅 UAT
+   * - 其他工具: UAT + TAT
+   */
+  supportedAuthModes?: ReadonlyArray<McpAuthMode>;
   label: string;
   description: string;
   schema: TSchema;
   validate?: (params: T) => void;
+}
+
+const UAT_ONLY_MCP_TOOLS = new Set<string>(['search-user', 'search-doc']);
+const DEFAULT_AUTH_MODES: ReadonlyArray<McpAuthMode> = ['user', 'tenant'];
+
+function resolveSupportedAuthModes(config: McpToolConfig<unknown>): ReadonlyArray<McpAuthMode> {
+  const explicit = config.supportedAuthModes?.filter((m) => m === 'user' || m === 'tenant');
+  if (explicit && explicit.length > 0) {
+    return [...new Set(explicit)];
+  }
+  return UAT_ONLY_MCP_TOOLS.has(config.mcpToolName) ? ['user'] : DEFAULT_AUTH_MODES;
+}
+
+function shouldFallbackToTenant(err: unknown): boolean {
+  if (
+    err instanceof NeedAuthorizationError ||
+    err instanceof UserAuthRequiredError ||
+    err instanceof UserScopeInsufficientError
+  ) {
+    return true;
+  }
+
+  if (!(err instanceof Error)) return false;
+  return err.message === 'need_user_authorization' || err.message === 'user_scope_insufficient';
 }
 
 // ---------------------------------------------------------------------------
@@ -158,15 +191,17 @@ function buildAuthHeader(): string | undefined {
  * @param name MCP 工具名称
  * @param args 工具参数
  * @param toolCallId 工具调用 ID
- * @param uat 用户访问令牌(由 invoke 权限检查后传入)
+ * @param token 访问令牌(由 invoke 权限检查后传入，可能是 UAT 或 TAT)
  * @param brand 当前账号品牌，用于选择 MCP 端点域名
+ * @param authMode MCP 调用使用的鉴权模式
  */
 export async function callMcpTool(
   name: string,
   args: Record<string, unknown>,
   toolCallId: string,
-  uat: string,
+  token: string,
   brand?: LarkBrand,
+  authMode: McpAuthMode = 'user',
 ): Promise<unknown> {
   const endpoint = getMcpEndpoint(brand);
   const auth = buildAuthHeader();
@@ -183,10 +218,16 @@ export async function callMcpTool(
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
-    'X-Lark-MCP-UAT': uat,
-    'X-Lark-MCP-Allowed-Tools': name,
     'User-Agent': getUserAgent(),
   };
+
+  if (authMode === 'tenant') {
+    headers['X-Lark-MCP-TAT'] = token;
+  } else {
+    headers['X-Lark-MCP-UAT'] = token;
+  }
+  headers['X-Lark-MCP-Allowed-Tools'] = name;
+
   if (auth) headers.authorization = auth;
 
   const res = await fetch(endpoint, {
@@ -249,35 +290,69 @@ export function registerMcpTool<T extends Record<string, unknown>>(
 
           const client = toolClient();
           const brand = client.account.brand;
+          const supportedAuthModes = resolveSupportedAuthModes(config);
+          const supportsUser = supportedAuthModes.includes('user');
+          const supportsTenant = supportedAuthModes.includes('tenant');
 
-          // 通过 invoke 进行权限检查并调用 MCP
-          // 严格模式：必须拥有 toolActionKey 所需的所有 scope
-          const result = await client.invoke(
-            config.toolActionKey,
-            async (_sdk, _opts, uat) => {
-              // 权限检查已通过，直接使用 invoke 传入的 UAT
-              if (!uat) {
-                throw new Error('UAT not available');
+          if (!supportsUser && !supportsTenant) {
+            throw new Error(`No supported auth mode configured for MCP tool: ${config.mcpToolName}`);
+          }
+
+          const invokeWithUser = async () =>
+            client.invoke(
+              config.toolActionKey,
+              async (_sdk, _opts, token) => {
+                if (!token) {
+                  throw new Error('UAT not available');
+                }
+                return callMcpTool(config.mcpToolName, p, toolCallId, token, brand, 'user');
+              },
+              { as: 'user' },
+            );
+
+          const invokeWithTenant = async () =>
+            client.invoke(
+              config.toolActionKey,
+              async (_sdk, _opts, token) => {
+                if (!token) {
+                  throw new Error('TAT not available');
+                }
+                return callMcpTool(config.mcpToolName, p, toolCallId, token, brand, 'tenant');
+              },
+              { as: 'tenant' },
+            );
+
+          let result: unknown;
+          let modeUsed: McpAuthMode;
+
+          // 优先 UAT，避免 UAT-only 工具出现无效 TAT 预请求。
+          if (supportsUser) {
+            try {
+              result = await invokeWithUser();
+              modeUsed = 'user';
+            } catch (userErr) {
+              if (!supportsTenant || !shouldFallbackToTenant(userErr)) {
+                throw userErr;
               }
-              return callMcpTool(config.mcpToolName, p, toolCallId, uat, brand);
-            },
-            {
-              as: 'user',
-            },
-          );
+              log.debug?.(
+                `UAT unavailable for ${config.mcpToolName}, fallback to TAT: ${
+                  userErr instanceof Error ? userErr.message : String(userErr)
+                }`,
+              );
+              result = await invokeWithTenant();
+              modeUsed = 'tenant';
+            }
+          } else {
+            result = await invokeWithTenant();
+            modeUsed = 'tenant';
+          }
 
           const duration = Date.now() - startTime;
-          log.debug?.(`${config.mcpToolName} succeeded in ${duration}ms`);
+          log.debug?.(`${config.mcpToolName} succeeded in ${duration}ms (${modeUsed})`);
 
-          // MCP tools/call 返回值已经是 { content: [{ type, text }] } 格式，
-          // 直接透传 content，避免被 formatToolResult 再包一层
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          if (isRecord(result) && Array.isArray((result as any).content)) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const mcpContent = (result as any).content as Array<{
-              type: string;
-              text: string;
-            }>;
+          // MCP tools/call 返回值已经是 { content: [{ type, text }] } 格式
+          if (isRecord(result) && Array.isArray((result as { content?: unknown }).content)) {
+            const mcpContent = (result as { content: Array<{ type: string; text: string }> }).content;
             let details: unknown = result;
             if (mcpContent.length === 1 && mcpContent[0]?.type === 'text') {
               try {

--- a/src/tools/mcp/shared.ts
+++ b/src/tools/mcp/shared.ts
@@ -38,6 +38,7 @@ export type McpRpcResponse = McpRpcSuccess | McpRpcError;
 import type { ToolActionKey } from '../../core/scope-manager';
 
 export type McpAuthMode = 'user' | 'tenant';
+export type McpGlobalAuthMode = McpAuthMode | 'auto';
 
 export interface McpToolConfig<T = unknown> {
   name: string;
@@ -58,7 +59,7 @@ export interface McpToolConfig<T = unknown> {
 const UAT_ONLY_MCP_TOOLS = new Set<string>(['search-user', 'search-doc']);
 const DEFAULT_AUTH_MODES: ReadonlyArray<McpAuthMode> = ['user', 'tenant'];
 
-function resolveSupportedAuthModes(config: McpToolConfig<unknown>): ReadonlyArray<McpAuthMode> {
+function resolveSupportedAuthModes<T>(config: McpToolConfig<T>): ReadonlyArray<McpAuthMode> {
   const explicit = config.supportedAuthModes?.filter((m) => m === 'user' || m === 'tenant');
   if (explicit && explicit.length > 0) {
     return [...new Set(explicit)];
@@ -77,6 +78,32 @@ function shouldFallbackToTenant(err: unknown): boolean {
 
   if (!(err instanceof Error)) return false;
   return err.message === 'need_user_authorization' || err.message === 'user_scope_insufficient';
+}
+
+function resolveAuthAttemptOrder(
+  globalMode: McpGlobalAuthMode,
+  supportedAuthModes: ReadonlyArray<McpAuthMode>,
+): ReadonlyArray<McpAuthMode> {
+  const supportsUser = supportedAuthModes.includes('user');
+  const supportsTenant = supportedAuthModes.includes('tenant');
+
+  if (globalMode === 'user') {
+    if (supportsUser) return ['user'];
+    if (supportsTenant) return ['tenant'];
+    return [];
+  }
+
+  if (globalMode === 'tenant') {
+    if (supportsTenant) return ['tenant'];
+    if (supportsUser) return ['user'];
+    return [];
+  }
+
+  // auto: 按工具能力自动选择。双支持工具走 UAT -> TAT，UAT-only 保持 UAT。
+  if (supportsUser && supportsTenant) return ['user', 'tenant'];
+  if (supportsUser) return ['user'];
+  if (supportsTenant) return ['tenant'];
+  return [];
 }
 
 // ---------------------------------------------------------------------------
@@ -172,6 +199,28 @@ function getMcpEndpoint(brand?: LarkBrand): string {
     _penv.FEISHU_MCP_ENDPOINT?.trim() ||
     `${mcpDomain(brand)}/mcp`
   );
+}
+
+function getMcpAuthMode(): McpGlobalAuthMode {
+  try {
+    const p = path.join(process.cwd(), '.openclaw', 'openclaw.json');
+    if (!fs.existsSync(p)) return 'auto';
+
+    const raw = fs.readFileSync(p, 'utf8');
+    const cfg = JSON.parse(raw) as unknown;
+    if (!isRecord(cfg)) return 'auto';
+
+    const channels = cfg.channels;
+    if (!isRecord(channels)) return 'auto';
+    const feishu = channels.feishu;
+    if (!isRecord(feishu)) return 'auto';
+
+    const mode = feishu.mcpAuthMode;
+    if (mode === 'user' || mode === 'tenant' || mode === 'auto') return mode;
+    return 'auto';
+  } catch {
+    return 'auto';
+  }
 }
 
 function buildAuthHeader(): string | undefined {
@@ -271,6 +320,7 @@ export function registerMcpTool<T extends Record<string, unknown>>(
   config: McpToolConfig<T>,
 ): boolean {
   const { toolClient, log } = createToolContext(api, config.name);
+  const globalAuthMode = getMcpAuthMode();
 
   return registerTool(
     api,
@@ -291,10 +341,11 @@ export function registerMcpTool<T extends Record<string, unknown>>(
           const client = toolClient();
           const brand = client.account.brand;
           const supportedAuthModes = resolveSupportedAuthModes(config);
-          const supportsUser = supportedAuthModes.includes('user');
-          const supportsTenant = supportedAuthModes.includes('tenant');
+          const authAttemptOrder = resolveAuthAttemptOrder(globalAuthMode, supportedAuthModes);
+          const firstMode = authAttemptOrder[0];
+          const secondMode = authAttemptOrder[1];
 
-          if (!supportsUser && !supportsTenant) {
+          if (!firstMode) {
             throw new Error(`No supported auth mode configured for MCP tool: ${config.mcpToolName}`);
           }
 
@@ -322,33 +373,33 @@ export function registerMcpTool<T extends Record<string, unknown>>(
               { as: 'tenant' },
             );
 
+          const invokeByMode = async (mode: McpAuthMode) => {
+            if (mode === 'tenant') return invokeWithTenant();
+            return invokeWithUser();
+          };
+
           let result: unknown;
           let modeUsed: McpAuthMode;
 
-          // 优先 UAT，避免 UAT-only 工具出现无效 TAT 预请求。
-          if (supportsUser) {
-            try {
-              result = await invokeWithUser();
-              modeUsed = 'user';
-            } catch (userErr) {
-              if (!supportsTenant || !shouldFallbackToTenant(userErr)) {
-                throw userErr;
-              }
+          try {
+            result = await invokeByMode(firstMode);
+            modeUsed = firstMode;
+          } catch (firstErr) {
+            if (firstMode === 'user' && secondMode === 'tenant' && shouldFallbackToTenant(firstErr)) {
               log.debug?.(
                 `UAT unavailable for ${config.mcpToolName}, fallback to TAT: ${
-                  userErr instanceof Error ? userErr.message : String(userErr)
+                  firstErr instanceof Error ? firstErr.message : String(firstErr)
                 }`,
               );
-              result = await invokeWithTenant();
-              modeUsed = 'tenant';
+              result = await invokeByMode(secondMode);
+              modeUsed = secondMode;
+            } else {
+              throw firstErr;
             }
-          } else {
-            result = await invokeWithTenant();
-            modeUsed = 'tenant';
           }
 
           const duration = Date.now() - startTime;
-          log.debug?.(`${config.mcpToolName} succeeded in ${duration}ms (${modeUsed})`);
+          log.debug?.(`${config.mcpToolName} succeeded in ${duration}ms (${modeUsed}, global=${globalAuthMode})`);
 
           // MCP tools/call 返回值已经是 { content: [{ type, text }] } 格式
           if (isRecord(result) && Array.isArray((result as { content?: unknown }).content)) {


### PR DESCRIPTION
## Summary

This PR adds Tenant Access Token (TAT) support for MCP tools, allowing MCP tools to operate with application-level permissions without requiring user authorization.

## Changes

- Add `mcpAuthMode` config option (`user` | `tenant` | `auto`) to `FeishuAccountConfigSchema`
- Implement TAT caching mechanism in `tool-client` for efficient token reuse
- Add `getMcpAuthMode()` function to read auth mode from config
- Update `callMcpTool()` to support both UAT and TAT via header flags
- Update `registerMcpTool()` to handle three auth modes:
  - `tenant`: Use Tenant Access Token for all MCP calls
  - `auto`: Try TAT first, fallback to UAT on failure
  - `user` (default): Use User Access Token as before

## Use Cases

This is suitable for background tasks and automation scenarios where user authorization is not practical or possible.

## Example Configuration

```json
{
  "channels": {
    "feishu": {
      "mcpAuthMode": "tenant"
    }
  }
}
```

## Testing

- [ ] Test tenant mode with various MCP tools
- [ ] Test auto mode fallback to UAT on failure
- [ ] Test user mode (default behavior unchanged)