### PR TITLE
feat(owner-policy): add uat.allowedUsers whitelist to bypass owner-only restriction

### DIFF
--- a/src/core/config-schema.ts
+++ b/src/core/config-schema.ts
@@ -123,6 +123,12 @@ export const UATConfigSchema = z
     enabled: z.boolean().optional(),
     allowedScopes: z.array(z.string()).optional(),
     blockedScopes: z.array(z.string()).optional(),
+    /**
+     * 允许使用 API 功能的用户 open_id 白名单。
+     * 白名单中的用户与应用 Owner 享有相同的 API 调用权限。
+     * 设为 ["*"] 允许所有用户。
+     */
+    allowedUsers: z.array(z.string()).optional(),
   })
   .optional();
 

--- a/src/core/owner-policy.ts
+++ b/src/core/owner-policy.ts
@@ -6,11 +6,16 @@
  *
  * 从 uat-client.ts 迁移 owner 检查逻辑到独立 policy 层。
  * 提供 fail-close 策略（安全优先：授权发起路径）。
+ *
+ * 支持通过配置 `uat.allowedUsers` 白名单，让非 owner 用户也能使用 API 功能。
  */
 
 import type * as Lark from '@larksuiteoapi/node-sdk';
 import type { ConfiguredLarkAccount } from './types';
 import { getAppOwnerFallback } from './app-owner-fallback';
+import { larkLogger } from './lark-logger';
+
+const log = larkLogger('core/owner-policy');
 
 // ---------------------------------------------------------------------------
 // Error class
@@ -39,10 +44,23 @@ export class OwnerAccessDeniedError extends Error {
 // ---------------------------------------------------------------------------
 
 /**
- * 校验用户是否为应用 owner（fail-close 版本）。
+ * 检查用户是否在 `uat.allowedUsers` 白名单中。
  *
- * - 获取 owner 失败时 → 拒绝（安全优先）
- * - owner 不匹配时 → 拒绝
+ * - 白名单包含 `"*"` 时，允许所有用户
+ * - 白名单包含该用户的 open_id 时，允许该用户
+ */
+function isUserAllowlisted(account: ConfiguredLarkAccount, userOpenId: string): boolean {
+  const allowedUsers = account.config.uat?.allowedUsers;
+  if (!allowedUsers || allowedUsers.length === 0) return false;
+  return allowedUsers.includes('*') || allowedUsers.includes(userOpenId);
+}
+
+/**
+ * 校验用户是否为应用 owner 或在白名单中（fail-close 版本）。
+ *
+ * 检查顺序：
+ * 1. 白名单（`uat.allowedUsers`）— 包含 `"*"` 时允许所有用户
+ * 2. Owner 匹配 — 获取 owner 失败或不匹配时拒绝
  *
  * 适用于：`executeAuthorize`（OAuth 授权发起）、`commands/auth.ts`（批量授权）等
  * 赋予实质性权限的入口。
@@ -52,6 +70,11 @@ export async function assertOwnerAccessStrict(
   sdk: Lark.Client,
   userOpenId: string,
 ): Promise<void> {
+  if (isUserAllowlisted(account, userOpenId)) {
+    log.info(`user ${userOpenId} granted access via uat.allowedUsers allowlist`);
+    return;
+  }
+
   const ownerOpenId = await getAppOwnerFallback(account, sdk);
 
   if (!ownerOpenId) {

--- a/src/tools/auto-auth.ts
+++ b/src/tools/auto-auth.ts
@@ -937,7 +937,9 @@ export async function handleInvokeErrorWithAutoAuth(err: unknown, cfg: ClawdbotC
   if (err instanceof OwnerAccessDeniedError) {
     return json({
       error: 'permission_denied',
-      message: '当前应用仅限所有者（App Owner）使用。您没有权限使用相关功能。',
+      message:
+        '当前应用仅限所有者（App Owner）或白名单用户使用。您没有权限使用相关功能。' +
+        '\n如需授权更多用户，请在配置中添加 channels.feishu.uat.allowedUsers（open_id 数组）。',
       user_open_id: err.userOpenId,
       // 注意：不序列化 err.appOwnerId，避免泄露 owner 的 open_id
     });

--- a/src/tools/oauth.ts
+++ b/src/tools/oauth.ts
@@ -284,7 +284,9 @@ export async function executeAuthorize(
       log.warn(`non-owner user ${senderOpenId} attempted to authorize`);
       return json({
         error: 'permission_denied',
-        message: '当前应用仅限所有者（App Owner）使用。您没有权限发起授权，无法使用相关功能。',
+        message:
+          '当前应用仅限所有者（App Owner）或白名单用户使用。您没有权限发起授权，无法使用相关功能。' +
+          '\n如需授权更多用户，请在配置中添加 channels.feishu.uat.allowedUsers（open_id 数组）。',
       });
     }
     throw err;


### PR DESCRIPTION
## Summary

- Add `uat.allowedUsers` config field to allow non-owner users to use UAT-based Feishu APIs (OAuth, calendar, tasks, docs, etc.)
- The allowlist supports individual `open_id` entries and `"*"` wildcard for all users
- Update error messages to inform admins about the new configuration option

## Problem

The `assertOwnerAccessStrict` check in `owner-policy.ts` blocks all non-owner users from:
- Initiating OAuth authorization (`oauth.ts`)
- Calling any Feishu user API via `invokeAsUser()` (`tool-client.ts`)
- Using the `/feishu_auth` command (`commands/auth.ts`)

This is too restrictive for multi-user deployments where a single Feishu app serves an entire organization. Non-owner employees see: *"当前应用仅限所有者（App Owner）使用。您没有权限使用相关功能。"*

## Solution

Add a `uat.allowedUsers` configuration field — an array of `open_id` strings. Users in this list bypass the owner check and enjoy the same API access as the app owner.

### Configuration example

```yaml
channels:
  feishu:
    uat:
      enabled: true
      allowedUsers:
        - "ou_xxxxxxxxxxxxxx"   # specific user
        - "ou_yyyyyyyyyyyyyy"   # another user
```

Or allow all users (equivalent to disabling the owner gate):

```yaml
channels:
  feishu:
    uat:
      enabled: true
      allowedUsers:
        - "*"
```

### Changed files

| File | Change |
|------|--------|
| `src/core/config-schema.ts` | Add `allowedUsers` field to `UATConfigSchema` |
| `src/core/owner-policy.ts` | Add `isUserAllowlisted()` check before owner validation |
| `src/tools/auto-auth.ts` | Update error message to mention allowlist config |
| `src/tools/oauth.ts` | Update error message to mention allowlist config |

### Design decisions

- **Allowlist-first check**: The allowlist is checked before the owner API call, avoiding unnecessary network requests for whitelisted users
- **Backward compatible**: No `allowedUsers` configured = original owner-only behavior unchanged
- **Granular control**: Per-user `open_id` list is more secure than a simple boolean toggle; `"*"` wildcard provides the all-or-nothing option when needed
- **Zero call-site changes**: All three call sites (`tool-client.ts`, `oauth.ts`, `commands/auth.ts`) pass `ConfiguredLarkAccount` which already contains `config.uat`, so no caller modifications needed

## Test plan

- [x] `tsc --noEmit` passes
- [x] All existing tests pass (`vitest run` — 4 files, 12 tests)
- [ ] Manual test: configure `uat.allowedUsers` with a non-owner `open_id`, verify user can initiate OAuth and call Feishu APIs
- [ ] Manual test: verify that without `allowedUsers`, non-owner users are still blocked (backward compat)
- [ ] Manual test: verify `["*"]` allows all users

Closes #295

Made with [Cursor](https://cursor.com)