### PR TITLE
feat: add thread-reply action support for Feishu channel

### DIFF
--- a/src/messaging/outbound/actions.ts
+++ b/src/messaging/outbound/actions.ts
@@ -52,6 +52,7 @@ function assertLarkOk(res: any, context: string): void {
 
 const SUPPORTED_ACTIONS: Set<ChannelMessageActionName> = new Set([
   'send',
+  'thread-reply',
   'react',
   'reactions',
   'delete',
@@ -186,6 +187,18 @@ export const feishuMessageActions: ChannelMessageActionAdapter = {
       switch (action) {
         case 'send':
           return await deliverMessage(cfg, readFeishuSendParams(params, toolContext), aid, ctx.mediaLocalRoots);
+        case 'thread-reply': {
+          const messageId = readStringParam(params, 'messageId') ??
+            readStringParam(params, 'message_id') ??
+            readStringParam(params, 'replyTo');
+          if (!messageId) {
+            throw new Error('Feishu thread-reply requires messageId.');
+          }
+          const sendParams = readFeishuSendParams(params, toolContext);
+          sendParams.replyToMessageId = messageId;
+          sendParams.replyInThread = true;
+          return await deliverMessage(cfg, sendParams, aid, ctx.mediaLocalRoots);
+        }
         case 'react':
           return await handleReact(cfg, params, aid);
         case 'reactions':


### PR DESCRIPTION
## Summary

- Add `thread-reply` to `SUPPORTED_ACTIONS` in `src/messaging/outbound/actions.ts`
- Implement `case 'thread-reply'` in `handleAction` switch, reusing existing `readFeishuSendParams` + `deliverMessage` with `replyInThread=true`

## Problem

When using `message(action="thread-reply")` to reply within an existing Feishu topic/thread, the framework returns:

> "Message action thread-reply not supported for channel feishu"

The OpenClaw core framework already supports the `thread-reply` action, but this extension's `actions.ts` did not declare or handle it.

## Implementation

The fix reuses existing infrastructure — `readFeishuSendParams` extracts message parameters, then we override `replyToMessageId` (from `messageId` / `message_id` / `replyTo` params) and set `replyInThread = true` before passing to `deliverMessage`. This ensures the Feishu reply API is called with `reply_in_thread: true`, routing the message into the existing thread rather than creating a new topic.

## Test plan

- [x] Verified locally: `message(action="thread-reply", messageId="...", message="...")` successfully sends a reply into an existing Feishu thread
- [x] Project builds successfully with `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)