### PR TITLE
refactor(dispatchSystemCommand): remove `suppressReply` parameter and related dead code

### DIFF
--- a/src/messaging/inbound/dispatch-commands.ts
+++ b/src/messaging/inbound/dispatch-commands.ts
@@ -91,31 +91,24 @@ export async function dispatchPermissionNotification(
 /**
  * Dispatch a system command (/help, /reset, etc.) via plain-text delivery.
  * No streaming card, no "Processing..." state.
- *
- * When `suppressReply` is true the agent still runs (e.g. reads workspace
- * files) but its text output is not forwarded to Feishu.  This is used for
- * bare /new and /reset commands: the SDK already sends a "done" notice
- * via its own route, so the AI greeting would be redundant.
  */
 export async function dispatchSystemCommand(
   dc: DispatchContext,
   ctxPayload: ReturnType<typeof LarkClient.runtime.channel.reply.finalizeInboundContext>,
-  suppressReply = false,
   replyToMessageId?: string,
 ): Promise<void> {
   let delivered = false;
 
   dc.log(
-    `feishu[${dc.account.accountId}]: detected system command, using plain-text dispatch${suppressReply ? ' (reply suppressed)' : ''}`,
+    `feishu[${dc.account.accountId}]: detected system command, using plain-text dispatch`,
   );
-  log.info(`system command detected, plain-text dispatch${suppressReply ? ', reply suppressed' : ''}`);
+  log.info('system command detected, plain-text dispatch');
 
   await dc.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
     ctx: ctxPayload,
     cfg: dc.accountScopedCfg,
     dispatcherOptions: {
       deliver: async (payload) => {
-        if (suppressReply) return;
         const text = payload.text?.trim() ?? '';
         if (!text) return;
         await sendMessageFeishu({

--- a/src/messaging/inbound/dispatch.ts
+++ b/src/messaging/inbound/dispatch.ts
@@ -79,7 +79,7 @@ async function dispatchNormalMessage(
   if (isLikelyAbortText(dc.ctx.content?.trim() ?? '')) {
     dc.log(`feishu[${dc.account.accountId}]: abort message detected, using plain-text dispatch`);
     log.info('abort message detected, using plain-text dispatch');
-    await dispatchSystemCommand(dc, ctxPayload, false, replyToMessageId);
+    await dispatchSystemCommand(dc, ctxPayload, replyToMessageId);
     return;
   }
 
@@ -345,7 +345,7 @@ export async function dispatchToAgent(params: {
   const skillFilter = dc.isGroup ? (params.groupConfig?.skills ?? params.defaultGroupConfig?.skills) : undefined;
 
   if (isCommand) {
-    await dispatchSystemCommand(dc, ctxPayload, false, params.replyToMessageId);
+    await dispatchSystemCommand(dc, ctxPayload, params.replyToMessageId);
     // /new and /reset explicitly start a new session — clear pending history
     if (isBareNewOrReset && dc.isGroup && historyKey && params.chatHistories) {
       clearHistoryEntriesIfEnabled({


### PR DESCRIPTION
### What this PR does

This is a small follow-up cleanup for `dispatchSystemCommand`. I’ve removed the unused `suppressReply` parameter and related dead code to simplify the function and make the logs and JSDoc reflect the actual behavior.

### Changes

- Removed `suppressReply` parameter from `dispatchSystemCommand`
- Deleted conditional logic in `deliver` callback that depended on `suppressReply`
- Updated function JSDoc to remove `suppressReply` description
- Adjusted logs to reflect actual dispatch behavior
- Ensured TypeScript type safety and simplified API usage

### Build & Lint

- `npm run build` : completed successfully with no errors
- `npm run lint` : reported warnings, but none are related to this PR

### Related Issue

Related to #231 for traceability. The original issue was fixed in [this PR](https://github.com/larksuite/openclaw-lark/pull/77); this is just a cleanup.