### PR TITLE
fix: declare channelConfigs in manifest to fix OpenClaw 3.28 startup …

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -6,5 +6,12 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {}
+  },
+  "channelConfigs": {
+    "feishu": {
+      "schema": {
+        "type": "object"
+      }
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/openclaw-lark",
-  "version": "2026.3.26",
+  "version": "2026.3.28",
   "description": "OpenClaw Lark/Feishu channel plugin",
   "type": "module",
   "exports": {


### PR DESCRIPTION
…failure

OpenClaw 3.28 validates channels.feishu config against the bundled feishu plugin's JSON Schema which has additionalProperties: false. This rejects openclaw-lark specific fields (name, replyMode, footer, uat, dedup, etc.) and causes startup to fail with INVALID_CONFIG.

Declare channelConfigs.feishu.schema in the manifest so that our permissive schema (type: object, no additionalProperties restriction) overrides the bundled one via origin priority (external > bundled).

Change-Id: I836c0135004a17a96e595ecf9036950deda16e4d