### PR TITLE
fix: reduce line spacing, fix metrics for non-default accounts, deep-…

### DIFF
--- a/src/card/builder.ts
+++ b/src/card/builder.ts
@@ -222,29 +222,43 @@ export function formatFooterRuntimeSegments(params: {
   elapsedMs?: number;
   isError?: boolean;
   isAborted?: boolean;
-}): { zh: string[]; en: string[] } {
+}): { primaryZh: string[]; primaryEn: string[]; detailZh: string[]; detailEn: string[] } {
   const { footer, metrics, elapsedMs, isError, isAborted } = params;
-  const zhParts: string[] = [];
-  const enParts: string[] = [];
+  const primaryZh: string[] = [];
+  const primaryEn: string[] = [];
+  const detailZh: string[] = [];
+  const detailEn: string[] = [];
+
+  // --- Primary line: status, elapsed, model ---
 
   if (footer?.status) {
     if (isError) {
-      zhParts.push('出错');
-      enParts.push('Error');
+      primaryZh.push('出错');
+      primaryEn.push('Error');
     } else if (isAborted) {
-      zhParts.push('已停止');
-      enParts.push('Stopped');
+      primaryZh.push('已停止');
+      primaryEn.push('Stopped');
     } else {
-      zhParts.push('已完成');
-      enParts.push('Completed');
+      primaryZh.push('已完成');
+      primaryEn.push('Completed');
     }
   }
 
   if (footer?.elapsed && elapsedMs != null) {
     const d = formatElapsed(elapsedMs);
-    zhParts.push(`耗时 ${d}`);
-    enParts.push(`Elapsed ${d}`);
+    primaryZh.push(`耗时 ${d}`);
+    primaryEn.push(`Elapsed ${d}`);
   }
+
+  if (footer?.model && metrics?.model) {
+    const model = metrics.model.trim();
+    if (model) {
+      primaryZh.push(model);
+      primaryEn.push(model);
+    }
+  }
+
+  // --- Detail line: tokens, cache, context ---
 
   if (footer?.tokens && metrics) {
     const inTokens = typeof metrics.inputTokens === 'number' ? Math.max(0, metrics.inputTokens) : undefined;
@@ -252,8 +266,8 @@ export function formatFooterRuntimeSegments(params: {
     if (inTokens != null && outTokens != null) {
       const inLabel = compactNumber(inTokens);
       const outLabel = compactNumber(outTokens);
-      zhParts.push(`↑ ${inLabel} ↓ ${outLabel}`);
-      enParts.push(`↑ ${inLabel} ↓ ${outLabel}`);
+      detailZh.push(`↑ ${inLabel} ↓ ${outLabel}`);
+      detailEn.push(`↑ ${inLabel} ↓ ${outLabel}`);
     }
   }
 
@@ -266,8 +280,8 @@ export function formatFooterRuntimeSegments(params: {
       const hit = total > 0 ? Math.round((read / total) * 100) : 0;
       const left = compactNumber(read);
       const right = compactNumber(write);
-      zhParts.push(`缓存 ${left}/${right} (${hit}%)`);
-      enParts.push(`Cache ${left}/${right} (${hit}%)`);
+      detailZh.push(`缓存 ${left}/${right} (${hit}%)`);
+      detailEn.push(`Cache ${left}/${right} (${hit}%)`);
     }
   }
 
@@ -280,20 +294,12 @@ export function formatFooterRuntimeSegments(params: {
       const ctxLabel = compactNumber(ctx);
       const pct = ctx > 0 ? Math.round((total / ctx) * 100) : 0;
       const pctLabel = `${pct}%`;
-      zhParts.push(`上下文 ${totalLabel}/${ctxLabel} (${pctLabel})`);
-      enParts.push(`Context ${totalLabel}/${ctxLabel} (${pctLabel})`);
+      detailZh.push(`上下文 ${totalLabel}/${ctxLabel} (${pctLabel})`);
+      detailEn.push(`Context ${totalLabel}/${ctxLabel} (${pctLabel})`);
     }
   }
 
-  if (footer?.model && metrics?.model) {
-    const model = metrics.model.trim();
-    if (model) {
-      zhParts.push(model);
-      enParts.push(model);
-    }
-  }
-
-  return { zh: zhParts, en: enParts };
+  return { primaryZh, primaryEn, detailZh, detailEn };
 }
 
 // ---------------------------------------------------------------------------
@@ -489,9 +495,10 @@ function buildCompleteCard(params: {
     });
   }
 
-  // Footer meta-info: each metadata item is independently controlled via
-  // the `footer` config.
-  const footerParts = formatFooterRuntimeSegments({
+  // Footer meta-info: split into two lines for readability.
+  // Line 1 (primary): status · elapsed · model
+  // Line 2 (detail):  tokens · cache · context
+  const fp = formatFooterRuntimeSegments({
     footer,
     metrics: footerMetrics,
     elapsedMs,
@@ -499,8 +506,18 @@ function buildCompleteCard(params: {
     isAborted,
   });
 
-  if (footerParts.zh.length > 0) {
-    elements.push(...buildFooter(footerParts.zh.join(' · '), footerParts.en.join(' · '), isError));
+  const footerZhLines: string[] = [];
+  const footerEnLines: string[] = [];
+  if (fp.primaryZh.length > 0) {
+    footerZhLines.push(fp.primaryZh.join(' · '));
+    footerEnLines.push(fp.primaryEn.join(' · '));
+  }
+  if (fp.detailZh.length > 0) {
+    footerZhLines.push(fp.detailZh.join(' · '));
+    footerEnLines.push(fp.detailEn.join(' · '));
+  }
+  if (footerZhLines.length > 0) {
+    elements.push(...buildFooter(footerZhLines.join('\n'), footerEnLines.join('\n'), isError));
   }
 
   // Use the answer text (not reasoning) as the feed preview summary.

--- a/src/card/streaming-card-controller.ts
+++ b/src/card/streaming-card-controller.ts
@@ -13,6 +13,7 @@
 
 import { readFile } from 'node:fs/promises';
 import { SILENT_REPLY_TOKEN } from 'openclaw/plugin-sdk/reply-runtime';
+import { resolveDefaultAgentId } from 'openclaw/plugin-sdk/agent-runtime';
 import type { ReplyPayload } from 'openclaw/plugin-sdk';
 import { extractLarkApiCode } from '../core/api-error';
 import { larkLogger } from '../core/lark-logger';
@@ -177,15 +178,40 @@ export class StreamingCardController {
       const sessionStorePath = cfgWithSession.sessions?.store ?? cfgWithSession.session?.store;
       const key = this.deps.sessionKey.trim().toLowerCase();
 
+      // WORKAROUND: SDK session key round-trip bug.
+      // The SDK's toAgentRequestSessionKey() strips the agent scope from keys
+      // like "agent:hr:main" → "main", then toAgentStoreSessionKey() rebuilds
+      // using the default agent ID → "agent:main:main".  This means metrics
+      // written by the SDK always land under "agent:<defaultAgentId>:…"
+      // regardless of the account-scoped agent ID the plugin routing generated.
+      // Fallback: when the primary key misses, try replacing the agent-id
+      // segment with the resolved default agent ID.
+      // TODO: remove once the SDK preserves the original agent ID during the
+      // request→store key round-trip.
+      const defaultAgentId = resolveDefaultAgentId(this.deps.cfg as Record<string, unknown>);
+      const fallbackKey = key.replace(/^(agent):[^:]+:/, `$1:${defaultAgentId}:`);
+      const candidateKeys = fallbackKey !== key ? [key, fallbackKey] : [key];
+
       const sessionApi = runtime.agent?.session;
       if (sessionApi?.resolveStorePath && sessionApi?.loadSessionStore) {
         const storePath = sessionApi.resolveStorePath(sessionStorePath);
         const store = sessionApi.loadSessionStore(storePath);
-        const entry = store[key];
-        if (!entry || typeof entry !== 'object') {
+
+        let entry: Record<string, unknown> | undefined;
+        let matchedKey: string | undefined;
+        for (const candidate of candidateKeys) {
+          const val = store[candidate];
+          if (val && typeof val === 'object') {
+            entry = val as Record<string, unknown>;
+            matchedKey = candidate;
+            break;
+          }
+        }
+
+        if (!entry) {
           log.debug('footer metrics lookup: session entry missing', {
             sessionKey: this.deps.sessionKey,
-            normalizedSessionKey: key,
+            candidateKeys,
             storePath,
             source: 'runtime.agent.session',
           });
@@ -204,18 +230,9 @@ export class StreamingCardController {
         };
         log.debug('footer metrics lookup: session entry found', {
           sessionKey: this.deps.sessionKey,
-          normalizedSessionKey: key,
+          matchedKey,
           storePath,
           source: 'runtime.agent.session',
-          hasMetrics: !!(
-            metrics.inputTokens != null ||
-            metrics.outputTokens != null ||
-            metrics.cacheRead != null ||
-            metrics.cacheWrite != null ||
-            metrics.totalTokens != null ||
-            metrics.contextTokens != null ||
-            metrics.model
-          ),
         });
         return metrics;
       }
@@ -232,11 +249,22 @@ export class StreamingCardController {
         parsed && typeof parsed === 'object' && !Array.isArray(parsed)
           ? (parsed as Record<string, Record<string, unknown>>)
           : {};
-      const entry = store[key];
-      if (!entry || typeof entry !== 'object') {
+
+      let entry: Record<string, unknown> | undefined;
+      let matchedKey: string | undefined;
+      for (const candidate of candidateKeys) {
+        const val = store[candidate];
+        if (val && typeof val === 'object') {
+          entry = val as Record<string, unknown>;
+          matchedKey = candidate;
+          break;
+        }
+      }
+
+      if (!entry) {
         log.debug('footer metrics lookup: session entry missing', {
           sessionKey: this.deps.sessionKey,
-          normalizedSessionKey: key,
+          candidateKeys,
           storePath,
           source: 'channel.session.file',
         });
@@ -255,18 +283,9 @@ export class StreamingCardController {
       };
       log.debug('footer metrics lookup: session entry found', {
         sessionKey: this.deps.sessionKey,
-        normalizedSessionKey: key,
+        matchedKey,
         storePath,
         source: 'channel.session.file',
-        hasMetrics: !!(
-          metrics.inputTokens != null ||
-          metrics.outputTokens != null ||
-          metrics.cacheRead != null ||
-          metrics.cacheWrite != null ||
-          metrics.totalTokens != null ||
-          metrics.contextTokens != null ||
-          metrics.model
-        ),
       });
       return metrics;
     } catch (err) {

--- a/src/core/accounts.ts
+++ b/src/core/accounts.ts
@@ -42,9 +42,30 @@ function baseConfig(section: FeishuConfig): Omit<FeishuConfig, 'accounts'> {
   return rest;
 }
 
-/** Merge base config with account override (account fields take precedence). */
+/** Merge base config with account override (account fields take precedence).
+ *  Performs a one-level deep merge for plain-object fields so that partial
+ *  account overrides (e.g. `footer: { model: false }`) are merged with
+ *  the base instead of replacing the entire object. */
 function mergeAccountConfig(base: Omit<FeishuConfig, 'accounts'>, override: Partial<FeishuConfig>): FeishuConfig {
-  return { ...base, ...override } as FeishuConfig;
+  const result: Record<string, unknown> = { ...base };
+  for (const [key, value] of Object.entries(override)) {
+    if (value === undefined) continue;
+    const baseVal = (base as Record<string, unknown>)[key];
+    // Deep-merge plain objects one level (footer, tools, heartbeat, etc.)
+    if (
+      value &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      baseVal &&
+      typeof baseVal === 'object' &&
+      !Array.isArray(baseVal)
+    ) {
+      result[key] = { ...baseVal, ...value };
+    } else {
+      result[key] = value;
+    }
+  }
+  return result as FeishuConfig;
 }
 
 /** Coerce a domain string to `LarkBrand`, defaulting to `"feishu"`. */

--- a/tests/accounts-merge.test.ts
+++ b/tests/accounts-merge.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for multi-account config merging, particularly footer inheritance.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { ClawdbotConfig } from 'openclaw/plugin-sdk';
+import { getLarkAccount, getLarkAccountIds } from '../src/core/accounts';
+
+function makeCfg(feishu: Record<string, unknown>): ClawdbotConfig {
+  return { channels: { feishu } } as unknown as ClawdbotConfig;
+}
+
+describe('getLarkAccount – footer inheritance', () => {
+  const baseFooter = {
+    status: true,
+    elapsed: true,
+    tokens: true,
+    cache: true,
+    context: true,
+    model: true,
+  };
+
+  it('named accounts inherit top-level footer when they define no footer', () => {
+    const cfg = makeCfg({
+      appId: 'default',
+      appSecret: 'secret',
+      footer: baseFooter,
+      accounts: {
+        'bot-b': { appId: 'b', appSecret: 'sb' },
+      },
+    });
+
+    const account = getLarkAccount(cfg, 'bot-b');
+    expect(account.config.footer).toEqual(baseFooter);
+  });
+
+  it('named account partial footer is deep-merged with top-level footer', () => {
+    const cfg = makeCfg({
+      appId: 'default',
+      appSecret: 'secret',
+      footer: baseFooter,
+      accounts: {
+        'bot-b': { appId: 'b', appSecret: 'sb', footer: { model: false } },
+      },
+    });
+
+    const account = getLarkAccount(cfg, 'bot-b');
+    expect(account.config.footer).toEqual({
+      status: true,
+      elapsed: true,
+      tokens: true,
+      cache: true,
+      context: true,
+      model: false,
+    });
+  });
+
+  it('default account preserves top-level footer when accounts map exists', () => {
+    const cfg = makeCfg({
+      appId: 'default',
+      appSecret: 'secret',
+      footer: baseFooter,
+      accounts: {
+        'bot-b': { appId: 'b', appSecret: 'sb' },
+      },
+    });
+
+    const account = getLarkAccount(cfg, undefined);
+    expect(account.config.footer).toEqual(baseFooter);
+  });
+
+  it('all enabled accounts get the footer when defined at top level only', () => {
+    const cfg = makeCfg({
+      footer: baseFooter,
+      accounts: {
+        'bot-a': { appId: 'a', appSecret: 'sa' },
+        'bot-b': { appId: 'b', appSecret: 'sb' },
+        'bot-c': { appId: 'c', appSecret: 'sc' },
+      },
+    });
+
+    for (const id of ['bot-a', 'bot-b', 'bot-c']) {
+      const account = getLarkAccount(cfg, id);
+      expect(account.config.footer).toEqual(baseFooter);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests matching the user's real multi-account config structure
+// ---------------------------------------------------------------------------
+
+describe('getLarkAccount – real multi-account config (default + 8 named accounts)', () => {
+  const baseFooter = {
+    status: true,
+    elapsed: true,
+    tokens: true,
+    cache: true,
+    context: true,
+    model: true,
+  };
+
+  /** Config matching the actual production layout: top-level credentials +
+   *  `"default": {}` placeholder + multiple named accounts with only
+   *  appId / appSecret / dmPolicy / allowFrom overrides. */
+  const cfg = makeCfg({
+    appId: 'cli_top_level',
+    appSecret: 'top_secret',
+    footer: baseFooter,
+    streaming: true,
+    replyMode: 'streaming',
+    accounts: {
+      default: {},
+      hr: { appId: 'cli_hr', appSecret: 's_hr', dmPolicy: 'open', allowFrom: ['*'] },
+      codex: { appId: 'cli_codex', appSecret: 's_codex', dmPolicy: 'open', allowFrom: ['*'] },
+      writer: { appId: 'cli_writer', appSecret: 's_writer', dmPolicy: 'open', allowFrom: ['*'] },
+      pmo: { appId: 'cli_pmo', appSecret: 's_pmo', dmPolicy: 'open', allowFrom: ['*'] },
+      'ai-researcher': { appId: 'cli_air', appSecret: 's_air', dmPolicy: 'open', allowFrom: ['*'] },
+      'biz-ops': { appId: 'cli_biz', appSecret: 's_biz', dmPolicy: 'open', allowFrom: ['*'] },
+      sre: { appId: 'cli_sre', appSecret: 's_sre', dmPolicy: 'open', allowFrom: ['*'] },
+      qa: { appId: 'cli_qa', appSecret: 's_qa', dmPolicy: 'open', allowFrom: ['*'] },
+    },
+  });
+
+  const namedAccountIds = ['hr', 'codex', 'writer', 'pmo', 'ai-researcher', 'biz-ops', 'sre', 'qa'];
+
+  it('getLarkAccountIds returns all accounts including default', () => {
+    const ids = getLarkAccountIds(cfg);
+    expect(ids).toContain('default');
+    for (const id of namedAccountIds) {
+      expect(ids).toContain(id);
+    }
+  });
+
+  it('default account (with empty override) inherits footer from top level', () => {
+    const account = getLarkAccount(cfg, 'default');
+    expect(account.config.footer).toEqual(baseFooter);
+    // default account should use top-level credentials
+    expect(account.config.appId).toBe('cli_top_level');
+  });
+
+  it('every named account inherits footer from top level', () => {
+    for (const id of namedAccountIds) {
+      const account = getLarkAccount(cfg, id);
+      expect(account.config.footer).toEqual(baseFooter);
+    }
+  });
+
+  it('named accounts use their own appId, not the top-level one', () => {
+    const hr = getLarkAccount(cfg, 'hr');
+    expect(hr.config.appId).toBe('cli_hr');
+
+    const codex = getLarkAccount(cfg, 'codex');
+    expect(codex.config.appId).toBe('cli_codex');
+  });
+
+  it('named accounts inherit streaming/replyMode from top level', () => {
+    for (const id of namedAccountIds) {
+      const account = getLarkAccount(cfg, id);
+      expect(account.config.streaming).toBe(true);
+      expect(account.config.replyMode).toBe('streaming');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deep merge for nested config objects
+// ---------------------------------------------------------------------------
+
+describe('mergeAccountConfig – deep merge for nested objects', () => {
+  it('account partial tools override merges with top-level tools', () => {
+    const cfg = makeCfg({
+      appId: 'base',
+      appSecret: 'secret',
+      tools: { doc: true, wiki: true, drive: true },
+      accounts: {
+        a: { appId: 'a', appSecret: 'sa', tools: { wiki: false } },
+      },
+    });
+
+    const account = getLarkAccount(cfg, 'a');
+    expect(account.config.tools).toEqual({ doc: true, wiki: false, drive: true });
+  });
+
+  it('account array fields (allowFrom) replace rather than merge', () => {
+    const cfg = makeCfg({
+      appId: 'base',
+      appSecret: 'secret',
+      allowFrom: ['user-a', 'user-b'],
+      accounts: {
+        a: { appId: 'a', appSecret: 'sa', allowFrom: ['*'] },
+      },
+    });
+
+    const account = getLarkAccount(cfg, 'a');
+    // Arrays should be replaced, not merged
+    expect(account.config.allowFrom).toEqual(['*']);
+  });
+
+  it('scalar fields override correctly', () => {
+    const cfg = makeCfg({
+      appId: 'base',
+      appSecret: 'secret',
+      dmPolicy: 'pairing',
+      historyLimit: 10,
+      accounts: {
+        a: { appId: 'a', appSecret: 'sa', dmPolicy: 'open', allowFrom: ['*'] },
+      },
+    });
+
+    const account = getLarkAccount(cfg, 'a');
+    expect(account.config.dmPolicy).toBe('open');
+    expect(account.config.historyLimit).toBe(10); // inherited
+  });
+});

--- a/tests/builder-footer-runtime.test.ts
+++ b/tests/builder-footer-runtime.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { compactNumber, formatFooterRuntimeSegments } from '../src/card/builder';
+import { buildCardContent, compactNumber, formatFooterRuntimeSegments } from '../src/card/builder';
 
 // ---------------------------------------------------------------------------
 // compactNumber
@@ -26,7 +26,7 @@ describe('compactNumber', () => {
 // ---------------------------------------------------------------------------
 
 describe('formatFooterRuntimeSegments', () => {
-  it('renders configured runtime metrics', () => {
+  it('renders configured runtime metrics split into primary and detail lines', () => {
     const result = formatFooterRuntimeSegments({
       footer: {
         status: true,
@@ -49,23 +49,13 @@ describe('formatFooterRuntimeSegments', () => {
       },
     });
 
-    expect(result.zh).toEqual([
-      '已完成',
-      '耗时 12.3s',
-      '↑ 1.2k ↓ 3.5k',
-      '缓存 800/200 (36%)',
-      '上下文 4.5k/128k (4%)',
-      'claude-opus-4-6',
-    ]);
+    // Primary line: status, elapsed, model
+    expect(result.primaryZh).toEqual(['已完成', '耗时 12.3s', 'claude-opus-4-6']);
+    expect(result.primaryEn).toEqual(['Completed', 'Elapsed 12.3s', 'claude-opus-4-6']);
 
-    expect(result.en).toEqual([
-      'Completed',
-      'Elapsed 12.3s',
-      '↑ 1.2k ↓ 3.5k',
-      'Cache 800/200 (36%)',
-      'Context 4.5k/128k (4%)',
-      'claude-opus-4-6',
-    ]);
+    // Detail line: tokens, cache, context
+    expect(result.detailZh).toEqual(['↑ 1.2k ↓ 3.5k', '缓存 800/200 (36%)', '上下文 4.5k/128k (4%)']);
+    expect(result.detailEn).toEqual(['↑ 1.2k ↓ 3.5k', 'Cache 800/200 (36%)', 'Context 4.5k/128k (4%)']);
   });
 
   it('respects missing metrics and status variants', () => {
@@ -82,8 +72,10 @@ describe('formatFooterRuntimeSegments', () => {
       },
     });
 
-    expect(stopped.zh).toEqual(['已停止', '↑ 100 ↓ 50']);
-    expect(stopped.en).toEqual(['Stopped', '↑ 100 ↓ 50']);
+    expect(stopped.primaryZh).toEqual(['已停止']);
+    expect(stopped.primaryEn).toEqual(['Stopped']);
+    expect(stopped.detailZh).toEqual(['↑ 100 ↓ 50']);
+    expect(stopped.detailEn).toEqual(['↑ 100 ↓ 50']);
 
     const errored = formatFooterRuntimeSegments({
       footer: { status: true, elapsed: true },
@@ -91,7 +83,74 @@ describe('formatFooterRuntimeSegments', () => {
       isError: true,
     });
 
-    expect(errored.zh).toEqual(['出错', '耗时 1.0s']);
-    expect(errored.en).toEqual(['Error', 'Elapsed 1.0s']);
+    expect(errored.primaryZh).toEqual(['出错', '耗时 1.0s']);
+    expect(errored.primaryEn).toEqual(['Error', 'Elapsed 1.0s']);
+    expect(errored.detailZh).toEqual([]);
+    expect(errored.detailEn).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCardContent – footer rendered as a single markdown element with \n
+// ---------------------------------------------------------------------------
+
+describe('buildCardContent – footer line joining', () => {
+  /** Extract footer markdown elements (notation-sized) from the card's top-level elements array. */
+  function footerElements(card: ReturnType<typeof buildCardContent>) {
+    const elements = (card as { elements?: Array<Record<string, unknown>> }).elements ?? [];
+    return elements.filter((el) => el.tag === 'markdown' && el.text_size === 'notation');
+  }
+
+  it('merges primary and detail lines into one markdown element with \\n', () => {
+    const card = buildCardContent('complete', {
+      text: 'hello',
+      footer: { status: true, elapsed: true, tokens: true, cache: true, context: true, model: true },
+      footerMetrics: {
+        inputTokens: 1000,
+        outputTokens: 200,
+        cacheRead: 500,
+        cacheWrite: 100,
+        totalTokens: 1200,
+        totalTokensFresh: true,
+        contextTokens: 128000,
+        model: 'test-model',
+      },
+      elapsedMs: 5000,
+    });
+
+    const fes = footerElements(card);
+
+    // Should be exactly ONE footer element (not two)
+    expect(fes).toHaveLength(1);
+
+    // The zh_cn content should contain \n joining the two lines
+    const zhContent = (fes[0].i18n_content as Record<string, string>)?.zh_cn;
+    const lines = zhContent.split('\n');
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain('已完成');
+    expect(lines[0]).toContain('耗时');
+    expect(lines[0]).toContain('test-model');
+    expect(lines[1]).toContain('↑');
+    expect(lines[1]).toContain('缓存');
+    expect(lines[1]).toContain('上下文');
+  });
+
+  it('renders single line when only primary segments exist', () => {
+    const card = buildCardContent('complete', {
+      text: 'hello',
+      footer: { status: true, elapsed: true },
+      elapsedMs: 3000,
+    });
+
+    const fes = footerElements(card);
+    expect(fes).toHaveLength(1);
+
+    const content = fes[0].content as string;
+    expect(content).not.toContain('\n');
+  });
+
+  it('renders no footer element when all footer flags are off', () => {
+    const card = buildCardContent('complete', { text: 'hello' });
+    expect(footerElements(card)).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

- **Footer line spacing**: merged two separate markdown card elements into one
  element joined by `\n`, eliminating the extra vertical margin Lark adds between
  independent elements.
- **Non-default account footer metrics**: worked around an SDK session key
  round-trip bug where `toAgentRequestSessionKey("agent:hr:main")` strips the
  agent scope to `"main"`, and `toAgentStoreSessionKey()` rebuilds it as
  `"agent:main:main"` using the default agent ID. Added a fallback key lookup via
  `resolveDefaultAgentId()` so non-default accounts can locate their metrics in
  the session store. Marked with `TODO` for removal once the SDK is fixed.
- **Deep merge for account config**: upgraded `mergeAccountConfig` from a shallow
  spread (`{ ...base, ...override }`) to a one-level deep merge, so partial
  object overrides (e.g. `footer: { model: false }`) are merged with the base
  instead of replacing the entire object. Arrays and scalars still replace as
  before.