### PR TITLE
[codex] Fix Feishu channel health monitoring

### DIFF
--- a/src/channel/event-handlers.ts
+++ b/src/channel/event-handlers.ts
@@ -19,6 +19,7 @@ import { handleCardAction } from '../tools/auto-auth';
 import { handleAskUserAction } from '../tools/ask-user-question';
 import { buildQueueKey, enqueueFeishuChatTask, getActiveDispatcher, hasActiveTask } from './chat-queue';
 import { extractRawTextFromEvent, isLikelyAbortText } from './abort-detect';
+import { recordFeishuInbound } from './status-registry';
 import type { MonitorContext } from './types';
 
 const elog = larkLogger('channel/event-handlers');
@@ -81,6 +82,8 @@ export async function handleMessageEvent(ctx: MonitorContext, data: unknown): Pr
       log(`feishu[${accountId}]: message ${msgId} expired, discarding`);
       return;
     }
+
+    recordFeishuInbound(accountId);
 
     // ---- Abort fast-path ----
     // If the message looks like an abort trigger and there is an active
@@ -167,6 +170,8 @@ export async function handleReactionEvent(ctx: MonitorContext, data: unknown): P
       return;
     }
 
+    recordFeishuInbound(accountId);
+
     // ---- Pre-resolve real chatId before enqueuing ----
     // The API call (3s timeout) runs outside the queue so it doesn't
     // block the serial chain, and is read-only so ordering is irrelevant.
@@ -231,6 +236,7 @@ export async function handleBotMembershipEvent(
   const { accountId, log, error } = ctx;
   try {
     const event = data as FeishuBotAddedEvent;
+    recordFeishuInbound(accountId);
     log(`feishu[${accountId}]: bot ${action} ${action === 'removed' ? 'from' : 'to'} chat ${event.chat_id}`);
   } catch (err) {
     error(`feishu[${accountId}]: error handling bot ${action} event: ${String(err)}`);
@@ -243,6 +249,8 @@ export async function handleBotMembershipEvent(
 
 export async function handleCardActionEvent(ctx: MonitorContext, data: unknown): Promise<unknown> {
   try {
+    recordFeishuInbound(ctx.accountId);
+
     // AskUserQuestion card interactions — injects synthetic message
     // carrying user answers for the AI to receive in a new turn.
     const askResult = handleAskUserAction(data, ctx.cfg, ctx.accountId);

--- a/src/channel/monitor.ts
+++ b/src/channel/monitor.ts
@@ -9,6 +9,7 @@
  * appropriate handlers.
  */
 
+import { createConnectedChannelStatusPatch } from 'openclaw/plugin-sdk/gateway-runtime';
 import type { ClawdbotConfig, RuntimeEnv } from 'openclaw/plugin-sdk';
 import type { HistoryEntry } from 'openclaw/plugin-sdk/reply-history';
 import { getEnabledLarkAccounts, getLarkAccount } from '../core/accounts';
@@ -16,7 +17,8 @@ import { LarkClient } from '../core/lark-client';
 import { MessageDedup } from '../messaging/inbound/dedup';
 import { larkLogger } from '../core/lark-logger';
 import { drainShutdownHooks } from '../core/shutdown-hooks';
-import type { MonitorContext, MonitorFeishuOpts } from './types';
+import { bindFeishuStatusSink } from './status-registry';
+import type { FeishuRuntimeState, FeishuStatusPatch, MonitorContext, MonitorFeishuOpts } from './types';
 import {
   handleBotMembershipEvent,
   handleCardActionEvent,
@@ -28,6 +30,99 @@ const mlog = larkLogger('channel/monitor');
 
 // Re-export type for backward compatibility
 export type { MonitorFeishuOpts } from './types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEFAULT_STARTUP_TIMEOUT_MS = 30_000;
+const DEFAULT_INITIAL_RESTART_BACKOFF_MS = 3_000;
+const DEFAULT_MAX_RESTART_BACKOFF_MS = 60_000;
+
+function resolveHealthMonitorConfig(account: ReturnType<typeof getLarkAccount>): {
+  startupTimeoutMs: number;
+  initialRestartBackoffMs: number;
+  maxRestartBackoffMs: number;
+} {
+  const cfg = account.config?.healthMonitor ?? {};
+  const initialRestartBackoffMs = Math.max(1_000, cfg.initialRestartBackoffMs ?? DEFAULT_INITIAL_RESTART_BACKOFF_MS);
+
+  return {
+    startupTimeoutMs: Math.max(1_000, cfg.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS),
+    initialRestartBackoffMs,
+    maxRestartBackoffMs: Math.max(initialRestartBackoffMs, cfg.maxRestartBackoffMs ?? DEFAULT_MAX_RESTART_BACKOFF_MS),
+  };
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(resolve, ms);
+    if (typeof timer === 'object' && typeof timer.unref === 'function') {
+      timer.unref();
+    }
+
+    if (!signal) {
+      return;
+    }
+
+    if (signal.aborted) {
+      clearTimeout(timer);
+      resolve();
+      return;
+    }
+
+    signal.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer);
+        reject(new Error('aborted'));
+      },
+      { once: true },
+    );
+  });
+}
+
+function relayAbort(parent: AbortSignal | undefined, child: AbortController): () => void {
+  if (!parent) {
+    return () => {};
+  }
+
+  if (parent.aborted) {
+    child.abort();
+    return () => {};
+  }
+
+  const abort = () => child.abort();
+  parent.addEventListener('abort', abort, { once: true });
+  return () => parent.removeEventListener('abort', abort);
+}
+
+function withState(state: FeishuRuntimeState, patch: FeishuStatusPatch = {}): FeishuStatusPatch {
+  return {
+    ...patch,
+    state,
+    healthState: state,
+  };
+}
+
+function buildHandlers(ctx: MonitorContext): Record<string, (data: unknown) => Promise<void>> {
+  return {
+    'im.message.receive_v1': (data) => handleMessageEvent(ctx, data),
+    'im.message.message_read_v1': async () => {},
+    'im.message.reaction.created_v1': (data) => handleReactionEvent(ctx, data),
+    // These events are expected in normal usage but do not affect the
+    // plugin's current behavior. Register no-op handlers to avoid SDK
+    // warnings about missing handlers.
+    'im.message.reaction.deleted_v1': async () => {},
+    'im.chat.access_event.bot_p2p_chat_entered_v1': async () => {},
+    'im.chat.member.bot.added_v1': (data) => handleBotMembershipEvent(ctx, data, 'added'),
+    'im.chat.member.bot.deleted_v1': (data) => handleBotMembershipEvent(ctx, data, 'removed'),
+    // 飞书 SDK EventDispatcher.register 不支持带返回值的处理器，此处 as any 是 SDK 类型限制的变通
+    'card.action.trigger': ((data: unknown) =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      handleCardActionEvent(ctx, data)) as any,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Single-account monitor
@@ -45,8 +140,9 @@ async function monitorSingleAccount(params: {
   account: ReturnType<typeof getLarkAccount>;
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
+  setStatus?: (patch: FeishuStatusPatch) => void;
 }): Promise<void> {
-  const { account, runtime, abortSignal } = params;
+  const { account, runtime, abortSignal, setStatus } = params;
   const { accountId } = account;
   const log = runtime?.log ?? ((...args: unknown[]) => mlog.info(args.map(String).join(' ')));
   const error = runtime?.error ?? ((...args: unknown[]) => mlog.error(args.map(String).join(' ')));
@@ -64,6 +160,11 @@ async function monitorSingleAccount(params: {
     ttlMs: dedupCfg?.ttlMs,
     maxEntries: dedupCfg?.maxEntries,
   });
+  const healthCfg = resolveHealthMonitorConfig(account);
+  const statusSink = (patch: FeishuStatusPatch): void => {
+    setStatus?.(patch);
+  };
+  const unbindStatus = bindFeishuStatusSink(accountId, statusSink);
   log(
     `feishu[${accountId}]: message dedup enabled (ttl=${messageDedup['ttlMs']}ms, max=${messageDedup['maxEntries']})`,
   );
@@ -92,30 +193,222 @@ async function monitorSingleAccount(params: {
     error,
   };
 
-  await lark.startWS({
-    handlers: {
-      'im.message.receive_v1': (data) => handleMessageEvent(ctx, data),
-      'im.message.message_read_v1': async () => {},
-      'im.message.reaction.created_v1': (data) => handleReactionEvent(ctx, data),
-      // These events are expected in normal usage but do not affect the
-      // plugin's current behavior. Register no-op handlers to avoid SDK
-      // warnings about missing handlers.
-      'im.message.reaction.deleted_v1': async () => {},
-      'im.chat.access_event.bot_p2p_chat_entered_v1': async () => {},
-      'im.chat.member.bot.added_v1': (data) => handleBotMembershipEvent(ctx, data, 'added'),
-      'im.chat.member.bot.deleted_v1': (data) => handleBotMembershipEvent(ctx, data, 'removed'),
-      // 飞书 SDK EventDispatcher.register 不支持带返回值的处理器，此处 as any 是 SDK 类型限制的变通
-      'card.action.trigger': ((data: unknown) =>
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        handleCardActionEvent(ctx, data)) as any,
-    },
-    abortSignal,
-  });
+  const handlers = buildHandlers(ctx);
+  let backoffMs = healthCfg.initialRestartBackoffMs;
+  let attemptSeq = 0;
+  let consecutiveFailures = 0;
 
-  // startWS resolves when abortSignal fires — probe result is logged inside startWS.
-  log(`feishu[${accountId}]: bot open_id resolved: ${lark.botOpenId ?? 'unknown'}`);
-  log(`feishu[${accountId}]: WebSocket client started`);
-  mlog.info(`websocket started for account ${accountId}`);
+  statusSink(withState('starting', { connected: false, reconnectAttempts: 0 }));
+
+  try {
+    while (!abortSignal?.aborted) {
+      const sessionAbort = new AbortController();
+      const detachAbort = relayAbort(abortSignal, sessionAbort);
+      let currentAttemptId = 0;
+      let watchdog: ReturnType<typeof setTimeout> | null = null;
+      let watchdogAttemptId = 0;
+      let watchdogTriggered = false;
+      let everReady = false;
+
+      const clearWatchdog = (): void => {
+        if (watchdog) {
+          clearTimeout(watchdog);
+          watchdog = null;
+        }
+      };
+
+      const armWatchdog = (attemptId: number): void => {
+        watchdogAttemptId = attemptId;
+        if (!everReady && watchdog) {
+          return;
+        }
+        clearWatchdog();
+        watchdog = setTimeout(() => {
+          if (sessionAbort.signal.aborted) {
+            return;
+          }
+
+          watchdogTriggered = true;
+          consecutiveFailures += 1;
+          const now = Date.now();
+          const reason = 'startup_timeout';
+          statusSink(
+            withState('failed', {
+              attemptId: watchdogAttemptId,
+              connected: false,
+              lastError: reason,
+              lastErrorAt: now,
+              lastErrorReason: reason,
+              lastRestartReason: reason,
+              lastDisconnect: { at: now, error: reason },
+              consecutiveFailures,
+              reconnectAttempts: consecutiveFailures,
+            }),
+          );
+          error(
+            `feishu[${accountId}][attempt=${watchdogAttemptId}]: startup_timeout after ${healthCfg.startupTimeoutMs}ms`,
+          );
+          lark.disconnect();
+          sessionAbort.abort();
+        }, healthCfg.startupTimeoutMs);
+
+        if (typeof watchdog === 'object' && typeof watchdog.unref === 'function') {
+          watchdog.unref();
+        }
+      };
+
+      try {
+        await lark.startWS({
+          handlers,
+          abortSignal: sessionAbort.signal,
+          lifecycle: {
+            onConnectAttempt: () => {
+              currentAttemptId = ++attemptSeq;
+              const now = Date.now();
+              armWatchdog(currentAttemptId);
+              statusSink(
+                withState(everReady ? 'restarting' : 'connecting', {
+                  attemptId: currentAttemptId,
+                  connected: false,
+                  lastConnectStartAt: now,
+                  reconnectAttempts: consecutiveFailures,
+                }),
+              );
+              log(`feishu[${accountId}][attempt=${currentAttemptId}]: connect_start`);
+            },
+            onReady: () => {
+              clearWatchdog();
+              everReady = true;
+              consecutiveFailures = 0;
+              backoffMs = healthCfg.initialRestartBackoffMs;
+              const now = Date.now();
+              statusSink({
+                ...withState('ready', {
+                  attemptId: currentAttemptId,
+                  lastReadyAt: now,
+                  lastError: null,
+                  lastErrorReason: null,
+                  lastDisconnect: null,
+                  consecutiveFailures: 0,
+                  reconnectAttempts: 0,
+                }),
+                ...createConnectedChannelStatusPatch(now),
+              });
+              log(`feishu[${accountId}][attempt=${currentAttemptId}]: ready`);
+              log(`feishu[${accountId}]: bot open_id resolved: ${lark.botOpenId ?? 'unknown'}`);
+            },
+            onConnectFailure: () => {
+              consecutiveFailures += 1;
+              const now = Date.now();
+              const reason = 'connect_failed';
+              statusSink(
+                withState('connecting', {
+                  attemptId: currentAttemptId || null,
+                  connected: false,
+                  lastError: reason,
+                  lastErrorAt: now,
+                  lastErrorReason: reason,
+                  consecutiveFailures,
+                  reconnectAttempts: consecutiveFailures,
+                }),
+              );
+              error(`feishu[${accountId}][attempt=${currentAttemptId || 'unknown'}]: connect_failed`);
+            },
+            onClose: () => {
+              clearWatchdog();
+              if (sessionAbort.signal.aborted || abortSignal?.aborted) {
+                return;
+              }
+
+              const now = Date.now();
+              const reason = everReady ? 'socket_close' : 'connect_closed';
+              statusSink(
+                withState(everReady ? 'degraded' : 'connecting', {
+                  attemptId: currentAttemptId || null,
+                  connected: false,
+                  lastError: reason,
+                  lastErrorAt: now,
+                  lastErrorReason: reason,
+                  lastDisconnect: { at: now, error: reason },
+                  reconnectAttempts: consecutiveFailures,
+                }),
+              );
+              log(`feishu[${accountId}][attempt=${currentAttemptId || 'unknown'}]: socket_close`);
+            },
+            onError: (err) => {
+              if (sessionAbort.signal.aborted || abortSignal?.aborted) {
+                return;
+              }
+
+              const now = Date.now();
+              const reason = everReady ? 'ws_error' : 'connect_error';
+              const message = err.message || String(err);
+              statusSink(
+                withState(everReady ? 'degraded' : 'connecting', {
+                  attemptId: currentAttemptId || null,
+                  connected: false,
+                  lastError: message,
+                  lastErrorAt: now,
+                  lastErrorReason: reason,
+                  lastDisconnect: { at: now, error: message },
+                  reconnectAttempts: consecutiveFailures,
+                }),
+              );
+              error(`feishu[${accountId}][attempt=${currentAttemptId || 'unknown'}]: ws_error ${message}`);
+            },
+          },
+        });
+      } finally {
+        clearWatchdog();
+        detachAbort();
+      }
+
+      if (abortSignal?.aborted) {
+        break;
+      }
+
+      if (watchdogTriggered) {
+        statusSink(
+          withState('restarting', {
+            connected: false,
+            lastRestartReason: 'startup_timeout',
+            reconnectAttempts: consecutiveFailures,
+          }),
+        );
+        log(`feishu[${accountId}]: restart scheduled in ${backoffMs}ms`);
+        try {
+          await sleep(backoffMs, abortSignal);
+        } catch {
+          break;
+        }
+        backoffMs = Math.min(backoffMs * 2, healthCfg.maxRestartBackoffMs);
+        continue;
+      }
+
+      if (!everReady) {
+        consecutiveFailures += 1;
+      }
+
+      statusSink(
+        withState('restarting', {
+          connected: false,
+          lastRestartReason: everReady ? 'connection_ended' : 'connect_ended',
+          reconnectAttempts: consecutiveFailures,
+        }),
+      );
+      log(`feishu[${accountId}]: connection ended unexpectedly, restarting in ${backoffMs}ms`);
+      try {
+        await sleep(backoffMs, abortSignal);
+      } catch {
+        break;
+      }
+      backoffMs = Math.min(backoffMs * 2, healthCfg.maxRestartBackoffMs);
+    }
+  } finally {
+    unbindStatus();
+    statusSink(withState('stopped', { connected: false, reconnectAttempts: consecutiveFailures }));
+    mlog.info(`websocket stopped for account ${accountId}`);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -146,13 +439,14 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
       throw new Error(`Feishu account "${opts.accountId}" not configured or disabled`);
     }
     await monitorSingleAccount({
-      cfg,
-      account,
-      runtime: opts.runtime,
-      abortSignal: opts.abortSignal,
-    });
-    await drainShutdownHooks({ log });
-    return;
+        cfg,
+        account,
+        runtime: opts.runtime,
+        abortSignal: opts.abortSignal,
+        setStatus: opts.setStatus,
+      });
+      await drainShutdownHooks({ log });
+      return;
   }
 
   // Multi-account mode: start all enabled accounts in parallel.
@@ -170,6 +464,7 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
         account,
         runtime: opts.runtime,
         abortSignal: opts.abortSignal,
+        setStatus: opts.setStatus,
       }),
     ),
   );

--- a/src/channel/plugin.ts
+++ b/src/channel/plugin.ts
@@ -25,6 +25,7 @@ import { triggerOnboarding } from '../tools/onboarding-auth';
 import { larkLogger } from '../core/lark-logger';
 import { FEISHU_CONFIG_JSON_SCHEMA } from '../core/config-schema';
 import { applyAccountConfig, collectFeishuSecurityWarnings, deleteAccount, setAccountEnabled } from './config-adapter';
+import type { FeishuAccountRuntimeSnapshot, FeishuStatusPatch } from './types';
 import {
   listFeishuDirectoryGroups,
   listFeishuDirectoryGroupsLive,
@@ -36,6 +37,27 @@ const pluginLog = larkLogger('channel/plugin');
 
 /** 状态轮询的探针结果缓存时长（10 分钟）。 */
 const PROBE_CACHE_TTL_MS = 10 * 60 * 1000;
+
+const DEFAULT_FEISHU_RUNTIME = {
+  accountId: DEFAULT_ACCOUNT_ID,
+  running: false,
+  connected: false,
+  state: 'stopped',
+  lastStartAt: null,
+  lastStopAt: null,
+  lastError: null,
+  lastErrorAt: null,
+  lastErrorReason: null,
+  lastConnectStartAt: null,
+  lastReadyAt: null,
+  lastEventAt: null,
+  lastInboundAt: null,
+  lastOutboundAt: null,
+  lastRestartReason: null,
+  consecutiveFailures: 0,
+  attemptId: null,
+  port: null,
+};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -274,41 +296,65 @@ export const feishuPlugin: ChannelPlugin<LarkAccount> = {
   // -------------------------------------------------------------------------
 
   status: {
-    defaultRuntime: {
-      accountId: DEFAULT_ACCOUNT_ID,
-      running: false,
-      lastStartAt: null,
-      lastStopAt: null,
-      lastError: null,
-      port: null,
+    defaultRuntime: DEFAULT_FEISHU_RUNTIME,
+    buildChannelSummary: ({ snapshot }) => {
+      const runtime = snapshot as FeishuAccountRuntimeSnapshot;
+      return {
+        configured: snapshot.configured ?? false,
+        running: snapshot.running ?? false,
+        connected: snapshot.connected ?? false,
+        state: runtime.state ?? 'stopped',
+        lastStartAt: snapshot.lastStartAt ?? null,
+        lastStopAt: snapshot.lastStopAt ?? null,
+        lastError: snapshot.lastError ?? null,
+        lastErrorAt: runtime.lastErrorAt ?? null,
+        lastErrorReason: runtime.lastErrorReason ?? null,
+        lastConnectStartAt: runtime.lastConnectStartAt ?? null,
+        lastReadyAt: runtime.lastReadyAt ?? null,
+        lastEventAt: snapshot.lastEventAt ?? null,
+        lastInboundAt: snapshot.lastInboundAt ?? null,
+        lastOutboundAt: snapshot.lastOutboundAt ?? null,
+        lastRestartReason: runtime.lastRestartReason ?? null,
+        consecutiveFailures: runtime.consecutiveFailures ?? 0,
+        attemptId: runtime.attemptId ?? null,
+        port: snapshot.port ?? null,
+        probe: snapshot.probe,
+        lastProbeAt: snapshot.lastProbeAt ?? null,
+      };
     },
-    buildChannelSummary: ({ snapshot }) => ({
-      configured: snapshot.configured ?? false,
-      running: snapshot.running ?? false,
-      lastStartAt: snapshot.lastStartAt ?? null,
-      lastStopAt: snapshot.lastStopAt ?? null,
-      lastError: snapshot.lastError ?? null,
-      port: snapshot.port ?? null,
-      probe: snapshot.probe,
-      lastProbeAt: snapshot.lastProbeAt ?? null,
-    }),
     probeAccount: async ({ account }) => {
       return await LarkClient.fromAccount(account).probe({ maxAgeMs: PROBE_CACHE_TTL_MS });
     },
-    buildAccountSnapshot: ({ account, runtime, probe }) => ({
-      accountId: account.accountId,
-      enabled: account.enabled,
-      configured: account.configured,
-      name: account.name,
-      appId: account.appId,
-      brand: account.brand,
-      running: runtime?.running ?? false,
-      lastStartAt: runtime?.lastStartAt ?? null,
-      lastStopAt: runtime?.lastStopAt ?? null,
-      lastError: runtime?.lastError ?? null,
-      port: runtime?.port ?? null,
-      probe,
-    }),
+    buildAccountSnapshot: ({ account, runtime, probe }) => {
+      const accountRuntime = runtime as FeishuAccountRuntimeSnapshot | undefined;
+      const snapshot = {
+        accountId: account.accountId,
+        enabled: account.enabled,
+        configured: account.configured,
+        name: account.name,
+        appId: account.appId,
+        brand: account.brand,
+        running: runtime?.running ?? false,
+        connected: runtime?.connected ?? false,
+        state: accountRuntime?.state ?? 'stopped',
+        lastStartAt: runtime?.lastStartAt ?? null,
+        lastStopAt: runtime?.lastStopAt ?? null,
+        lastError: runtime?.lastError ?? null,
+        lastErrorAt: accountRuntime?.lastErrorAt ?? null,
+        lastErrorReason: accountRuntime?.lastErrorReason ?? null,
+        lastConnectStartAt: accountRuntime?.lastConnectStartAt ?? null,
+        lastReadyAt: accountRuntime?.lastReadyAt ?? null,
+        lastEventAt: runtime?.lastEventAt ?? null,
+        lastInboundAt: runtime?.lastInboundAt ?? null,
+        lastOutboundAt: runtime?.lastOutboundAt ?? null,
+        lastRestartReason: accountRuntime?.lastRestartReason ?? null,
+        consecutiveFailures: accountRuntime?.consecutiveFailures ?? 0,
+        attemptId: accountRuntime?.attemptId ?? null,
+        port: runtime?.port ?? null,
+        probe,
+      };
+      return snapshot;
+    },
   },
 
   // -------------------------------------------------------------------------
@@ -320,12 +366,25 @@ export const feishuPlugin: ChannelPlugin<LarkAccount> = {
       const { monitorFeishuProvider } = await import('./monitor.js');
       const account = getLarkAccount(ctx.cfg, ctx.accountId);
       const port = account.config?.webhookPort ?? null;
-      ctx.setStatus({ accountId: ctx.accountId, port });
+      const setStatus = (patch: FeishuStatusPatch) => {
+        ctx.setStatus({
+          accountId: ctx.accountId,
+          ...(patch as Record<string, unknown>),
+        } as never);
+      };
+      setStatus({
+        port,
+        connected: false,
+        state: 'starting',
+        healthState: 'starting',
+        lastConnectStartAt: Date.now(),
+      });
       ctx.log?.info(`starting feishu[${ctx.accountId}] (mode: ${account.config?.connectionMode ?? 'websocket'})`);
       return monitorFeishuProvider({
         config: ctx.cfg,
         runtime: ctx.runtime,
         abortSignal: ctx.abortSignal,
+        setStatus,
         accountId: ctx.accountId,
       });
     },

--- a/src/channel/status-registry.ts
+++ b/src/channel/status-registry.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Lightweight runtime status sink registry for the Feishu channel.
+ *
+ * The gateway owns the actual runtime snapshot, but inbound handlers,
+ * outbound senders and WebSocket lifecycle callbacks run in different
+ * modules. This registry provides a single place to publish per-account
+ * status patches back to the gateway-managed account runtime.
+ */
+
+import { LarkClient } from '../core/lark-client';
+import type { FeishuStatusPatch } from './types';
+
+const sinks = new Map<string, (patch: FeishuStatusPatch) => void>();
+
+export function bindFeishuStatusSink(accountId: string, sink: (patch: FeishuStatusPatch) => void): () => void {
+  sinks.set(accountId, sink);
+  return () => {
+    if (sinks.get(accountId) === sink) {
+      sinks.delete(accountId);
+    }
+  };
+}
+
+export function clearFeishuStatusSinks(): void {
+  sinks.clear();
+}
+
+export function updateFeishuAccountStatus(accountId: string, patch: FeishuStatusPatch): void {
+  sinks.get(accountId)?.(patch);
+}
+
+function recordChannelActivity(accountId: string, direction: 'inbound' | 'outbound', at: number): void {
+  try {
+    LarkClient.runtime.channel.activity.record({
+      channel: 'feishu',
+      accountId,
+      direction,
+      at,
+    });
+  } catch {
+    // Runtime is optional in unit tests and one-off utility entrypoints.
+  }
+}
+
+export function recordFeishuInbound(accountId: string, at = Date.now()): void {
+  recordChannelActivity(accountId, 'inbound', at);
+  updateFeishuAccountStatus(accountId, {
+    lastEventAt: at,
+    lastInboundAt: at,
+  });
+}
+
+export function recordFeishuOutbound(accountId: string, at = Date.now()): void {
+  recordChannelActivity(accountId, 'outbound', at);
+  updateFeishuAccountStatus(accountId, {
+    lastOutboundAt: at,
+  });
+}

--- a/src/channel/types.ts
+++ b/src/channel/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ClawdbotConfig, RuntimeEnv } from 'openclaw/plugin-sdk';
+import type { ChannelAccountSnapshot } from 'openclaw/plugin-sdk/channel-runtime';
 import type { HistoryEntry } from 'openclaw/plugin-sdk/reply-history';
 import type { LarkClient } from '../core/lark-client';
 import type { MessageDedup } from '../messaging/inbound/dedup';
@@ -17,11 +18,27 @@ export type { FeishuProbeResult } from '../core/types';
 // Monitor types
 // ---------------------------------------------------------------------------
 
+export type FeishuRuntimeState = 'starting' | 'connecting' | 'ready' | 'degraded' | 'restarting' | 'failed' | 'stopped';
+
+export interface FeishuAccountRuntimeSnapshot extends ChannelAccountSnapshot {
+  state?: FeishuRuntimeState;
+  lastErrorAt?: number | null;
+  lastErrorReason?: string | null;
+  lastConnectStartAt?: number | null;
+  lastReadyAt?: number | null;
+  lastRestartReason?: string | null;
+  consecutiveFailures?: number;
+  attemptId?: number | null;
+}
+
+export type FeishuStatusPatch = Omit<FeishuAccountRuntimeSnapshot, 'accountId'>;
+
 export interface MonitorFeishuOpts {
   config?: ClawdbotConfig;
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
   accountId?: string;
+  setStatus?: (patch: FeishuStatusPatch) => void;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/channel/ws-lifecycle.ts
+++ b/src/channel/ws-lifecycle.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Attach lightweight lifecycle callbacks to the Feishu SDK WS client.
+ *
+ * The upstream SDK handles reconnects internally but does not expose a
+ * high-level readiness lifecycle to plugin code. This helper wraps the
+ * relevant internal methods so the channel monitor can observe:
+ * - connect attempt start
+ * - successful readiness
+ * - connect failures before ready
+ * - socket close and error events
+ */
+
+export interface FeishuWsLifecycle {
+  onConnectAttempt?: () => void;
+  onReady?: () => void;
+  onConnectFailure?: () => void;
+  onClose?: () => void;
+  onError?: (err: Error) => void;
+}
+
+interface SocketLike {
+  on?: (event: 'close' | 'error', listener: (...args: unknown[]) => void) => unknown;
+}
+
+interface WsClientWithInternals {
+  reConnect?: (...args: unknown[]) => Promise<unknown>;
+  connect?: (...args: unknown[]) => Promise<boolean>;
+  communicate?: (...args: unknown[]) => unknown;
+  wsConfig?: {
+    getWSInstance?: () => SocketLike | null | undefined;
+  };
+}
+
+export function attachWsLifecycle<T>(wsClient: T, lifecycle: FeishuWsLifecycle = {}): T {
+  if (!wsClient || typeof wsClient !== "object") {
+    return wsClient;
+  }
+
+  const client = wsClient as WsClientWithInternals;
+  const attachedSockets = new WeakSet<object>();
+
+  const attachSocketListeners = (): void => {
+    const socket = client.wsConfig?.getWSInstance?.();
+    if (!socket || typeof socket !== 'object' || attachedSockets.has(socket)) {
+      return;
+    }
+
+    attachedSockets.add(socket);
+    socket.on?.('close', () => {
+      lifecycle.onClose?.();
+    });
+    socket.on?.('error', (err) => {
+      lifecycle.onError?.(err instanceof Error ? err : new Error(String(err)));
+    });
+  };
+
+  if (typeof client.reConnect === 'function') {
+    const originalReConnect = client.reConnect.bind(client);
+    client.reConnect = async (...args: unknown[]) => {
+      lifecycle.onConnectAttempt?.();
+      return await originalReConnect(...args);
+    };
+  }
+
+  if (typeof client.connect === 'function') {
+    const originalConnect = client.connect.bind(client);
+    client.connect = async (...args: unknown[]) => {
+      const ok = await originalConnect(...args);
+      if (ok) {
+        lifecycle.onReady?.();
+      } else {
+        lifecycle.onConnectFailure?.();
+      }
+      return ok;
+    };
+  }
+
+  if (typeof client.communicate === 'function') {
+    const originalCommunicate = client.communicate.bind(client);
+    client.communicate = (...args: unknown[]) => {
+      const result = originalCommunicate(...args);
+      attachSocketListeners();
+      return result;
+    };
+  }
+
+  return wsClient;
+}

--- a/src/core/config-schema.ts
+++ b/src/core/config-schema.ts
@@ -116,6 +116,14 @@ const DedupSchema = z
   })
   .optional();
 
+const HealthMonitorSchema = z
+  .object({
+    startupTimeoutMs: z.number().optional(),
+    initialRestartBackoffMs: z.number().optional(),
+    maxRestartBackoffMs: z.number().optional(),
+  })
+  .optional();
+
 const ReactionNotificationModeSchema = z.enum(['off', 'own', 'all']).optional();
 
 export const UATConfigSchema = z
@@ -186,6 +194,7 @@ export const FeishuAccountConfigSchema = z.object({
   configWrites: z.boolean().optional(),
   capabilities: CapabilitiesSchema,
   dedup: DedupSchema,
+  healthMonitor: HealthMonitorSchema,
   reactionNotifications: ReactionNotificationModeSchema,
   threadSession: z.boolean().optional(),
   uat: UATConfigSchema,

--- a/src/core/lark-client.ts
+++ b/src/core/lark-client.ts
@@ -17,7 +17,9 @@
 import * as Lark from '@larksuiteoapi/node-sdk';
 
 import type { ClawdbotConfig, PluginRuntime } from 'openclaw/plugin-sdk';
+import { attachWsLifecycle } from '../channel/ws-lifecycle';
 import type { MessageDedup } from '../messaging/inbound/dedup';
+import type { FeishuWsLifecycle } from '../channel/ws-lifecycle';
 import { clearUserNameCache } from '../messaging/inbound/user-name-cache-store';
 import type { FeishuProbeResult, LarkAccount, LarkBrand } from './types';
 import { getLarkAccount } from './accounts';
@@ -344,8 +346,9 @@ export class LarkClient {
     handlers: Record<string, (data: unknown) => Promise<void>>;
     abortSignal?: AbortSignal;
     autoProbe?: boolean;
+    lifecycle?: FeishuWsLifecycle;
   }): Promise<void> {
-    const { handlers, abortSignal, autoProbe = true } = opts;
+    const { handlers, abortSignal, autoProbe = true, lifecycle } = opts;
 
     if (autoProbe) await this.probe();
 
@@ -374,6 +377,7 @@ export class LarkClient {
       domain: resolveBrand(this.account.brand),
       loggerLevel: Lark.LoggerLevel.info,
     });
+    attachWsLifecycle(this._wsClient, lifecycle);
 
     // SDK 的 handleEventData 只处理 type="event"，card action 回调是 type="card" 会被丢弃。
     // 打 patch 将 "card" 类型消息改成 "event" 后交给原 handler，让 EventDispatcher 正常路由。

--- a/src/messaging/outbound/deliver.ts
+++ b/src/messaging/outbound/deliver.ts
@@ -16,6 +16,7 @@ import { normalizeFeishuTarget, resolveReceiveIdType } from '../../core/targets'
 import { optimizeMarkdownStyle } from '../../card/markdown-style';
 import { formatLarkError } from '../../core/api-error';
 import { larkLogger } from '../../core/lark-logger';
+import { recordFeishuOutbound } from '../../channel/status-registry';
 import { uploadAndSendMediaLark } from './media';
 
 const log = larkLogger('outbound/deliver');
@@ -90,8 +91,9 @@ async function sendImMessage(params: {
   msgType: 'post' | 'interactive';
   replyToMessageId?: string;
   replyInThread?: boolean;
+  accountId?: string;
 }): Promise<FeishuSendResult> {
-  const { client, to, content, msgType, replyToMessageId, replyInThread } = params;
+  const { client, to, content, msgType, replyToMessageId, replyInThread, accountId } = params;
 
   // --- Reply path ---
   if (replyToMessageId) {
@@ -105,6 +107,9 @@ async function sendImMessage(params: {
       messageId: response?.data?.message_id ?? '',
       chatId: response?.data?.chat_id ?? '',
     };
+    if (accountId) {
+      recordFeishuOutbound(accountId);
+    }
     log.debug(`reply sent: messageId=${result.messageId}`);
     return result;
   }
@@ -130,6 +135,9 @@ async function sendImMessage(params: {
     messageId: response?.data?.message_id ?? '',
     chatId: response?.data?.chat_id ?? '',
   };
+  if (accountId) {
+    recordFeishuOutbound(accountId);
+  }
   log.debug(`message created: messageId=${result.messageId}`);
   return result;
 }
@@ -250,11 +258,20 @@ export async function sendTextLark(params: SendTextLarkParams): Promise<FeishuSe
   }
 
   log.info(`sendTextLark: target=${to}, textLength=${text.length}`);
-  const client = LarkClient.fromCfg(cfg, accountId).sdk;
+  const lark = LarkClient.fromCfg(cfg, accountId);
+  const client = lark.sdk;
   const processedText = prepareTextForLark(cfg, text, accountId);
   const content = buildPostContent(processedText);
 
-  return sendImMessage({ client, to, content, msgType: 'post', replyToMessageId, replyInThread });
+  return sendImMessage({
+    client,
+    to,
+    content,
+    msgType: 'post',
+    replyToMessageId,
+    replyInThread,
+    accountId: lark.accountId,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -328,11 +345,20 @@ export async function sendCardLark(params: SendCardLarkParams): Promise<FeishuSe
   const version = card.schema === '2.0' ? 'v2' : 'v1';
   log.info(`sendCardLark: target=${to}, cardVersion=${version}`);
 
-  const client = LarkClient.fromCfg(cfg, accountId).sdk;
+  const lark = LarkClient.fromCfg(cfg, accountId);
+  const client = lark.sdk;
   const content = JSON.stringify(card);
 
   try {
-    return await sendImMessage({ client, to, content, msgType: 'interactive', replyToMessageId, replyInThread });
+    return await sendImMessage({
+      client,
+      to,
+      content,
+      msgType: 'interactive',
+      replyToMessageId,
+      replyInThread,
+      accountId: lark.accountId,
+    });
   } catch (err) {
     const detail = formatLarkError(err);
     log.error(`sendCardLark failed: ${detail}`);

--- a/src/messaging/outbound/media.ts
+++ b/src/messaging/outbound/media.ts
@@ -21,6 +21,7 @@ import type { OpenClawConfig } from 'openclaw/plugin-sdk';
 import { LarkClient } from '../../core/lark-client';
 import { normalizeFeishuTarget, resolveReceiveIdType } from '../../core/targets';
 import { larkLogger } from '../../core/lark-logger';
+import { recordFeishuOutbound } from '../../channel/status-registry';
 import {
   isLocalMediaPath,
   normalizeMediaUrlInput,
@@ -371,18 +372,23 @@ async function sendMediaMessage(params: {
   msgType: 'image' | 'file' | 'audio' | 'media';
   replyToMessageId?: string;
   replyInThread?: boolean;
+  accountId?: string;
 }): Promise<SendMediaResult> {
-  const { client, to, content, msgType, replyToMessageId, replyInThread } = params;
+  const { client, to, content, msgType, replyToMessageId, replyInThread, accountId } = params;
 
   if (replyToMessageId) {
     const response = await client.im.message.reply({
       path: { message_id: replyToMessageId },
       data: { content, msg_type: msgType, reply_in_thread: replyInThread },
     });
-    return {
+    const result = {
       messageId: response?.data?.message_id ?? '',
       chatId: response?.data?.chat_id ?? '',
     };
+    if (accountId) {
+      recordFeishuOutbound(accountId);
+    }
+    return result;
   }
 
   const target = normalizeFeishuTarget(to);
@@ -399,10 +405,14 @@ async function sendMediaMessage(params: {
     data: { receive_id: target, msg_type: msgType, content },
   });
 
-  return {
+  const result = {
     messageId: response?.data?.message_id ?? '',
     chatId: response?.data?.chat_id ?? '',
   };
+  if (accountId) {
+    recordFeishuOutbound(accountId);
+  }
+  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -431,9 +441,18 @@ export async function sendImageLark(params: {
   const { cfg, to, imageKey, replyToMessageId, replyInThread, accountId } = params;
   log.info(`sendImageLark: target=${to}, imageKey=${imageKey}`);
 
-  const client = LarkClient.fromCfg(cfg, accountId).sdk;
+  const lark = LarkClient.fromCfg(cfg, accountId);
+  const client = lark.sdk;
   const content = JSON.stringify({ image_key: imageKey });
-  return sendMediaMessage({ client, to, content, msgType: 'image', replyToMessageId, replyInThread });
+  return sendMediaMessage({
+    client,
+    to,
+    content,
+    msgType: 'image',
+    replyToMessageId,
+    replyInThread,
+    accountId: lark.accountId,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -462,9 +481,18 @@ export async function sendFileLark(params: {
   const { cfg, to, fileKey, replyToMessageId, replyInThread, accountId } = params;
   log.info(`sendFileLark: target=${to}, fileKey=${fileKey}`);
 
-  const client = LarkClient.fromCfg(cfg, accountId).sdk;
+  const lark = LarkClient.fromCfg(cfg, accountId);
+  const client = lark.sdk;
   const content = JSON.stringify({ file_key: fileKey });
-  return sendMediaMessage({ client, to, content, msgType: 'file', replyToMessageId, replyInThread });
+  return sendMediaMessage({
+    client,
+    to,
+    content,
+    msgType: 'file',
+    replyToMessageId,
+    replyInThread,
+    accountId: lark.accountId,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -496,9 +524,18 @@ export async function sendVideoLark(params: {
   const { cfg, to, fileKey, replyToMessageId, replyInThread, accountId } = params;
   log.info(`sendVideoLark: target=${to}, fileKey=${fileKey}`);
 
-  const client = LarkClient.fromCfg(cfg, accountId).sdk;
+  const lark = LarkClient.fromCfg(cfg, accountId);
+  const client = lark.sdk;
   const content = JSON.stringify({ file_key: fileKey });
-  return sendMediaMessage({ client, to, content, msgType: 'media', replyToMessageId, replyInThread });
+  return sendMediaMessage({
+    client,
+    to,
+    content,
+    msgType: 'media',
+    replyToMessageId,
+    replyInThread,
+    accountId: lark.accountId,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -530,9 +567,18 @@ export async function sendAudioLark(params: {
   const { cfg, to, fileKey, replyToMessageId, replyInThread, accountId } = params;
   log.info(`sendAudioLark: target=${to}, fileKey=${fileKey}`);
 
-  const client = LarkClient.fromCfg(cfg, accountId).sdk;
+  const lark = LarkClient.fromCfg(cfg, accountId);
+  const client = lark.sdk;
   const content = JSON.stringify({ file_key: fileKey });
-  return sendMediaMessage({ client, to, content, msgType: 'audio', replyToMessageId, replyInThread });
+  return sendMediaMessage({
+    client,
+    to,
+    content,
+    msgType: 'audio',
+    replyToMessageId,
+    replyInThread,
+    accountId: lark.accountId,
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/channel/monitor.test.ts
+++ b/tests/channel/monitor.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FeishuAccountConfig } from '../../src/core/types';
+
+const mockAccount: {
+  accountId: string;
+  enabled: boolean;
+  configured: boolean;
+  appId: string;
+  appSecret: string;
+  brand: string;
+  config: FeishuAccountConfig;
+} = {
+  accountId: 'default',
+  enabled: true,
+  configured: true,
+  appId: 'cli_xxx',
+  appSecret: 'secret_xxx',
+  brand: 'feishu',
+  config: {
+    allowFrom: undefined,
+    connectionMode: 'websocket',
+    dedup: {
+      ttlMs: 5000,
+      maxEntries: 100,
+    },
+    groupAllowFrom: undefined,
+  },
+};
+
+let currentConfig: Record<string, unknown> = {};
+
+const mockDisconnect = vi.fn();
+const mockStartWS = vi.fn();
+const mockDrainShutdownHooks = vi.fn().mockResolvedValue(undefined);
+const mockSetGlobalConfig = vi.fn();
+
+vi.mock('../../src/core/accounts', () => ({
+  getEnabledLarkAccounts: vi.fn(() => [mockAccount]),
+  getLarkAccount: vi.fn(() => mockAccount),
+}));
+
+vi.mock('../../src/core/lark-client', () => ({
+  LarkClient: {
+    runtime: {
+      config: {
+        loadConfig: () => currentConfig,
+      },
+    },
+    setGlobalConfig: (...args: unknown[]) => mockSetGlobalConfig(...args),
+    fromAccount: () => ({
+      messageDedup: null,
+      botOpenId: 'ou_bot',
+      disconnect: (...args: unknown[]) => mockDisconnect(...args),
+      startWS: (...args: unknown[]) => mockStartWS(...args),
+    }),
+  },
+}));
+
+vi.mock('../../src/messaging/inbound/dedup', () => ({
+  MessageDedup: class {
+    ttlMs = mockAccount.config.dedup?.ttlMs ?? 5000;
+    maxEntries = mockAccount.config.dedup?.maxEntries ?? 100;
+    size = 0;
+
+    tryRecord() {
+      return true;
+    }
+
+    dispose() {}
+  },
+}));
+
+vi.mock('../../src/core/lark-logger', () => ({
+  larkLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock('../../src/core/shutdown-hooks', () => ({
+  drainShutdownHooks: (...args: unknown[]) => mockDrainShutdownHooks(...args),
+}));
+
+vi.mock('../../src/channel/event-handlers', () => ({
+  handleBotMembershipEvent: vi.fn(),
+  handleCardActionEvent: vi.fn(),
+  handleMessageEvent: vi.fn(),
+  handleReactionEvent: vi.fn(),
+}));
+
+import { monitorFeishuProvider } from '../../src/channel/monitor';
+
+describe('monitorFeishuProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    currentConfig = {};
+    mockAccount.config = {
+      allowFrom: undefined,
+      connectionMode: 'websocket',
+      dedup: { ttlMs: 5000, maxEntries: 100 },
+      groupAllowFrom: undefined,
+    } as FeishuAccountConfig;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('keeps the account disconnected until the socket reports ready', async () => {
+    const patches: Array<Record<string, unknown>> = [];
+    const abortController = new AbortController();
+
+    mockStartWS.mockImplementationOnce(async (opts: { abortSignal?: AbortSignal; lifecycle?: Record<string, () => void> }) => {
+      opts.lifecycle?.onConnectAttempt?.();
+      opts.lifecycle?.onReady?.();
+
+      await new Promise<void>((resolve) => {
+        opts.abortSignal?.addEventListener('abort', () => resolve(), { once: true });
+      });
+    });
+
+    const monitorPromise = monitorFeishuProvider({
+      config: currentConfig as never,
+      accountId: 'default',
+      abortSignal: abortController.signal,
+      setStatus: (patch) => {
+        patches.push(patch);
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(patches.some((patch) => patch.state === 'ready' && patch.connected === true)).toBe(true);
+    });
+
+    abortController.abort();
+    await monitorPromise;
+
+    expect(patches[0]).toMatchObject({
+      connected: false,
+      state: 'starting',
+    });
+    expect(patches.some((patch) => patch.state === 'connecting' && patch.connected === false)).toBe(true);
+    expect(patches.some((patch) => patch.state === 'ready' && patch.connected === true)).toBe(true);
+  });
+
+  it('marks startup timeouts as failed and schedules a restart', async () => {
+    vi.useFakeTimers();
+    const patches: Array<Record<string, unknown>> = [];
+    const abortController = new AbortController();
+
+    mockAccount.config = {
+      allowFrom: undefined,
+      connectionMode: 'websocket',
+      dedup: { ttlMs: 5000, maxEntries: 100 },
+      groupAllowFrom: undefined,
+      healthMonitor: {
+        startupTimeoutMs: 50,
+        initialRestartBackoffMs: 1000,
+        maxRestartBackoffMs: 2000,
+      },
+    } as FeishuAccountConfig;
+
+    mockStartWS.mockImplementation(async (opts: { abortSignal?: AbortSignal; lifecycle?: Record<string, () => void> }) => {
+      opts.lifecycle?.onConnectAttempt?.();
+
+      await new Promise<void>((resolve) => {
+        opts.abortSignal?.addEventListener('abort', () => resolve(), { once: true });
+      });
+    });
+
+    const monitorPromise = monitorFeishuProvider({
+      config: currentConfig as never,
+      accountId: 'default',
+      abortSignal: abortController.signal,
+      setStatus: (patch) => {
+        patches.push(patch);
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(50);
+    await vi.waitFor(() => {
+      expect(
+        patches.some((patch) => patch.state === 'failed' && patch.lastErrorReason === 'startup_timeout'),
+      ).toBe(true);
+    });
+    await vi.waitFor(() => {
+      expect(
+        patches.some((patch) => patch.state === 'restarting' && patch.lastRestartReason === 'startup_timeout'),
+      ).toBe(true);
+    });
+
+    abortController.abort();
+    await monitorPromise;
+
+    expect(mockDisconnect).toHaveBeenCalled();
+  });
+});

--- a/tests/channel/status-registry.test.ts
+++ b/tests/channel/status-registry.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  bindFeishuStatusSink,
+  clearFeishuStatusSinks,
+  recordFeishuInbound,
+  recordFeishuOutbound,
+  updateFeishuAccountStatus,
+} from '../../src/channel/status-registry';
+
+afterEach(() => {
+  clearFeishuStatusSinks();
+});
+
+describe('status-registry', () => {
+  it('forwards patches to the bound sink', () => {
+    const patches: Array<Record<string, unknown>> = [];
+
+    bindFeishuStatusSink('default', (patch) => {
+      patches.push(patch);
+    });
+
+    updateFeishuAccountStatus('default', {
+      state: 'ready',
+      connected: true,
+    });
+
+    expect(patches).toEqual([{ state: 'ready', connected: true }]);
+  });
+
+  it('records inbound timestamps and lastEventAt', () => {
+    const patches: Array<Record<string, unknown>> = [];
+
+    bindFeishuStatusSink('default', (patch) => {
+      patches.push(patch);
+    });
+
+    recordFeishuInbound('default', 1234);
+
+    expect(patches).toEqual([
+      {
+        lastEventAt: 1234,
+        lastInboundAt: 1234,
+      },
+    ]);
+  });
+
+  it('records outbound timestamps', () => {
+    const patches: Array<Record<string, unknown>> = [];
+
+    bindFeishuStatusSink('default', (patch) => {
+      patches.push(patch);
+    });
+
+    recordFeishuOutbound('default', 5678);
+
+    expect(patches).toEqual([
+      {
+        lastOutboundAt: 5678,
+      },
+    ]);
+  });
+});

--- a/tests/channel/ws-lifecycle.test.ts
+++ b/tests/channel/ws-lifecycle.test.ts
@@ -1,0 +1,82 @@
+import { EventEmitter } from 'node:events';
+
+import { describe, expect, it } from 'vitest';
+
+import { attachWsLifecycle } from '../../src/channel/ws-lifecycle';
+
+function createFakeClient() {
+  const socket = new EventEmitter();
+  const client = {
+    wsConfig: {
+      getWSInstance() {
+        return socket;
+      },
+    },
+    async reConnect() {
+      return true;
+    },
+    async connect() {
+      return true;
+    },
+    communicate() {},
+  };
+
+  return { client, socket };
+}
+
+describe('attachWsLifecycle', () => {
+  it('reports connect attempts and ready transitions', async () => {
+    const events: string[] = [];
+    const { client } = createFakeClient();
+
+    attachWsLifecycle(client, {
+      onConnectAttempt() {
+        events.push('attempt');
+      },
+      onReady() {
+        events.push('ready');
+      },
+    });
+
+    await client.reConnect();
+    await client.connect();
+
+    expect(events).toEqual(['attempt', 'ready']);
+  });
+
+  it('reports failed connect attempts', async () => {
+    const events: string[] = [];
+    const { client } = createFakeClient();
+    client.connect = async () => false;
+
+    attachWsLifecycle(client, {
+      onConnectFailure() {
+        events.push('failed');
+      },
+    });
+
+    await client.connect();
+
+    expect(events).toEqual(['failed']);
+  });
+
+  it('subscribes to socket close and error events', () => {
+    const events: string[] = [];
+    const { client, socket } = createFakeClient();
+
+    attachWsLifecycle(client, {
+      onClose() {
+        events.push('close');
+      },
+      onError(err) {
+        events.push(err.message);
+      },
+    });
+
+    client.communicate();
+    socket.emit('error', new Error('boom'));
+    socket.emit('close');
+
+    expect(events).toEqual(['boom', 'close']);
+  });
+});


### PR DESCRIPTION
## Summary

- add Feishu WebSocket lifecycle instrumentation plus a startup watchdog so the channel no longer stays in a fake-online state when the SDK never reaches ready
- publish explicit runtime state and connection timestamps to channel status, including `connected`, `lastEventAt`, `lastInboundAt`, `lastOutboundAt`, and failure metadata used by health monitoring
- add regression tests for lifecycle hooks, status propagation, and startup-timeout restart behavior

## Root Cause

`LarkClient.startWS()` returned as soon as the SDK client was started, but the plugin never observed whether the socket actually reached a ready state. When the SDK got stuck in an in-between reconnect loop, the account still looked running even though it was not receiving events. The channel also did not surface `connected` or activity timestamps, so OpenClaw's generic channel health monitor had no signal to detect the broken state quickly.

## User Impact

Feishu accounts now stay disconnected until the socket reports ready, expose clearer runtime state in diagnostics/status views, and record inbound/outbound activity timestamps so OpenClaw can detect and recover stale connections earlier.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
