### PR TITLE
fix: immediate visual feedback on card submission

### DIFF
--- a/src/tools/ask-user-question.ts
+++ b/src/tools/ask-user-question.ts
@@ -327,13 +327,14 @@ export function handleAskUserAction(data: unknown, _cfg: ClawdbotConfig, account
   }
 
   // Mark as submitted (guard against double-submit & TTL expiry).
-  // Card stays in "待回答" state until synthetic message succeeds — this
-  // keeps the form submittable so the user can retry if injection fails.
   ctx.submitted = true;
 
+  // Build the intermediate "processing" card for immediate visual feedback.
+  const processingCard = buildProcessingCard(ctx.questions, answers);
+
   // Inject synthetic message with answers. On success, updates card to
-  // "answered" and consumes context. On failure, resets submitted flag
-  // so user can re-submit — card is still in its original form state.
+  // "answered" and consumes context. On failure, reverts card to submittable
+  // form state and resets submitted flag so user can re-submit.
   setImmediate(() => {
     injectAnswerSyntheticMessage(ctx, answers).catch((err) => {
       log.error(`unhandled error in injectAnswerSyntheticMessage: ${err}`);
@@ -341,7 +342,21 @@ export function handleAskUserAction(data: unknown, _cfg: ClawdbotConfig, account
   });
 
   log.info(`question ${operationId} submitted, synthetic message will be injected`);
-  return {};
+
+  // Return immediate visual feedback via Feishu callback response:
+  // - toast: ephemeral success message for the clicking user
+  // - card: replaces card content immediately for the clicking user
+  // Note: callback-return card does NOT consume a cardSequence number.
+  return {
+    toast: {
+      type: 'success' as const,
+      content: '已收到回答，正在处理...',
+    },
+    card: {
+      type: 'raw' as const,
+      data: processingCard,
+    },
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -378,6 +393,25 @@ async function injectAnswerSyntheticMessage(ctx: QuestionContext, answers: Recor
     log: (msg: string) => log.info(msg),
     error: (msg: string) => log.error(msg),
   };
+
+  // Update card to "processing" state via API so ALL viewers see it (not just
+  // the clicking user — the callback-return card field only updates for the
+  // clicker). Per Feishu docs, delayed update must execute AFTER the callback
+  // response — since we're in setImmediate, the callback has already returned.
+  try {
+    const processingCard = buildProcessingCard(ctx.questions, answers);
+    ctx.cardSequence++;
+    await updateCardKitCard({
+      cfg: ctx.cfg,
+      cardId: ctx.cardId,
+      card: processingCard,
+      sequence: ctx.cardSequence,
+      accountId: ctx.accountId,
+    });
+  } catch (err) {
+    log.warn(`failed to update card to processing state via API: ${err}`);
+    // Non-fatal: the clicking user already sees the processing state via callback return.
+  }
 
   let lastError: unknown;
   for (let attempt = 0; attempt <= INJECT_MAX_RETRIES; attempt++) {
@@ -436,12 +470,20 @@ async function injectAnswerSyntheticMessage(ctx: QuestionContext, answers: Recor
   }
 
   // All retries exhausted — reset submitted flag so user can retry via card,
-  // and re-arm TTL so the entry doesn't live forever.
+  // revert card to submittable form state, and re-arm TTL.
   ctx.submitted = false;
   armTtlTimer(ctx, PENDING_QUESTION_TTL_MS);
   log.error(
     `synthetic message injection failed after ${INJECT_MAX_RETRIES + 1} attempts for question ${ctx.questionId}: ${lastError}`,
   );
+
+  // Revert card from "processing" back to interactive form so user can retry.
+  try {
+    await updateCardToSubmittable(ctx);
+    log.info(`reverted card to submittable state for question ${ctx.questionId}`);
+  } catch (err) {
+    log.warn(`failed to revert card to submittable state: ${err}`);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -696,6 +738,59 @@ function buildAnsweredCard(questions: QuestionItem[], answers: Record<string, st
   };
 }
 
+function buildProcessingCard(questions: QuestionItem[], answers: Record<string, string>): Record<string, unknown> {
+  const elements: Record<string, unknown>[] = [];
+
+  for (let i = 0; i < questions.length; i++) {
+    const q = questions[i];
+    const answer = answers[q.question] ?? '(no answer)';
+    if (i > 0) {
+      elements.push({ tag: 'hr' });
+    }
+    elements.push(
+      buildLabeledRow(
+        { tag: 'markdown', content: `**${q.header}**` },
+        { tag: 'markdown', content: `⏳ **${answer}**` },
+      ),
+    );
+  }
+
+  elements.push({
+    tag: 'markdown',
+    content: '正在处理你的回答...',
+    text_size: 'notation',
+  });
+
+  return {
+    schema: '2.0',
+    config: V2_CONFIG,
+    header: {
+      title: {
+        tag: 'plain_text',
+        content: '已提交回答',
+        i18n_content: { zh_cn: '已提交回答', en_us: 'Response Submitted' },
+      },
+      subtitle: {
+        tag: 'plain_text',
+        content: `共 ${questions.length} 个问题 · 正在处理`,
+        i18n_content: {
+          zh_cn: `共 ${questions.length} 个问题 · 正在处理`,
+          en_us: `${questions.length} question${questions.length > 1 ? 's' : ''} · Processing`,
+        },
+      },
+      text_tag_list: [
+        {
+          tag: 'text_tag',
+          text: { tag: 'plain_text', content: '处理中' },
+          color: 'turquoise',
+        },
+      ],
+      template: 'turquoise',
+    },
+    body: { elements },
+  };
+}
+
 function buildExpiredCard(questions: QuestionItem[]): Record<string, unknown> {
   const elements: Record<string, unknown>[] = [];
 
@@ -761,6 +856,18 @@ async function updateCardToAnswered(ctx: QuestionContext, answers: Record<string
 
 async function updateCardToExpired(ctx: QuestionContext): Promise<void> {
   const card = buildExpiredCard(ctx.questions);
+  ctx.cardSequence++;
+  await updateCardKitCard({
+    cfg: ctx.cfg,
+    cardId: ctx.cardId,
+    card,
+    sequence: ctx.cardSequence,
+    accountId: ctx.accountId,
+  });
+}
+
+async function updateCardToSubmittable(ctx: QuestionContext): Promise<void> {
+  const card = buildAskUserCard(ctx.questions, ctx.questionId);
   ctx.cardSequence++;
   await updateCardKitCard({
     cfg: ctx.cfg,

--- a/tests/ask-user-question.test.ts
+++ b/tests/ask-user-question.test.ts
@@ -1,0 +1,403 @@
+/**
+ * Tests for AskUserQuestion card callback immediate feedback.
+ *
+ * Verifies that submitting the card returns instant visual feedback
+ * (toast + processing card) and that the two-phase card update flow
+ * works correctly for success and failure paths.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Module mocks (hoisted)
+// ---------------------------------------------------------------------------
+
+vi.mock('../src/core/lark-logger', () => ({
+  larkLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+const mockCreateCardEntity = vi.fn();
+const mockSendCardByCardId = vi.fn();
+const mockUpdateCardKitCard = vi.fn();
+vi.mock('../src/card/cardkit', () => ({
+  createCardEntity: (...args: unknown[]) => mockCreateCardEntity(...args),
+  sendCardByCardId: (...args: unknown[]) => mockSendCardByCardId(...args),
+  updateCardKitCard: (...args: unknown[]) => mockUpdateCardKitCard(...args),
+}));
+
+const mockEnqueueFeishuChatTask = vi.fn();
+vi.mock('../src/channel/chat-queue', () => ({
+  buildQueueKey: (accountId: string, chatId: string) => `${accountId}:${chatId}`,
+  enqueueFeishuChatTask: (...args: unknown[]) => mockEnqueueFeishuChatTask(...args),
+}));
+
+vi.mock('../src/messaging/inbound/handler', () => ({
+  handleFeishuMessage: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockGetTicket = vi.fn();
+const mockWithTicket = vi.fn();
+vi.mock('../src/core/lark-ticket', () => ({
+  getTicket: (...args: unknown[]) => mockGetTicket(...args),
+  withTicket: (...args: unknown[]) => mockWithTicket(...args),
+}));
+
+vi.mock('../src/tools/helpers', () => ({
+  checkToolRegistration: () => true,
+  formatToolResult: (obj: unknown) => ({ content: [{ type: 'text', text: JSON.stringify(obj) }] }),
+  formatToolError: (msg: string) => ({ content: [{ type: 'text', text: msg }], isError: true }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test (after mocks)
+// ---------------------------------------------------------------------------
+
+import { handleAskUserAction, registerAskUserQuestionTool } from '../src/tools/ask-user-question';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const TEST_ACCOUNT_ID = 'test-account';
+const TEST_CHAT_ID = 'oc_test123';
+const TEST_SENDER = 'ou_sender1';
+const TEST_MSG_ID = 'msg_test1';
+
+function createMockCfg() {
+  return {} as any;
+}
+
+/**
+ * Seed a pending question by calling the tool's execute().
+ * Returns the questionId that was generated.
+ */
+async function seedPendingQuestion(opts?: {
+  questionId?: string;
+  questions?: Array<{ question: string; header: string; options: Array<{ label: string; description: string }>; multiSelect: boolean }>;
+}): Promise<string> {
+  const cfg = createMockCfg();
+  const questions = opts?.questions ?? [
+    { question: '你喜欢什么水果?', header: '水果', options: [{ label: '苹果', description: 'Apple' }, { label: '香蕉', description: 'Banana' }], multiSelect: false },
+  ];
+
+  mockGetTicket.mockReturnValue({
+    chatId: TEST_CHAT_ID,
+    accountId: TEST_ACCOUNT_ID,
+    senderOpenId: TEST_SENDER,
+    messageId: TEST_MSG_ID,
+    chatType: 'p2p',
+  });
+  mockCreateCardEntity.mockResolvedValue('card_test_id');
+  mockSendCardByCardId.mockResolvedValue(undefined);
+
+  // Register and invoke the tool
+  const registeredTools: Record<string, any> = {};
+  const mockApi = {
+    config: cfg,
+    registerTool: (def: any) => { registeredTools[def.name] = def; },
+    logger: { debug: vi.fn() },
+  };
+  registerAskUserQuestionTool(mockApi as any);
+
+  const tool = registeredTools['feishu_ask_user_question'];
+  const result = await tool.execute('call-1', { questions });
+  const parsed = JSON.parse(result.content[0].text);
+
+  return parsed.questionId;
+}
+
+/**
+ * Create a card action event that simulates form submission.
+ */
+function createFormSubmitEvent(questionId: string, formValue: Record<string, unknown>, senderOpenId = TEST_SENDER) {
+  return {
+    operator: { open_id: senderOpenId },
+    open_chat_id: TEST_CHAT_ID,
+    action: {
+      tag: 'button',
+      name: `ask_user_submit_${questionId}`,
+      form_value: formValue,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AskUserQuestion card callback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('handleAskUserAction immediate feedback', () => {
+    it('returns { toast, card } with processing state on successful submit', async () => {
+      const questionId = await seedPendingQuestion();
+
+      const event = createFormSubmitEvent(questionId, { selection_0: '苹果' });
+      const result = handleAskUserAction(event, createMockCfg(), TEST_ACCOUNT_ID) as any;
+
+      expect(result).toBeDefined();
+      expect(result.toast).toEqual({
+        type: 'success',
+        content: '已收到回答，正在处理...',
+      });
+      expect(result.card).toBeDefined();
+      expect(result.card.type).toBe('raw');
+      // The card data should contain processing state indicators
+      expect(result.card.data.header.template).toBe('turquoise');
+      expect(result.card.data.header.text_tag_list[0].text.content).toBe('处理中');
+      expect(result.card.data.header.title.content).toBe('已提交回答');
+    });
+
+    it('sets ctx.submitted to true on successful submit', async () => {
+      const questionId = await seedPendingQuestion();
+
+      const event = createFormSubmitEvent(questionId, { selection_0: '苹果' });
+      handleAskUserAction(event, createMockCfg(), TEST_ACCOUNT_ID);
+
+      // Submitting again should return the "already submitted" toast
+      const result2 = handleAskUserAction(event, createMockCfg(), TEST_ACCOUNT_ID) as any;
+      expect(result2.toast.type).toBe('info');
+      expect(result2.toast.content).toContain('已提交');
+    });
+
+    it('returns warning toast for missing required answers', async () => {
+      const questionId = await seedPendingQuestion();
+
+      // Submit without any form values
+      const event = createFormSubmitEvent(questionId, {});
+      const result = handleAskUserAction(event, createMockCfg(), TEST_ACCOUNT_ID) as any;
+
+      expect(result.toast.type).toBe('warning');
+      expect(result.toast.content).toContain('请先完成');
+
+      // Submitting again should still work (not marked as submitted)
+      const event2 = createFormSubmitEvent(questionId, { selection_0: '苹果' });
+      const result2 = handleAskUserAction(event2, createMockCfg(), TEST_ACCOUNT_ID) as any;
+      expect(result2.toast.type).toBe('success');
+    });
+
+    it('returns undefined for non-submit actions', () => {
+      const event = { action: { tag: 'some_other_action', name: 'other' } };
+      const result = handleAskUserAction(event, createMockCfg(), TEST_ACCOUNT_ID);
+      expect(result).toBeUndefined();
+    });
+
+    it('returns expired toast for unknown questionId', () => {
+      const event = createFormSubmitEvent('non-existent-id', { selection_0: '苹果' });
+      const result = handleAskUserAction(event, createMockCfg(), TEST_ACCOUNT_ID) as any;
+
+      expect(result.toast.type).toBe('info');
+      expect(result.toast.content).toContain('已过期');
+    });
+  });
+
+  describe('buildProcessingCard output', () => {
+    it('includes ⏳ prefix on answers', async () => {
+      const questionId = await seedPendingQuestion();
+
+      const event = createFormSubmitEvent(questionId, { selection_0: '苹果' });
+      const result = handleAskUserAction(event, createMockCfg(), TEST_ACCOUNT_ID) as any;
+
+      const cardData = result.card.data;
+      const body = cardData.body;
+
+      // Find markdown elements with answers
+      const markdownElements = findDeep(body, (el: any) =>
+        el?.tag === 'markdown' && typeof el?.content === 'string' && el.content.includes('⏳'),
+      );
+      expect(markdownElements.length).toBeGreaterThan(0);
+      expect(markdownElements[0].content).toContain('苹果');
+    });
+
+    it('includes processing hint text', async () => {
+      const questionId = await seedPendingQuestion();
+
+      const event = createFormSubmitEvent(questionId, { selection_0: '苹果' });
+      const result = handleAskUserAction(event, createMockCfg(), TEST_ACCOUNT_ID) as any;
+
+      const cardData = result.card.data;
+      const hintElements = findDeep(cardData.body, (el: any) =>
+        el?.tag === 'markdown' && el?.content === '正在处理你的回答...',
+      );
+      expect(hintElements.length).toBe(1);
+    });
+  });
+
+  describe('injectAnswerSyntheticMessage flow', () => {
+    it('calls updateCardKitCard twice on success: processing then answered', async () => {
+      mockEnqueueFeishuChatTask.mockImplementation(({ task }: any) => {
+        const promise = (async () => {
+          // Simulate task execution with withTicket mock
+          mockWithTicket.mockImplementation((_ticket: any, fn: any) => fn());
+          await task();
+        })();
+        return { status: 'queued', promise };
+      });
+      mockUpdateCardKitCard.mockResolvedValue(undefined);
+
+      const questionId = await seedPendingQuestion();
+      const event = createFormSubmitEvent(questionId, { selection_0: '苹果' });
+      handleAskUserAction(event, createMockCfg(), TEST_ACCOUNT_ID);
+
+      // Run setImmediate callbacks
+      await vi.runAllTimersAsync();
+      // Flush all microtasks
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Should be called: 1st for processing state, 2nd for answered state
+      expect(mockUpdateCardKitCard.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+      // First call: processing card (turquoise)
+      const firstCallCard = mockUpdateCardKitCard.mock.calls[0][0].card;
+      expect(firstCallCard.header.template).toBe('turquoise');
+      expect(firstCallCard.header.text_tag_list[0].text.content).toBe('处理中');
+
+      // Second call: answered card (green)
+      const secondCallCard = mockUpdateCardKitCard.mock.calls[1][0].card;
+      expect(secondCallCard.header.template).toBe('green');
+      expect(secondCallCard.header.text_tag_list[0].text.content).toBe('已完成');
+    });
+
+    it('sequences increase correctly: processing=2, answered=3', async () => {
+      mockEnqueueFeishuChatTask.mockImplementation(({ task }: any) => {
+        const promise = (async () => {
+          mockWithTicket.mockImplementation((_ticket: any, fn: any) => fn());
+          await task();
+        })();
+        return { status: 'queued', promise };
+      });
+      mockUpdateCardKitCard.mockResolvedValue(undefined);
+
+      const questionId = await seedPendingQuestion();
+      const event = createFormSubmitEvent(questionId, { selection_0: '苹果' });
+      handleAskUserAction(event, createMockCfg(), TEST_ACCOUNT_ID);
+
+      await vi.runAllTimersAsync();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(mockUpdateCardKitCard.mock.calls.length).toBeGreaterThanOrEqual(2);
+      // cardSequence starts at 1, processing increments to 2, answered increments to 3
+      expect(mockUpdateCardKitCard.mock.calls[0][0].sequence).toBe(2);
+      expect(mockUpdateCardKitCard.mock.calls[1][0].sequence).toBe(3);
+    });
+
+    it('reverts card to submittable on injection failure', async () => {
+      mockEnqueueFeishuChatTask.mockImplementation(() => {
+        return { status: 'queued', promise: Promise.reject(new Error('injection failed')) };
+      });
+      mockUpdateCardKitCard.mockResolvedValue(undefined);
+
+      const questionId = await seedPendingQuestion();
+      const event = createFormSubmitEvent(questionId, { selection_0: '苹果' });
+      handleAskUserAction(event, createMockCfg(), TEST_ACCOUNT_ID);
+
+      // Run through all retries (INJECT_MAX_RETRIES=2, so 3 total attempts)
+      // Each retry has a 2s delay. Advance just enough for retries, not TTL.
+      for (let i = 0; i < 5; i++) {
+        await vi.advanceTimersByTimeAsync(2500);
+      }
+
+      // Find the submittable (blue) card update among all calls.
+      // After retries exhaust, updateCardToSubmittable is called, but the
+      // TTL timer (re-armed on failure) may also fire if timers advance too far.
+      const submittableCall = mockUpdateCardKitCard.mock.calls.find(
+        (call: any) => call[0].card?.header?.template === 'blue',
+      );
+      expect(submittableCall).toBeDefined();
+      expect(submittableCall![0].card.header.text_tag_list[0].text.content).toBe('待回答');
+    });
+
+    it('continues injection even if processing card API update fails', async () => {
+      let updateCallCount = 0;
+      mockUpdateCardKitCard.mockImplementation(() => {
+        updateCallCount++;
+        if (updateCallCount === 1) {
+          // First call (processing state) fails
+          return Promise.reject(new Error('API error'));
+        }
+        // Subsequent calls succeed
+        return Promise.resolve(undefined);
+      });
+
+      mockEnqueueFeishuChatTask.mockImplementation(({ task }: any) => {
+        const promise = (async () => {
+          mockWithTicket.mockImplementation((_ticket: any, fn: any) => fn());
+          await task();
+        })();
+        return { status: 'queued', promise };
+      });
+
+      const questionId = await seedPendingQuestion();
+      const event = createFormSubmitEvent(questionId, { selection_0: '苹果' });
+      handleAskUserAction(event, createMockCfg(), TEST_ACCOUNT_ID);
+
+      await vi.runAllTimersAsync();
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Despite first updateCardKitCard failing, enqueue should still be called
+      expect(mockEnqueueFeishuChatTask).toHaveBeenCalled();
+
+      // Second call should be the answered state (green)
+      const answeredCall = mockUpdateCardKitCard.mock.calls.find(
+        (call: any) => call[0].card?.header?.template === 'green',
+      );
+      expect(answeredCall).toBeDefined();
+    });
+  });
+
+  describe('multi-question form', () => {
+    it('handles multiple questions in processing card', async () => {
+      const questionId = await seedPendingQuestion({
+        questions: [
+          { question: '水果?', header: '水果', options: [{ label: '苹果', description: '' }], multiSelect: false },
+          { question: '颜色?', header: '颜色', options: [], multiSelect: false },
+        ],
+      });
+
+      const event = createFormSubmitEvent(questionId, {
+        selection_0: '苹果',
+        answer_1: '红色',
+      });
+      const result = handleAskUserAction(event, createMockCfg(), TEST_ACCOUNT_ID) as any;
+
+      expect(result.toast.type).toBe('success');
+      const cardData = result.card.data;
+      expect(cardData.header.subtitle.content).toContain('2');
+
+      // Both answers should appear in the card
+      const allMarkdown = findDeep(cardData.body, (el: any) =>
+        el?.tag === 'markdown' && typeof el?.content === 'string' && el.content.includes('⏳'),
+      );
+      expect(allMarkdown.length).toBe(2);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Utility
+// ---------------------------------------------------------------------------
+
+/**
+ * Deep-search an object tree for elements matching a predicate.
+ */
+function findDeep(obj: unknown, predicate: (el: unknown) => boolean): any[] {
+  const results: any[] = [];
+  function walk(node: unknown): void {
+    if (node === null || node === undefined) return;
+    if (predicate(node)) results.push(node);
+    if (Array.isArray(node)) {
+      for (const item of node) walk(item);
+    } else if (typeof node === 'object') {
+      for (const value of Object.values(node as Record<string, unknown>)) walk(value);
+    }
+  }
+  walk(obj);
+  return results;
+}


### PR DESCRIPTION
## Summary

- Fix AskUserQuestion card submission UX: card now shows instant "处理中" (processing) feedback instead of waiting for the full AI response to complete
- Add intermediate card state (turquoise, ⏳) between "待回答" (blue) and "已完成" (green)
- Revert card to interactive form on injection failure, preserving retry capability
- Add 12 unit tests for the two-phase card update flow