### PR TITLE
fix(streaming): preserve <think> tag content in onPartialReply

### DIFF
--- a/src/card/streaming-card-controller.ts
+++ b/src/card/streaming-card-controller.ts
@@ -343,7 +343,20 @@ export class StreamingCardController {
   async onPartialReply(payload: ReplyPayload): Promise<void> {
     if (!this.shouldProceed('onPartialReply')) return;
 
-    const text = stripReasoningTags(payload.text ?? '');
+    // Use splitReasoningText (consistent with onDeliver/onReasoningStream)
+    // to extract <think> tag content before stripping it from the answer.
+    // Previously only stripReasoningTags was called, silently discarding
+    // any thinking content that the LLM wrapped in <think> tags.
+    const rawText = payload.text ?? '';
+    const split = splitReasoningText(rawText);
+    if (split.reasoningText) {
+      if (!this.reasoning.reasoningStartTime) {
+        this.reasoning.reasoningStartTime = Date.now();
+      }
+      this.reasoning.accumulatedReasoningText = split.reasoningText;
+      this.reasoning.isReasoningPhase = true;
+    }
+    const text = split.answerText ?? stripReasoningTags(rawText);
     log.debug('onPartialReply', { len: text.length });
     if (!text) return;
 


### PR DESCRIPTION
## Summary

`onPartialReply` calls `stripReasoningTags()` which removes `<think>`/`<thinking>` tags but silently discards their content. This is inconsistent with `onDeliver` and `onReasoningStream`, both of which use `splitReasoningText()` to properly extract reasoning content into `accumulatedReasoningText`.

**Result**: When an LLM wraps its chain-of-thought in `<think>` tags (via prompt engineering), the reasoning text is lost during streaming — the collapsible "💭 Thought for Xs" panel in the final card remains empty.

## Changes

- Use `splitReasoningText()` in `onPartialReply` to extract `<think>` tag content into `reasoning.accumulatedReasoningText` before stripping tags from the answer text
- Fallback to `stripReasoningTags()` only when `splitReasoningText` returns no `answerText`

## Before / After

| Callback | Before | After |
|---|---|---|
| `onReasoningStream` | ✅ `splitReasoningText` → reasoning preserved | (unchanged) |
| `onDeliver` | ✅ `splitReasoningText` → reasoning preserved | (unchanged) |
| `onPartialReply` | ❌ `stripReasoningTags` → reasoning **discarded** | ✅ `splitReasoningText` → reasoning preserved |

Fixes #268