### PR TITLE
fix: deliver media payloads (e.g. TTS audio) in streaming card mode

### DIFF
--- a/src/card/reply-dispatcher.ts
+++ b/src/card/reply-dispatcher.ts
@@ -38,7 +38,7 @@ export type { CreateFeishuReplyDispatcherParams } from './reply-dispatcher-types
 
 export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherParams): FeishuReplyDispatcherResult {
   const core = LarkClient.runtime;
-  const { cfg, agentId, sessionKey, chatId, replyToMessageId, accountId, replyInThread } = params;
+  const { cfg, agentId, sessionKey, chatId, replyToMessageId, accountId, replyInThread, mediaLocalRoots } = params;
 
   // Resolve account so we can read per-account config (e.g. replyMode)
   const account = getLarkAccount(cfg, accountId);
@@ -228,6 +228,20 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
 
         if (controller.cardMessageId) {
           await controller.onDeliver(payload);
+          // Send attached media even in streaming card mode
+          if (payloadMediaUrls.length > 0) {
+            log.info('deliver: sending attached media in streaming mode', { count: payloadMediaUrls.length });
+            for (const mediaUrl of payloadMediaUrls) {
+              if (!mediaUrl?.trim()) continue;
+              try {
+                await sendMediaLark({
+                  cfg, to: chatId, mediaUrl, accountId, replyToMessageId, replyInThread, mediaLocalRoots,
+                });
+              } catch (mediaErr) {
+                log.error('deliver: streaming media send failed', { error: String(mediaErr) });
+              }
+            }
+          }
           return;
         }
         // Card creation failed — fall through to static delivery
@@ -334,6 +348,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             accountId,
             replyToMessageId,
             replyInThread,
+            mediaLocalRoots,
           });
         } catch (mediaErr) {
           if (staticGuard?.terminate('deliver.media', mediaErr)) return;

--- a/src/messaging/inbound/dispatch.ts
+++ b/src/messaging/inbound/dispatch.ts
@@ -92,6 +92,17 @@ async function dispatchNormalMessage(
     chatType: dc.ctx.chatType,
     skipTyping,
     replyInThread: dc.isThread,
+    // TODO: Extract from dispatch context once OpenClaw core exposes
+    // mediaLocalRoots to channel plugins (e.g. via dc.mediaLocalRoots).
+    // For now, fall back to the same defaults used by the OpenClaw
+    // web-media resolution layer.
+    mediaLocalRoots: dc.mediaLocalRoots ?? [
+      '/tmp/openclaw',
+      '/root/.openclaw/media',
+      '/root/.openclaw/agents',
+      '/root/.openclaw/workspace',
+      '/root/.openclaw/sandboxes',
+    ],
   });
 
   // Create an AbortController so the abort fast-path can cancel the


### PR DESCRIPTION
## Problem

When a tool result contains `mediaUrls` (e.g. the `tts` tool returning a generated audio file), the payload gets silently dropped in streaming card mode because `onDeliver()` handles only text and returns early.

The same issue affects the static media delivery path where `mediaLocalRoots` was not passed to `sendMediaLark`, causing local file access to fail with a security error.

## Changes

### `src/card/reply-dispatcher.ts`
1. **Destructure `mediaLocalRoots`** from dispatcher params (was missing)
2. **Streaming card mode**: After `onDeliver()`, check for `payloadMediaUrls` and send each via `sendMediaLark`
3. **Static media path**: Pass `mediaLocalRoots` to `sendMediaLark` call (was missing)

### `src/messaging/inbound/dispatch.ts`
4. **Pass `mediaLocalRoots`** from dispatch context into reply dispatcher, with fallback defaults matching OpenClaw's web-media resolution layer

## Result

TTS tool chain now works end-to-end on Feishu:
```
tts tool → mp3 → deliver callback → sendMediaLark → ffmpeg mp3→opus → voice bubble ✅
```

## Notes

- The hardcoded `mediaLocalRoots` fallback is a workaround. Ideally OpenClaw core should expose this to channel plugins via the dispatch context. See TODO in dispatch.ts.
- Tested on OpenClaw 2026.3.24 + openclaw-lark 2026.3.26