### PR TITLE
fix: treat empty card object as undefined in parseCardParam

### DIFF
--- a/src/messaging/outbound/actions.ts
+++ b/src/messaging/outbound/actions.ts
@@ -67,9 +67,11 @@ const SUPPORTED_ACTIONS: Set<ChannelMessageActionName> = new Set([
 function parseCardParam(raw: unknown): Record<string, unknown> | undefined {
   if (raw == null) return undefined;
 
-  // Already a non-array object — use directly.
+  // Already a non-array object — use directly (empty {} is never a valid card).
   if (typeof raw === 'object' && !Array.isArray(raw)) {
-    return raw as Record<string, unknown>;
+    const obj = raw as Record<string, unknown>;
+    if (Object.keys(obj).length === 0) return undefined;
+    return obj;
   }
 
   // String — attempt JSON.parse.


### PR DESCRIPTION
## Summary

- Add empty-object guard in `parseCardParam` so `{}` is treated as `undefined`
- Prevents media send requests from being misrouted to the card send path

## Problem

When `params.card` arrives as an empty object `{}`, `parseCardParam` treats it as a valid card (passes `typeof raw === 'object'` check). Then in `deliverMessage`, the truthy `{}` routes the request into the card path instead of media, causing `Card send failed` / `parse card json err` errors when sending images.

## Changes

| File | Change |
|------|--------|
| `src/messaging/outbound/actions.ts` | Add `Object.keys(obj).length === 0` guard in `parseCardParam` to return `undefined` for empty objects |

## Test plan

- [ ] Send local image via `message` tool to Feishu chat — should succeed via media path
- [ ] Send card message with valid card object — should still work as before

Closes #288