### PR TITLE
fix: don't block chat queue on dispatch — allow steer/followup queue to work

### DIFF
--- a/src/channel/event-handlers.ts
+++ b/src/channel/event-handlers.ts
@@ -107,30 +107,39 @@ export async function handleMessageEvent(ctx: MonitorContext, data: unknown): Pr
       chatId,
       threadId,
       task: async () => {
-        try {
-          await withTicket(
-            {
-              messageId: msgId,
-              chatId,
+        // Fire-and-forget: start the dispatch without awaiting completion.
+        // The per-chat queue still serializes *task starts*, but individual
+        // dispatches run concurrently.  This allows the SDK's steer/followup
+        // queue mechanism to receive the next inbound message while the
+        // current agent run is in progress — matching the pattern used by
+        // the Discord inbound-worker (`void runQueue.enqueue(...)`).
+        //
+        // Reply delivery is handled proactively by the dispatcher's deliver
+        // callback (streaming card updates, final card close), so the caller
+        // does not need to await the result.
+        const result = withTicket(
+          {
+            messageId: msgId,
+            chatId,
+            accountId,
+            startTime: Date.now(),
+            senderOpenId: event.sender?.sender_id?.open_id || '',
+            chatType: (event.message?.chat_type as 'p2p' | 'group') || undefined,
+            threadId,
+          },
+          () =>
+            handleFeishuMessage({
+              cfg: ctx.cfg,
+              event,
+              botOpenId: ctx.lark.botOpenId,
+              runtime: ctx.runtime,
+              chatHistories: ctx.chatHistories,
               accountId,
-              startTime: Date.now(),
-              senderOpenId: event.sender?.sender_id?.open_id || '',
-              chatType: (event.message?.chat_type as 'p2p' | 'group') || undefined,
-              threadId,
-            },
-            () =>
-              handleFeishuMessage({
-                cfg: ctx.cfg,
-                event,
-                botOpenId: ctx.lark.botOpenId,
-                runtime: ctx.runtime,
-                chatHistories: ctx.chatHistories,
-                accountId,
-              }),
-          );
-        } catch (err) {
+            }),
+        );
+        void Promise.resolve(result).catch((err: unknown) => {
           error(`feishu[${accountId}]: error handling message: ${String(err)}`);
-        }
+        });
       },
     });
     log(`feishu[${accountId}]: message ${msgId} in chat ${chatId}${threadId ? ` thread ${threadId}` : ''} — ${status}`);


### PR DESCRIPTION
## Summary

- Fix steer/followup queue mode not working when messages arrive during an active agent run
- The per-chat serial queue currently `await`s the full `dispatchReplyFromConfig` call,
  which blocks the next message from reaching the SDK's steer mechanism
- Change to fire-and-forget dispatch within the queue task, matching the pattern used by
  OpenClaw's Discord inbound-worker (`void runQueue.enqueue(...)`)

## Root Cause

The serial queue (`enqueueFeishuChatTask` in `chat-queue.ts`) chains tasks via `prev.then(task, task)`, where each `task` awaits `withTicket → handleFeishuMessage → dispatchReplyFromConfig()` — which blocks for the entire LLM inference + reply delivery (tens of seconds to minutes).

This means the second message's task cannot start until the first agent run fully completes:

```
msg1 → enqueueFeishuChatTask → task starts → await dispatchReplyFromConfig → agent running...
msg2 → enqueueFeishuChatTask → prev.then(task) → waits for msg1's task ← BLOCKED HERE
                                                   ↓
                                   msg2 never reaches SDK's steer mechanism
```

The SDK's steer queue action (`resolveActiveRunQueueAction`) correctly returns `"enqueue-followup"` when `isActive === true && queueMode === "steer"`, but the second message never reaches `runReplyAgent` because it's stuck behind the serial queue.

**WeCom (working correctly)**: No per-session serial queue; each message independently calls `dispatchReplyFromConfig`.

**Discord (working correctly)**: Uses `void runQueue.enqueue(...)` — fire-and-forget pattern.

## Fix

Make the dispatch within the queue task fire-and-forget (`void` instead of `await`). The queue still guarantees per-chat message ordering (tasks start serially), but individual agent runs execute concurrently in the background.

```diff
 task: async () => {
-  try {
-    await withTicket({ ... }, () => handleFeishuMessage({ ... }));
-  } catch (err) {
-    error(`feishu[${accountId}]: error handling message: ${String(err)}`);
-  }
+  const result = withTicket({ ... }, () => handleFeishuMessage({ ... }));
+  void Promise.resolve(result).catch((err: unknown) => {
+    error(`feishu[${accountId}]: error handling message: ${String(err)}`);
+  });
 },
```

Note: `withTicket` returns `T | Promise<T>`, so `Promise.resolve(result)` is used to normalize the return type before attaching `.catch()`.

### Safety analysis

| Concern | Status | Detail |
|---------|--------|--------|
| Reply delivery | ✅ Safe | `dispatcher.deliver` callback bound at creation time, works async |
| Streaming card final update | ✅ Safe | `markFullyComplete()` runs inside `dispatchNormalMessage` try block |
| Typing indicator cleanup | ✅ Safe | `markDispatchIdle()` runs in dispatch finally block |
| Active dispatcher registry | ✅ Safe | `registerActiveDispatcher` / `unregisterActiveDispatcher` in dispatch try/finally |
| Abort fast-path | ✅ Safe | Dispatcher registered before dispatch starts, stays valid during background run |
| Error handling | ✅ Safe | Changed from `try/catch` to `.catch()` — errors still logged |
| Concurrent agent runs | ✅ Safe | SDK's steer mechanism injects into current run or enqueues followup — no parallel runs |

### What's NOT changed (intentionally)

- **`synthetic-message.ts`** and **`ask-user-question.ts`**: These callers `await promise` because they are interactive flows that need the dispatch result. They should remain blocking.
- **Reaction event handler**: Uses the same `enqueueFeishuChatTask` + `await withTicket` pattern. Could benefit from the same fix for consistency, but reaction dispatches are typically fast, so this is lower priority.
- **`dispatch.ts` internals**: `waitForIdle`, `markFullyComplete`, `registerActiveDispatcher` — all run inside the background promise and continue to work correctly.

## Test Plan

- [ ] Send two messages in quick succession in the same chat (steer mode enabled)
- [ ] Verify the second message is processed without waiting for the first to complete
- [ ] Verify the first message's streaming card / reply completes normally
- [ ] Verify error handling: simulate a dispatch failure and check error logs
- [ ] Verify abort fast-path still works (send abort command during active run)
- [ ] Verify non-steer modes (collect, followup) still work correctly
- [ ] Verify `ask-user-question` and synthetic message flows still work (they should — not changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)