### PR TITLE
feat: add Feishu QR onboarding login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,22 @@ Before you start, make sure you have the following:
 
 [How to Use the Official Lark/Feishu Plugin for OpenClaw](https://bytedance.larkoffice.com/docx/MFK7dDFLFoVlOGxWCv5cTXKmnMh)
 
+### QR Pairing
+
+After the plugin is installed and enabled, you can create and pair a new Feishu/Lark bot directly from OpenClaw:
+
+```bash
+openclaw channels login --channel feishu
+```
+
+`openclaw channels login --channel openclaw-lark` works as an alias as well.
+
+For control-plane or dashboard integrations, the plugin also supports the gateway `web.login.start` / `web.login.wait` flow:
+
+- `web.login.start` returns a QR data URL plus the login link.
+- `web.login.wait` polls the official registration session until the new bot is created.
+- On success, the plugin writes the generated `appId` / `appSecret` back into `channels.feishu` so the gateway can start the channel immediately.
+
 ## Contributing
 
 Community contributions are welcome! If you find a bug or have feature suggestions, please submit an [Issue](https://github.com/larksuite/openclaw-larksuite/issues) or a [Pull Request](https://github.com/larksuite/openclaw-larksuite/pulls).

--- a/README.zh.md
+++ b/README.zh.md
@@ -59,6 +59,26 @@
 ## 使用说明
 [OpenClaw  Lark/飞书官方插件使用指南](https://bytedance.larkoffice.com/docx/MFK7dDFLFoVlOGxWCv5cTXKmnMh)
 
+### 二维码配对
+
+插件安装并启用后，可以直接通过 OpenClaw 创建并配对一个新的飞书/Lark 机器人：
+
+```bash
+openclaw channels login --channel feishu
+```
+
+也支持使用别名：
+
+```bash
+openclaw channels login --channel openclaw-lark
+```
+
+对于控制台 / Dashboard 集成，插件同时支持 gateway 的 `web.login.start` / `web.login.wait` 流程：
+
+- `web.login.start` 返回二维码 Data URL 和登录链接。
+- `web.login.wait` 轮询官方注册会话，直到新机器人创建完成。
+- 成功后，插件会将生成的 `appId` / `appSecret` 回写到 `channels.feishu`，网关可以立即启动该 channel。
+
 ## 贡献
 
 我们欢迎社区的贡献！如果你发现 Bug 或有功能建议，请随时提交 [Issue](https://github.com/larksuite/openclaw-larksuite/issues) 或 [Pull Request](https://github.com/larksuite/openclaw-larksuite/pulls)。

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@larksuiteoapi/node-sdk": "^1.60.0",
     "@sinclair/typebox": "0.34.48",
     "image-size": "^2.0.2",
+    "qrcode": "^1.5.4",
     "zod": "^4.3.6"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "zod": "^4.3.6"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.3.22"
+    "openclaw": ">=2026.4.27"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       image-size:
         specifier: ^2.0.2
         version: 2.0.2
+      qrcode:
+        specifier: ^1.5.4
+        version: 1.5.4
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1730,6 +1733,10 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
+    engines: {node: '>=6'}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -1754,6 +1761,9 @@ packages:
     resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
     engines: {node: '>=8.0.0', npm: '>=5.0.0'}
     hasBin: true
+
+  cliui@6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
   cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
@@ -1845,6 +1855,10 @@ packages:
       supports-color:
         optional: true
 
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1870,6 +1884,9 @@ packages:
   diff@8.0.3:
     resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
+
+  dijkstrajs@1.0.3:
+    resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -2172,6 +2189,10 @@ packages:
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
+
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -2635,6 +2656,10 @@ packages:
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
 
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -2867,9 +2892,17 @@ packages:
     resolution: {integrity: sha512-4/8JfsetakdeEa4vAYV45FW20aY+B/+K8NEXp5Eiar3wR8726whgHrbSg5Ar/ZY1FLJ/AGtUqV7W2IVF+Gvp9A==}
     engines: {node: '>=20'}
 
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
+
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
 
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
@@ -2886,6 +2919,10 @@ packages:
   p-timeout@4.1.0:
     resolution: {integrity: sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==}
     engines: {node: '>=10'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
 
   pac-proxy-agent@7.2.0:
     resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
@@ -2978,6 +3015,10 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  pngjs@5.0.0:
+    resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
+    engines: {node: '>=10.13.0'}
+
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -3031,6 +3072,11 @@ packages:
     resolution: {integrity: sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==}
     hasBin: true
 
+  qrcode@1.5.4:
+    resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+
   qs@6.15.0:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
@@ -3060,6 +3106,9 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  require-main-filename@2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -3145,6 +3194,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
@@ -3579,6 +3631,9 @@ packages:
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
+  which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -3592,6 +3647,10 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -3616,6 +3675,9 @@ packages:
       utf-8-validate:
         optional: true
 
+  y18n@4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -3629,6 +3691,10 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+
   yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
@@ -3636,6 +3702,10 @@ packages:
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+
+  yargs@15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
 
   yargs@16.2.0:
     resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
@@ -5819,6 +5889,8 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  camelcase@5.3.1: {}
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
@@ -5842,6 +5914,12 @@ snapshots:
       parse5: 5.1.1
       parse5-htmlparser2-tree-adapter: 6.0.1
       yargs: 16.2.0
+
+  cliui@6.0.0:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
 
   cliui@7.0.4:
     dependencies:
@@ -5916,6 +5994,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decamelize@1.2.0: {}
+
   deep-is@0.1.4: {}
 
   defu@6.1.4: {}
@@ -5933,6 +6013,8 @@ snapshots:
   detect-libc@2.1.2: {}
 
   diff@8.0.3: {}
+
+  dijkstrajs@1.0.3: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -6300,6 +6382,11 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
 
   find-up@5.0.0:
     dependencies:
@@ -6751,6 +6838,10 @@ snapshots:
     dependencies:
       uc.micro: 2.1.0
 
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -7014,9 +7105,17 @@ snapshots:
 
   osc-progress@0.3.0: {}
 
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
+
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
 
   p-locate@5.0.0:
     dependencies:
@@ -7033,6 +7132,8 @@ snapshots:
 
   p-timeout@4.1.0:
     optional: true
+
+  p-try@2.2.0: {}
 
   pac-proxy-agent@7.2.0:
     dependencies:
@@ -7111,6 +7212,8 @@ snapshots:
 
   playwright-core@1.58.2: {}
 
+  pngjs@5.0.0: {}
+
   postcss@8.5.8:
     dependencies:
       nanoid: 3.3.11
@@ -7179,6 +7282,12 @@ snapshots:
 
   qrcode-terminal@0.12.0: {}
 
+  qrcode@1.5.4:
+    dependencies:
+      dijkstrajs: 1.0.3
+      pngjs: 5.0.0
+      yargs: 15.4.1
+
   qs@6.15.0:
     dependencies:
       side-channel: 1.1.0
@@ -7209,6 +7318,8 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  require-main-filename@2.0.0: {}
 
   resolve-from@4.0.0: {}
 
@@ -7333,6 +7444,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  set-blocking@2.0.0: {}
 
   setimmediate@1.0.5: {}
 
@@ -7745,6 +7858,8 @@ snapshots:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
 
+  which-module@2.0.1: {}
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -7755,6 +7870,12 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -7772,15 +7893,36 @@ snapshots:
 
   ws@8.20.0: {}
 
+  y18n@4.0.3: {}
+
   y18n@5.0.8: {}
 
   yallist@5.0.0: {}
 
   yaml@2.8.3: {}
 
+  yargs-parser@18.1.3:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+
   yargs-parser@20.2.9: {}
 
   yargs-parser@21.1.1: {}
+
+  yargs@15.4.1:
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
 
   yargs@16.2.0:
     dependencies:

--- a/src/channel/plugin.ts
+++ b/src/channel/plugin.ts
@@ -25,6 +25,7 @@ import { triggerOnboarding } from '../tools/onboarding-auth';
 import { larkLogger } from '../core/lark-logger';
 import { FEISHU_CONFIG_JSON_SCHEMA } from '../core/config-schema';
 import { applyAccountConfig, collectFeishuSecurityWarnings, deleteAccount, setAccountEnabled } from './config-adapter';
+import { runFeishuQrLoginCli, startFeishuQrLogin, waitForFeishuQrLogin } from './qr-login';
 import {
   listFeishuDirectoryGroups,
   listFeishuDirectoryGroupsLive,
@@ -67,7 +68,7 @@ const meta = {
   docsPath: '/channels/feishu',
   docsLabel: 'feishu',
   blurb: '\u98DE\u4E66/Lark enterprise messaging.',
-  aliases: ['lark'],
+  aliases: ['lark', 'openclaw-lark'],
   order: 70,
 };
 
@@ -221,6 +222,16 @@ export const feishuPlugin: ChannelPlugin<LarkAccount> = {
   },
 
   // -------------------------------------------------------------------------
+  // Auth
+  // -------------------------------------------------------------------------
+
+  auth: {
+    login: async ({ accountId, runtime }) => {
+      await runFeishuQrLoginCli({ accountId, runtime });
+    },
+  },
+
+  // -------------------------------------------------------------------------
   // Messaging
   // -------------------------------------------------------------------------
 
@@ -334,6 +345,14 @@ export const feishuPlugin: ChannelPlugin<LarkAccount> = {
       ctx.log?.info(`stopping feishu[${ctx.accountId}]`);
       await LarkClient.clearCache(ctx.accountId);
       ctx.log?.info(`stopped feishu[${ctx.accountId}]`);
+    },
+
+    loginWithQrStart: async ({ accountId, force }) => {
+      return await startFeishuQrLogin({ accountId, force });
+    },
+
+    loginWithQrWait: async ({ accountId, timeoutMs }) => {
+      return await waitForFeishuQrLogin({ accountId, timeoutMs });
     },
   },
 };

--- a/src/channel/plugin.ts
+++ b/src/channel/plugin.ts
@@ -322,6 +322,8 @@ export const feishuPlugin: ChannelPlugin<LarkAccount> = {
     }),
   },
 
+  gatewayMethods: ['web.login.start', 'web.login.wait'],
+
   // -------------------------------------------------------------------------
   // Gateway
   // -------------------------------------------------------------------------

--- a/src/channel/qr-login.ts
+++ b/src/channel/qr-login.ts
@@ -1,0 +1,431 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Feishu/Lark QR onboarding for both local CLI and remote dashboard flows.
+ *
+ * This mirrors the official onboarding tool's registration API:
+ *   1. init   -> check supported auth methods
+ *   2. begin  -> create a registration session and QR/login URL
+ *   3. poll   -> wait until the user finishes scan + app creation
+ *
+ * On success, the new bot credentials are written back into OpenClaw config
+ * so the gateway can immediately start the Feishu channel.
+ */
+
+import QRCode from 'qrcode';
+import type { ClawdbotConfig, RuntimeEnv } from 'openclaw/plugin-sdk';
+import { DEFAULT_ACCOUNT_ID } from 'openclaw/plugin-sdk/account-id';
+import { loadConfig, writeConfigFile } from 'openclaw/plugin-sdk/config-runtime';
+import { getLarkAccount } from '../core/accounts';
+import { accountsDomain } from '../core/domains';
+import { feishuFetch } from '../core/feishu-fetch';
+import { LarkClient } from '../core/lark-client';
+import type { LarkBrand } from '../core/types';
+import { applyAccountConfig } from './config-adapter';
+
+const REGISTRATION_PATH = '/oauth/v1/app/registration';
+const REGISTRATION_ARCHETYPE = 'PersonalAgent';
+const DEFAULT_WAIT_TIMEOUT_MS = 30_000;
+const MAX_POLL_INTERVAL_MS = 60_000;
+
+interface RegistrationInitResponse {
+  supported_auth_methods?: string[];
+}
+
+interface RegistrationBeginResponse {
+  device_code?: string;
+  verification_uri?: string;
+  verification_uri_complete?: string;
+  interval?: number;
+  expire_in?: number;
+  error?: string;
+  error_description?: string;
+}
+
+interface RegistrationPollResponse {
+  client_id?: string;
+  client_secret?: string;
+  error?: string;
+  error_description?: string;
+  user_info?: {
+    open_id?: string;
+    tenant_brand?: string;
+  };
+}
+
+interface FeishuQrLoginSuccess {
+  appId: string;
+  appSecret: string;
+  brand: LarkBrand;
+  userOpenId?: string;
+  hasUserInfo: boolean;
+}
+
+interface FeishuQrLoginSession {
+  accountId: string;
+  brand: LarkBrand;
+  verificationUrl: string;
+  qrDataUrl: string;
+  deviceCode: string;
+  pollIntervalMs: number;
+  expiresAt: number;
+  state: 'pending' | 'connected' | 'failed';
+  success?: FeishuQrLoginSuccess;
+  failureMessage?: string;
+  persisted: boolean;
+}
+
+interface FeishuQrLoginStartResult {
+  qrDataUrl?: string;
+  message: string;
+}
+
+interface FeishuQrLoginWaitResult {
+  connected: boolean;
+  message: string;
+}
+
+const sessions = new Map<string, FeishuQrLoginSession>();
+
+function normalizeAccountId(accountId?: string | null): string {
+  return accountId?.trim() || DEFAULT_ACCOUNT_ID;
+}
+
+function registrationUrl(brand: LarkBrand): string {
+  return `${accountsDomain(brand)}${REGISTRATION_PATH}`;
+}
+
+async function postRegistrationJson(
+  brand: LarkBrand,
+  action: 'init' | 'begin' | 'poll',
+  body: Record<string, string>,
+  opts?: { tolerateErrors?: boolean },
+): Promise<Record<string, unknown>> {
+  const resp = await feishuFetch(registrationUrl(brand), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ action, ...body }).toString(),
+  });
+
+  const text = await resp.text();
+  let data: Record<string, unknown>;
+  try {
+    data = JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    throw new Error(`Feishu registration ${action} failed: HTTP ${resp.status}`);
+  }
+
+  if (!resp.ok && !opts?.tolerateErrors) {
+    const detail = (data.error_description as string) ?? (data.error as string) ?? `HTTP ${resp.status}`;
+    throw new Error(`Feishu registration ${action} failed: ${detail}`);
+  }
+
+  return data;
+}
+
+async function initRegistration(brand: LarkBrand): Promise<RegistrationInitResponse> {
+  return (await postRegistrationJson(brand, 'init', {})) as RegistrationInitResponse;
+}
+
+async function beginRegistration(brand: LarkBrand): Promise<RegistrationBeginResponse> {
+  return (await postRegistrationJson(brand, 'begin', {
+    archetype: REGISTRATION_ARCHETYPE,
+    auth_method: 'client_secret',
+    request_user_info: 'open_id',
+  })) as RegistrationBeginResponse;
+}
+
+async function pollRegistration(brand: LarkBrand, deviceCode: string): Promise<RegistrationPollResponse> {
+  return (await postRegistrationJson(
+    brand,
+    'poll',
+    { device_code: deviceCode },
+    { tolerateErrors: true },
+  )) as RegistrationPollResponse;
+}
+
+function appendOnboardSource(url: string): string {
+  const parsed = new URL(url);
+  parsed.searchParams.set('from', 'onboard');
+  return parsed.toString();
+}
+
+function toStringList(values: unknown): string[] {
+  if (!Array.isArray(values)) return [];
+  return values.map((value) => String(value).trim()).filter(Boolean);
+}
+
+export function applyFeishuOnboardingConfig(
+  cfg: ClawdbotConfig,
+  accountId: string,
+  success: FeishuQrLoginSuccess,
+): ClawdbotConfig {
+  const current = getLarkAccount(cfg, accountId).config;
+
+  let next = applyAccountConfig(cfg, accountId, {
+    enabled: true,
+    appId: success.appId,
+    appSecret: success.appSecret,
+    domain: success.brand,
+    connectionMode: current.connectionMode ?? 'websocket',
+  });
+
+  if (success.userOpenId) {
+    const allowFrom = new Set([...toStringList(current.allowFrom), success.userOpenId]);
+    next = applyAccountConfig(next, accountId, {
+      dmPolicy: 'allowlist',
+      allowFrom: [...allowFrom],
+    });
+
+    if (!current.groupPolicy) {
+      const groupAllowFrom = new Set([...toStringList(current.groupAllowFrom), success.userOpenId]);
+      next = applyAccountConfig(next, accountId, {
+        groupPolicy: 'allowlist',
+        groupAllowFrom: [...groupAllowFrom],
+        groups: current.groups ?? { '*': { enabled: true } },
+      });
+    }
+  } else if (success.hasUserInfo) {
+    next = applyAccountConfig(next, accountId, {
+      dmPolicy: current.dmPolicy ?? 'open',
+    });
+  } else if (!current.dmPolicy) {
+    next = applyAccountConfig(next, accountId, {
+      dmPolicy: 'pairing',
+    });
+  }
+
+  if (!getLarkAccount(next, accountId).config.groupPolicy) {
+    next = applyAccountConfig(next, accountId, { groupPolicy: 'open' });
+  }
+
+  return next;
+}
+
+function buildStartMessage(session: FeishuQrLoginSession): string {
+  return [
+    'Scan the QR code with Feishu/Lark to create and pair a new bot.',
+    `Open this link if QR scanning is unavailable: ${session.verificationUrl}`,
+    `Account: ${session.accountId}`,
+  ].join('\n');
+}
+
+function buildPendingMessage(session: FeishuQrLoginSession): string {
+  return ['Waiting for Feishu/Lark onboarding to complete.', `You can still open: ${session.verificationUrl}`].join(
+    '\n',
+  );
+}
+
+function buildSuccessMessage(session: FeishuQrLoginSession): string {
+  const details = [
+    `Feishu bot created and paired successfully for account ${session.accountId}.`,
+    `App ID: ${session.success?.appId}`,
+    `Domain: ${session.success?.brand}`,
+  ];
+  if (session.success?.userOpenId) {
+    details.push(`Owner open_id added to allowlists: ${session.success.userOpenId}`);
+  }
+  return details.join('\n');
+}
+
+async function persistConnectedSession(session: FeishuQrLoginSession): Promise<void> {
+  if (session.persisted || !session.success) return;
+
+  const currentConfig = loadConfig() as ClawdbotConfig;
+  const nextConfig = applyFeishuOnboardingConfig(currentConfig, session.accountId, session.success);
+
+  await writeConfigFile(nextConfig);
+  await LarkClient.clearCache(session.accountId);
+  session.persisted = true;
+}
+
+function resolveInitialBrand(accountId: string): LarkBrand {
+  try {
+    return getLarkAccount(loadConfig() as ClawdbotConfig, accountId).brand ?? 'feishu';
+  } catch {
+    return 'feishu';
+  }
+}
+
+async function createSession(accountId: string): Promise<FeishuQrLoginSession> {
+  const initialBrand = resolveInitialBrand(accountId);
+  const init = await initRegistration(initialBrand);
+  const supportedMethods = Array.isArray(init.supported_auth_methods) ? init.supported_auth_methods : [];
+  if (!supportedMethods.includes('client_secret')) {
+    throw new Error('Current Feishu environment does not support client_secret onboarding');
+  }
+
+  const begin = await beginRegistration(initialBrand);
+  const verificationUrlRaw = begin.verification_uri_complete ?? begin.verification_uri;
+  const deviceCode = begin.device_code;
+  if (!verificationUrlRaw || !deviceCode) {
+    throw new Error(
+      `Feishu onboarding did not return a usable QR session (${begin.error_description ?? begin.error ?? 'missing fields'})`,
+    );
+  }
+
+  const verificationUrl = appendOnboardSource(verificationUrlRaw);
+  const qrDataUrl = await QRCode.toDataURL(verificationUrl, { margin: 1 });
+  return {
+    accountId,
+    brand: initialBrand,
+    verificationUrl,
+    qrDataUrl,
+    deviceCode,
+    pollIntervalMs: Math.max(0, (begin.interval ?? 5) * 1000),
+    expiresAt: Date.now() + Math.max(1, begin.expire_in ?? 600) * 1000,
+    state: 'pending',
+    persisted: false,
+  };
+}
+
+export async function startFeishuQrLogin(
+  params: {
+    accountId?: string | null;
+    force?: boolean;
+  } = {},
+): Promise<FeishuQrLoginStartResult> {
+  const accountId = normalizeAccountId(params.accountId);
+  const existing = sessions.get(accountId);
+  if (existing && existing.state === 'pending' && !params.force && Date.now() < existing.expiresAt) {
+    return {
+      qrDataUrl: existing.qrDataUrl,
+      message: buildStartMessage(existing),
+    };
+  }
+
+  const session = await createSession(accountId);
+  sessions.set(accountId, session);
+  return {
+    qrDataUrl: session.qrDataUrl,
+    message: buildStartMessage(session),
+  };
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function waitForFeishuQrLogin(
+  params: {
+    accountId?: string | null;
+    timeoutMs?: number;
+  } = {},
+): Promise<FeishuQrLoginWaitResult> {
+  const accountId = normalizeAccountId(params.accountId);
+  const session = sessions.get(accountId);
+  if (!session) {
+    return {
+      connected: false,
+      message: `No active Feishu onboarding session for account ${accountId}. Start a new login first.`,
+    };
+  }
+
+  if (session.state === 'connected') {
+    await persistConnectedSession(session);
+    return { connected: true, message: buildSuccessMessage(session) };
+  }
+
+  if (session.state === 'failed') {
+    return { connected: false, message: session.failureMessage ?? 'Feishu onboarding failed.' };
+  }
+
+  const timeoutMs = Math.max(0, params.timeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS);
+  const deadline = Math.min(Date.now() + timeoutMs, session.expiresAt);
+
+  while (Date.now() <= deadline) {
+    const poll = await pollRegistration(session.brand, session.deviceCode);
+    const pollBrand = poll.user_info?.tenant_brand;
+    if (pollBrand === 'lark') {
+      session.brand = 'lark';
+    }
+
+    if (poll.client_id && poll.client_secret) {
+      session.state = 'connected';
+      session.success = {
+        appId: poll.client_id,
+        appSecret: poll.client_secret,
+        brand: session.brand,
+        userOpenId: poll.user_info?.open_id,
+        hasUserInfo: Boolean(poll.user_info),
+      };
+      await persistConnectedSession(session);
+      return { connected: true, message: buildSuccessMessage(session) };
+    }
+
+    switch (poll.error) {
+      case undefined:
+      case 'authorization_pending':
+        break;
+      case 'slow_down':
+        session.pollIntervalMs = Math.min(session.pollIntervalMs + 5_000, MAX_POLL_INTERVAL_MS);
+        break;
+      case 'access_denied':
+        session.state = 'failed';
+        session.failureMessage = 'Feishu onboarding was denied by the user.';
+        return { connected: false, message: session.failureMessage };
+      case 'expired_token':
+        session.state = 'failed';
+        session.failureMessage = 'Feishu onboarding session expired. Start a new login.';
+        return { connected: false, message: session.failureMessage };
+      default:
+        session.state = 'failed';
+        session.failureMessage = `Feishu onboarding failed: ${poll.error_description ?? poll.error}`;
+        return { connected: false, message: session.failureMessage };
+    }
+
+    if (Date.now() >= deadline) break;
+    if (session.pollIntervalMs > 0) {
+      await sleep(Math.min(session.pollIntervalMs, Math.max(0, deadline - Date.now())));
+    }
+  }
+
+  if (Date.now() >= session.expiresAt) {
+    session.state = 'failed';
+    session.failureMessage = 'Feishu onboarding session expired. Start a new login.';
+    return { connected: false, message: session.failureMessage };
+  }
+
+  return {
+    connected: false,
+    message: buildPendingMessage(session),
+  };
+}
+
+export async function runFeishuQrLoginCli(params: {
+  accountId?: string | null;
+  runtime: RuntimeEnv;
+  force?: boolean;
+}): Promise<void> {
+  const accountId = normalizeAccountId(params.accountId);
+  await startFeishuQrLogin({
+    accountId,
+    force: params.force,
+  });
+  const session = sessions.get(accountId);
+  if (!session) {
+    throw new Error('Failed to initialize Feishu onboarding session');
+  }
+
+  params.runtime.log('Scan with Feishu/Lark to configure your bot:');
+  params.runtime.log(session.verificationUrl);
+
+  const terminalQr = await QRCode.toString(session.verificationUrl, { type: 'terminal', small: true });
+  params.runtime.log(terminalQr);
+
+  const waited = await waitForFeishuQrLogin({
+    accountId,
+    timeoutMs: Math.max(0, session.expiresAt - Date.now()),
+  });
+
+  if (!waited.connected) {
+    throw new Error(waited.message);
+  }
+
+  params.runtime.log(waited.message);
+}
+
+export function _resetFeishuQrLoginSessions(): void {
+  sessions.clear();
+}

--- a/src/core/domains.ts
+++ b/src/core/domains.ts
@@ -19,6 +19,24 @@ export function openPlatformDomain(brand?: LarkBrand): string {
   return brand === 'lark' ? 'https://open.larksuite.com' : 'https://open.feishu.cn';
 }
 
+/** 账号/注册域名 */
+export function accountsDomain(brand?: LarkBrand): string {
+  if (!brand || brand === 'feishu') return 'https://accounts.feishu.cn';
+  if (brand === 'lark') return 'https://accounts.larksuite.com';
+
+  const base = brand.replace(/\/+$/, '');
+  try {
+    const parsed = new URL(base);
+    if (parsed.hostname.startsWith('open.')) {
+      return `${parsed.protocol}//${parsed.hostname.replace(/^open\./, 'accounts.')}`;
+    }
+  } catch {
+    // Fall through to the raw custom brand string.
+  }
+
+  return base;
+}
+
 /** Applink 域名 */
 export function applinkDomain(brand?: LarkBrand): string {
   return brand === 'lark' ? 'https://applink.larksuite.com' : 'https://applink.feishu.cn';

--- a/tests/qr-login.test.ts
+++ b/tests/qr-login.test.ts
@@ -171,4 +171,60 @@ describe('Feishu QR login', () => {
       },
     });
   });
+
+  it('wires the current OpenClaw web login contract through the channel plugin', async () => {
+    const qrLogin = await import('../src/channel/qr-login');
+    const runCliSpy = vi.spyOn(qrLogin, 'runFeishuQrLoginCli').mockResolvedValue(undefined);
+    const startSpy = vi.spyOn(qrLogin, 'startFeishuQrLogin').mockResolvedValue({
+      qrDataUrl: 'data:image/png;base64,plugin-qr',
+      message: 'plugin start',
+    });
+    const waitSpy = vi.spyOn(qrLogin, 'waitForFeishuQrLogin').mockResolvedValue({
+      connected: true,
+      message: 'plugin wait',
+    });
+
+    const { feishuPlugin } = await import('../src/channel/plugin');
+    const runtime = { log: vi.fn() };
+
+    expect(feishuPlugin.meta.aliases).toContain('openclaw-lark');
+    expect(feishuPlugin.gatewayMethods).toEqual(['web.login.start', 'web.login.wait']);
+
+    await feishuPlugin.auth?.login?.({
+      cfg: { channels: { feishu: {} } } as unknown as ClawdbotConfig,
+      accountId: 'default',
+      runtime: runtime as never,
+      channelInput: 'feishu',
+    });
+    expect(runCliSpy).toHaveBeenCalledWith({
+      accountId: 'default',
+      runtime,
+    });
+
+    const started = await feishuPlugin.gateway?.loginWithQrStart?.({
+      accountId: 'default',
+      force: true,
+    });
+    expect(started).toEqual({
+      qrDataUrl: 'data:image/png;base64,plugin-qr',
+      message: 'plugin start',
+    });
+    expect(startSpy).toHaveBeenCalledWith({
+      accountId: 'default',
+      force: true,
+    });
+
+    const waited = await feishuPlugin.gateway?.loginWithQrWait?.({
+      accountId: 'default',
+      timeoutMs: 1234,
+    });
+    expect(waited).toEqual({
+      connected: true,
+      message: 'plugin wait',
+    });
+    expect(waitSpy).toHaveBeenCalledWith({
+      accountId: 'default',
+      timeoutMs: 1234,
+    });
+  });
 });

--- a/tests/qr-login.test.ts
+++ b/tests/qr-login.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ */
+
+import type { ClawdbotConfig } from 'openclaw/plugin-sdk';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const loadConfigMock = vi.fn<() => ClawdbotConfig>();
+const writeConfigFileMock = vi.fn<(cfg: ClawdbotConfig) => Promise<void>>();
+const clearCacheMock = vi.fn<(accountId?: string) => Promise<void>>();
+const toDataURLMock = vi.fn<(text: string) => Promise<string>>();
+const toStringMock = vi.fn<(text: string, options?: unknown) => Promise<string>>();
+const feishuFetchMock = vi.fn<(url: string | URL | Request, init?: RequestInit) => Promise<Response>>();
+
+vi.mock('openclaw/plugin-sdk/config-runtime', () => ({
+  loadConfig: loadConfigMock,
+  writeConfigFile: writeConfigFileMock,
+}));
+
+vi.mock('qrcode', () => ({
+  default: {
+    toDataURL: toDataURLMock,
+    toString: toStringMock,
+  },
+}));
+
+vi.mock('../src/core/feishu-fetch', () => ({
+  feishuFetch: feishuFetchMock,
+}));
+
+vi.mock('../src/core/lark-client', () => ({
+  LarkClient: {
+    clearCache: clearCacheMock,
+  },
+}));
+
+function jsonResponse(body: Record<string, unknown>, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('Feishu QR login', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    loadConfigMock.mockReset();
+    writeConfigFileMock.mockReset();
+    clearCacheMock.mockReset();
+    toDataURLMock.mockReset();
+    toStringMock.mockReset();
+    feishuFetchMock.mockReset();
+
+    loadConfigMock.mockReturnValue({ channels: { feishu: {} } });
+    writeConfigFileMock.mockResolvedValue();
+    clearCacheMock.mockResolvedValue();
+    toDataURLMock.mockResolvedValue('data:image/png;base64,qr');
+    toStringMock.mockResolvedValue('qr');
+  });
+
+  it('applies onboarding credentials to the default account config', async () => {
+    const { applyFeishuOnboardingConfig } = await import('../src/channel/qr-login');
+
+    const next = applyFeishuOnboardingConfig(
+      { channels: { feishu: { enabled: false } } },
+      'default',
+      {
+        appId: 'cli_test',
+        appSecret: 'secret_test',
+        brand: 'lark',
+        userOpenId: 'ou_owner',
+        hasUserInfo: true,
+      },
+    );
+
+    expect(next.channels?.feishu).toMatchObject({
+      enabled: true,
+      appId: 'cli_test',
+      appSecret: 'secret_test',
+      domain: 'lark',
+      dmPolicy: 'allowlist',
+      groupPolicy: 'allowlist',
+      allowFrom: ['ou_owner'],
+      groupAllowFrom: ['ou_owner'],
+      groups: { '*': { enabled: true } },
+    });
+  });
+
+  it('starts a QR session, waits for success, and persists the bot credentials', async () => {
+    feishuFetchMock
+      .mockResolvedValueOnce(jsonResponse({ supported_auth_methods: ['client_secret'] }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          device_code: 'dev_123',
+          verification_uri_complete: 'https://accounts.feishu.cn/device?ticket=123',
+          interval: 0,
+          expire_in: 600,
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          client_id: 'cli_generated',
+          client_secret: 'secret_generated',
+          user_info: { open_id: 'ou_owner' },
+        }),
+      );
+
+    const qrLogin = await import('../src/channel/qr-login');
+    const started = await qrLogin.startFeishuQrLogin({ accountId: 'default' });
+    const waited = await qrLogin.waitForFeishuQrLogin({ accountId: 'default', timeoutMs: 5 });
+
+    expect(started.qrDataUrl).toBe('data:image/png;base64,qr');
+    expect(started.message).toContain('https://accounts.feishu.cn/device?ticket=123&from=onboard');
+    expect(waited).toEqual({
+      connected: true,
+      message: expect.stringContaining('cli_generated'),
+    });
+    expect(writeConfigFileMock).toHaveBeenCalledTimes(1);
+    expect(writeConfigFileMock.mock.calls[0]?.[0]).toMatchObject({
+      channels: {
+        feishu: {
+          appId: 'cli_generated',
+          appSecret: 'secret_generated',
+          dmPolicy: 'allowlist',
+          allowFrom: ['ou_owner'],
+        },
+      },
+    });
+    expect(clearCacheMock).toHaveBeenCalledWith('default');
+  });
+
+  it('switches polling to the Lark accounts domain when tenant_brand indicates lark', async () => {
+    feishuFetchMock
+      .mockResolvedValueOnce(jsonResponse({ supported_auth_methods: ['client_secret'] }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          device_code: 'dev_lark',
+          verification_uri_complete: 'https://accounts.feishu.cn/device?ticket=lark',
+          interval: 0,
+          expire_in: 600,
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          error: 'authorization_pending',
+          user_info: { tenant_brand: 'lark' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          client_id: 'cli_lark',
+          client_secret: 'secret_lark',
+          user_info: { open_id: 'ou_lark_owner', tenant_brand: 'lark' },
+        }),
+      );
+
+    const qrLogin = await import('../src/channel/qr-login');
+    await qrLogin.startFeishuQrLogin({ accountId: 'default' });
+    const waited = await qrLogin.waitForFeishuQrLogin({ accountId: 'default', timeoutMs: 10 });
+
+    expect(waited.connected).toBe(true);
+    expect(String(feishuFetchMock.mock.calls[2]?.[0])).toContain('https://accounts.feishu.cn');
+    expect(String(feishuFetchMock.mock.calls[3]?.[0])).toContain('https://accounts.larksuite.com');
+    expect(writeConfigFileMock.mock.calls[0]?.[0]).toMatchObject({
+      channels: {
+        feishu: {
+          domain: 'lark',
+          appId: 'cli_lark',
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Refresh Note (2026-04-08)

This PR has been refreshed against the latest `main` and revalidated against the current OpenClaw web-login flow used by `openclaw@2026.4.5`.

The intended remote pairing contract is still:

- `web.login.start`
- `web.login.wait`

On the plugin side, this PR now explicitly wires that through:

- `gatewayMethods = ["web.login.start", "web.login.wait"]`
- `gateway.loginWithQrStart`
- `gateway.loginWithQrWait`

So this PR is now aligned with the current provider discovery path used by OpenClaw web login.

Closes #310.

## What This PR Adds

This PR adds a structured Feishu/Lark QR onboarding flow so Feishu pairing can work in both local and remote / hosted scenarios:

- `openclaw channels login --channel feishu`
- `openclaw channels login --channel openclaw-lark`
- dashboard / control-plane initiated pairing through `web.login.start` + `web.login.wait`

It does this by:

- adding a dedicated `src/channel/qr-login.ts` session manager
- calling the official Feishu/Lark registration endpoints: `init` / `begin` / `poll`
- returning structured QR data (`qrDataUrl`) and login message for remote consumers
- persisting the generated `appId` / `appSecret` back into `channels.feishu`
- auto-filling DM/group allowlists with the owner `open_id` when available
- exposing the flow through both local auth login and gateway QR login hooks
- registering the current OpenClaw web-login methods on the plugin
- adding `openclaw-lark` as a compatibility alias for the `feishu` channel

## Changed Files (8)

1. `README.md`
2. `README.zh.md`
3. `package.json`
4. `pnpm-lock.yaml`
5. `src/channel/plugin.ts`
6. `src/channel/qr-login.ts`
7. `src/core/domains.ts`
8. `tests/qr-login.test.ts`

## Test Coverage

`tests/qr-login.test.ts` now covers four concrete cases:

1. onboarding credentials are applied back into `channels.feishu`
2. QR session start + wait persists generated bot credentials
3. polling switches from Feishu accounts domain to Lark accounts domain when `tenant_brand=lark`
4. the channel plugin wiring is correct for the current OpenClaw contract:
   - `meta.aliases` contains `openclaw-lark`
   - `gatewayMethods` advertises `web.login.start` / `web.login.wait`
   - `auth.login` delegates to the CLI QR flow
   - `gateway.loginWithQrStart` / `gateway.loginWithQrWait` delegate to the QR session helpers

## Validation

I rechecked this branch against the current published packages:

- `openclaw@2026.4.5`
- `@larksuite/openclaw-lark@2026.4.7`

and confirmed:

- the latest published plugin still does not include this Feishu QR onboarding flow
- the current OpenClaw gateway contract for remote login is still `web.login.start` / `web.login.wait`
- this PR's start/wait payload shape still matches the current plugin SDK expectations

## Testing

- `corepack pnpm lint` (repo has existing warnings only; no new lint errors from this PR)
- `corepack pnpm format:check`
- `corepack pnpm typecheck`
- `corepack pnpm test tests/qr-login.test.ts`
- `corepack pnpm test -- --runInBand`
- `corepack pnpm build`

Current local result on this branch: `17` test files passed, `150` tests passed.
