### PR TITLE
fix(actions): send media after card instead of silently dropping it

### DIFF
--- a/src/messaging/outbound/actions.ts
+++ b/src/messaging/outbound/actions.ts
@@ -249,14 +249,22 @@ async function deliverMessage(
     await sendTextLark({ ...sendCtx, text });
   }
 
-  // Card path.
+  // Card + media path: send card first, then media separately (like reply-dispatcher).
+  if (card && mediaUrl) {
+    const cardResult = await sendCardLark({ ...sendCtx, card });
+    log.info(`deliverMessage: card sent, messageId=${cardResult.messageId}, now sending media`);
+    const mediaResult = await deliverMedia(cfg, sp, accountId, mediaLocalRoots);
+    return mediaResult;
+  }
+
+  // Card-only path.
   if (card) {
     const result = await sendCardLark({ ...sendCtx, card });
     log.info(`deliverMessage: card sent, messageId=${result.messageId}`);
     return jsonResult({ ok: true, messageId: result.messageId, chatId: result.chatId });
   }
 
-  // Media path — uses uploadAndSendMediaLark directly to support fileName.
+  // Media-only path — uses uploadAndSendMediaLark directly to support fileName.
   if (mediaUrl) {
     return await deliverMedia(cfg, sp, accountId, mediaLocalRoots);
   }


### PR DESCRIPTION
## Summary

- Fix `deliverMessage` to send both card and media when both are present, instead of silently dropping the media file

## Problem

When using the `message` tool's `send` action with both a `card` and a `filePath`/`media` parameter, the media file is silently dropped. The `deliverMessage` function in `actions.ts` sends only the card and returns immediately, never reaching the media delivery path.

**Before (broken):**
```
Card exists? → Send card → return (media silently lost)
```

**After (fixed):**
```
Card + media? → Send card → Send media → return
Card only? → Send card → return
Media only? → Send media → return
```

This follows the same pattern already used by `reply-dispatcher.ts` (line 297-361) and `outbound.ts` (line 215-238), where card and media are sent as separate messages.

## Root cause

In `deliverMessage` (`src/messaging/outbound/actions.ts`), the card path had an early `return` that prevented media from ever being sent:

```typescript
// Card path — immediately returns, media never reached
if (card) {
    const result = await sendCardLark({ ...sendCtx, card });
    return jsonResult({ ... }); // ← early return drops media
}

// Media path — unreachable when card is present
if (mediaUrl) {
    return await deliverMedia(cfg, sp, accountId, mediaLocalRoots);
}
```

## Fix

Added a `card && mediaUrl` branch that sends card first, then delivers media:

```typescript
// Card + media path: send card first, then media separately
if (card && mediaUrl) {
    const cardResult = await sendCardLark({ ...sendCtx, card });
    const mediaResult = await deliverMedia(cfg, sp, accountId, mediaLocalRoots);
    return mediaResult;
}
```

## Test plan

- [x] `tsc --noEmit` passes
- [x] All existing tests pass (4 files, 12 tests)
- [ ] Manual: send message with `card` + `filePath` → both card and image delivered
- [ ] Manual: send message with `card` only → card delivered (unchanged)
- [ ] Manual: send message with `filePath` only → image delivered (unchanged)

Ref: openclaw/openclaw#55091

Made with [Cursor](https://cursor.com)