### PR TITLE
fix(im): 修复 message.list 使用错误的调用身份 (#36)

### DIFF
--- a/src/tools/oapi/im/message-read.ts
+++ b/src/tools/oapi/im/message-read.ts
@@ -2,7 +2,9 @@
  * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
  * SPDX-License-Identifier: MIT
  *
- * 消息读取工具集 -- 以用户身份获取/搜索飞书消息
+ * 消息读取工具集
+ * - list（会话/话题历史）走 TAT（应用身份），因 im.v1.message.list 仅支持 TAT
+ * - search（跨会话搜索）走 UAT（用户身份）
  *
  * 包含：
  *   - feishu_im_user_get_messages       (chat_id / open_id → 会话消息)
@@ -207,7 +209,7 @@ function registerGetMessages(api: OpenClawPluginApi): boolean {
                 opts,
               ),
             {
-              as: 'user',
+              as: 'tenant',
             },
           );
           assertLarkOk(res);
@@ -287,7 +289,7 @@ function registerGetThreadMessages(api: OpenClawPluginApi): boolean {
                 opts,
               ),
             {
-              as: 'user',
+              as: 'tenant',
             },
           );
           assertLarkOk(res);


### PR DESCRIPTION
## 说明

Closes #36
Supersedes #58

`im.v1.message.list` 接口仅支持 `tenant_access_token`（应用身份），但代码中使用了 `as: 'user'`（用户身份），导致报错 "The app type is not supported"。

### 修复

将两处 `message.list` 调用的 `as: 'user'` 改为 `as: 'tenant'`：

- `feishu_im_user_get_messages`（会话历史消息）
- `feishu_im_user_get_thread_messages`（话题历史消息）

相比 #58 的 search API 绕行方案（~350 行改动），本 PR 采用定点修复（1 文件 5 增 3 删），保留了排序功能和单次 API 调用。

### 验证

- `pnpm build` 通过
- `pnpm lint` 无新增 error