### PR TITLE
fix: validate loadConfig() result in getResolvedConfig() for isolated sessions

### DIFF
--- a/src/core/lark-client.ts
+++ b/src/core/lark-client.ts
@@ -475,20 +475,34 @@ injectLarkClient(LarkClient);
 // ---------------------------------------------------------------------------
 
 /**
- * Returns the freshest available config for account resolution.
+ * Returns the best available config for account resolution.
+ *
+ * Priority: live config (has `channels.feishu`) > fallback (has
+ * `channels.feishu`) > live config (last resort).
  *
  * The `config` object captured in tool-registration closures may be stale
- * after a hot-reload: openclaw re-initialises the runtime but the plugin
- * closure still holds the old snapshot.  Calling
- * `LarkClient.runtime.config.loadConfig()` always returns the current live
- * config, so account lookups pick up any changes made since plugin load.
+ * after a hot-reload, so we prefer the live config from
+ * `LarkClient.runtime.config.loadConfig()`.  However, `loadConfig()` may
+ * return `{}` when the runtime config snapshot has been cleared (e.g. in
+ * isolated cron sessions), so we fall back to the closure-captured config
+ * when the live result lacks Feishu credentials.
  *
  * @param fallback - Config to use when the runtime is not yet initialised
- *   (e.g. during early startup before the first `LarkClient.runtime` attach).
+ *   or when `loadConfig()` returns an incomplete config.
  */
 export function getResolvedConfig(fallback: ClawdbotConfig): ClawdbotConfig {
   try {
-    return LarkClient.runtime.config.loadConfig() as ClawdbotConfig;
+    const live = LarkClient.runtime.config.loadConfig() as ClawdbotConfig;
+    // loadConfig() may return {} (empty config) when runtimeConfigSnapshot
+    // has been cleared (e.g. after writeConfigFile, secrets teardown, or
+    // concurrent cron race conditions in isolated sessions).  In that case
+    // the closure-captured fallback still holds a valid resolved config.
+    if (live?.channels?.feishu) return live;
+    if (fallback?.channels?.feishu) {
+      log.debug(`loadConfig() returned config without channels.feishu, using fallback`);
+      return fallback;
+    }
+    return live;
   } catch {
     // runtime not yet initialised — fall back to passed config
     return fallback;


### PR DESCRIPTION
## Summary

- `getResolvedConfig()` now validates that `loadConfig()` returned a config containing `channels.feishu` before using it
- Falls back to the closure-captured config when the live result is incomplete (e.g. `{}`)
- Adds a debug log when fallback is used, for operational visibility

## Problem

When cron jobs run in isolated sessions (`sessionTarget: isolated`), `loadConfig()` may return `{}` because `runtimeConfigSnapshot` has been cleared (by `writeConfigFile()`, secrets teardown, or concurrent cron race conditions). The previous code only fell back to the closure-captured config when `loadConfig()` **threw**, so the empty object was used as-is, causing:

```
Error: LarkClient[default]: appId and appSecret are required
```

## Changes

| File | Change |
|------|--------|
| `src/core/lark-client.ts` | `getResolvedConfig()`: validate live config has `channels.feishu` before returning; prefer fallback when live is incomplete; add debug log on fallback; update JSDoc |

Single-function change, no new dependencies.

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm format:check` passes
- [x] `pnpm build` passes
- [ ] E2E: create a cron job with `sessionTarget: isolated` that sends a Feishu message, confirm it no longer errors

Closes #293