### PR TITLE
fix: empty card object routes media to card path (#288)

### DIFF
--- a/src/messaging/outbound/actions.ts
+++ b/src/messaging/outbound/actions.ts
@@ -142,7 +142,12 @@ function readFeishuSendParams(
     readStringParam(params, 'replyTo') ??
     (replyInThread && toolContext?.currentMessageId ? String(toolContext.currentMessageId) : undefined);
 
-  const card = parseCardParam(params.card);
+  let card = parseCardParam(params.card);
+  // Guard: treat empty card objects as undefined when media is present
+  if (card && Object.keys(card).length === 0 && mediaUrl) {
+    log.info('params.card is empty object with media present, ignoring card');
+    card = undefined;
+  }
 
   return {
     to,


### PR DESCRIPTION
Fixes #288

## Problem
When sending local images via the `message` tool, an empty card object `{}` was being passed through `parseCardParam()` as truthy, causing the delivery to incorrectly route to `sendCardLark` instead of `uploadAndSendMediaLark`.

## Root Cause
In JavaScript, `{} ? "card" : "media"` evaluates to `"card"` because empty objects are truthy.

## Fix
Added a guard in `readFeishuSendParams()` to treat empty card objects as `undefined` when `mediaUrl` is present. This ensures the media delivery path is taken.

## Testing
User confirmed the fix resolves the issue — images now send successfully.

Ref: https://github.com/larksuite/openclaw-lark/issues/288