### PR TITLE
fix(streaming): safety net for leaked thinking tags and unbalanced markdown

### DIFF
--- a/src/card/markdown-style.ts
+++ b/src/card/markdown-style.ts
@@ -86,6 +86,122 @@ function _optimizeMarkdownStyle(text: string, cardVersion = 2): string {
 }
 
 // ---------------------------------------------------------------------------
+// stripLeakedThinkingContent — channel-level safety net
+// ---------------------------------------------------------------------------
+
+const THINKING_TAGS_RE =
+  /<\s*(?:think(?:ing)?|thought|antthinking)\s*>[\s\S]*?<\s*\/\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
+const UNCLOSED_THINKING_RE =
+  /<\s*(?:think(?:ing)?|thought|antthinking)\s*>[\s\S]*$/gi;
+const ORPHAN_CLOSE_THINKING_RE =
+  /<\s*\/\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
+
+/**
+ * Safety net: strip any leaked `<thinking>` / `<think>` / `<thought>` /
+ * `<antthinking>` content from streaming snapshots.
+ *
+ * The main reasoning pipeline (`splitReasoningText`) handles this during
+ * normal flow, but partial chunks or edge cases may leak through.
+ * Call this right before handing content to CardKit / IM patch.
+ */
+export function stripLeakedThinkingContent(text: string): string {
+  if (!text) return text;
+  // 1. Remove fully-closed blocks
+  let r = text.replace(THINKING_TAGS_RE, '');
+  // 2. Remove unclosed tag at end (still streaming)
+  r = r.replace(UNCLOSED_THINKING_RE, '');
+  // 3. Remove orphaned closing tags
+  r = r.replace(ORPHAN_CLOSE_THINKING_RE, '');
+  return r;
+}
+
+// ---------------------------------------------------------------------------
+// sanitizeCardKitMarkdown — prevent streaming truncation
+// ---------------------------------------------------------------------------
+
+/**
+ * Sanitize markdown for CardKit streaming to prevent rendering breakage
+ * from incomplete markdown in mid-stream snapshots:
+ *
+ * 1. Balance triple-backtick fences (close unclosed code blocks)
+ * 2. Balance inline backticks (outside fenced code blocks)
+ * 3. Escape bare angle brackets outside any code context
+ *
+ * Uses a segment-based approach instead of sentinels to correctly handle
+ * angle brackets inside inline code spans.
+ */
+export function sanitizeCardKitMarkdown(text: string): string {
+  if (!text) return text;
+
+  // ── Step 1: Balance triple-backtick fences ───────────────────────────
+  const fenceRe = /^```/gm;
+  const fenceCount = (text.match(fenceRe) || []).length;
+  let r = text;
+  if (fenceCount % 2 !== 0) {
+    r += '\n```';
+  }
+
+  // ── Step 2 & 3: Process content outside fenced code blocks ───────────
+  // Split by fenced code blocks, process only non-code segments
+  const parts = r.split(/(```[\s\S]*?```)/g);
+  for (let i = 0; i < parts.length; i++) {
+    // Odd indices are fenced code blocks — skip
+    if (i % 2 === 1) continue;
+    parts[i] = sanitizeInlineSegment(parts[i]);
+  }
+  return parts.join('');
+}
+
+/**
+ * Process a segment that is NOT inside a fenced code block:
+ * - Balance inline backticks
+ * - Escape bare `<` outside inline code spans
+ */
+function sanitizeInlineSegment(segment: string): string {
+  // Count inline backticks to check balance
+  const backtickCount = (segment.match(/`/g) || []).length;
+  let result = segment;
+
+  if (backtickCount % 2 !== 0) {
+    // Append closing backtick to balance
+    result += '`';
+  }
+
+  // Escape bare angle brackets outside inline code spans.
+  // Walk through the text tracking code span boundaries.
+  const output: string[] = [];
+  let inCode = false;
+  let pos = 0;
+
+  while (pos < result.length) {
+    if (result[pos] === '`') {
+      inCode = !inCode;
+      output.push('`');
+      pos++;
+    } else if (!inCode && result[pos] === '<') {
+      // Check if this looks like a known safe HTML tag (br, img)
+      const rest = result.slice(pos);
+      if (/^<\/?(?:br|img)\s*\/?>/.test(rest)) {
+        // Known safe tag — keep as-is
+        const tagMatch = rest.match(/^<\/?(?:br|img)\s*\/?>/);
+        if (tagMatch) {
+          output.push(tagMatch[0]);
+          pos += tagMatch[0].length;
+          continue;
+        }
+      }
+      output.push('&lt;');
+      pos++;
+    } else {
+      output.push(result[pos]);
+      pos++;
+    }
+  }
+
+  return output.join('');
+}
+
+// ---------------------------------------------------------------------------
 // stripInvalidImageKeys
 // ---------------------------------------------------------------------------
 

--- a/src/card/markdown-style.ts
+++ b/src/card/markdown-style.ts
@@ -156,6 +156,10 @@ export function sanitizeCardKitMarkdown(text: string): string {
  * Process a segment that is NOT inside a fenced code block:
  * - Balance inline backticks
  * - Escape bare `<` outside inline code spans
+ *
+ * Inline code spans follow CommonMark rules: a run of N backticks opens
+ * a code span that is closed by the next run of exactly N backticks.
+ * E.g. `` `code` ``, ``` ``code with `backtick` inside`` ```.
  */
 function sanitizeInlineSegment(segment: string): string {
   // Count inline backticks to check balance
@@ -168,17 +172,33 @@ function sanitizeInlineSegment(segment: string): string {
   }
 
   // Escape bare angle brackets outside inline code spans.
-  // Walk through the text tracking code span boundaries.
+  // Walk through the text, properly handling multi-backtick code spans.
   const output: string[] = [];
-  let inCode = false;
   let pos = 0;
 
   while (pos < result.length) {
+    // Check for backtick run (start of inline code span)
     if (result[pos] === '`') {
-      inCode = !inCode;
-      output.push('`');
-      pos++;
-    } else if (!inCode && result[pos] === '<') {
+      // Count the opening backtick run length
+      let openLen = 0;
+      const runStart = pos;
+      while (pos < result.length && result[pos] === '`') {
+        openLen++;
+        pos++;
+      }
+      // Look for a matching closing run of exactly the same length
+      const closePattern = '`'.repeat(openLen);
+      const closeIdx = findClosingBacktickRun(result, pos, openLen);
+      if (closeIdx !== -1) {
+        // Found matching close — emit the entire code span as-is
+        output.push(result.slice(runStart, closeIdx + openLen));
+        pos = closeIdx + openLen;
+      } else {
+        // No matching close — emit the backticks as literal text
+        output.push(closePattern);
+        // Continue processing (pos already advanced past the backticks)
+      }
+    } else if (result[pos] === '<') {
       // Check if this looks like a known safe HTML tag (br, img)
       const rest = result.slice(pos);
       if (/^<\/?(?:br|img)\s*\/?>/.test(rest)) {
@@ -199,6 +219,30 @@ function sanitizeInlineSegment(segment: string): string {
   }
 
   return output.join('');
+}
+
+/**
+ * Find the position of a closing backtick run of exactly `runLen` backticks,
+ * starting the search from `startPos`. Returns the index of the first
+ * backtick of the closing run, or -1 if not found.
+ */
+function findClosingBacktickRun(text: string, startPos: number, runLen: number): number {
+  let pos = startPos;
+  while (pos < text.length) {
+    if (text[pos] === '`') {
+      let len = 0;
+      const start = pos;
+      while (pos < text.length && text[pos] === '`') {
+        len++;
+        pos++;
+      }
+      if (len === runLen) return start;
+      // Otherwise, this run doesn't match — keep searching
+    } else {
+      pos++;
+    }
+  }
+  return -1;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/card/streaming-card-controller.ts
+++ b/src/card/streaming-card-controller.ts
@@ -44,7 +44,7 @@ import {
 } from './cardkit';
 import { FlushController } from './flush-controller';
 import { ImageResolver } from './image-resolver';
-import { optimizeMarkdownStyle } from './markdown-style';
+import { optimizeMarkdownStyle, stripLeakedThinkingContent, sanitizeCardKitMarkdown } from './markdown-style';
 import { type ToolUseDisplayResult, buildToolUseTitleSuffix, normalizeToolUseDisplay } from './tool-use-display';
 import { clearToolUseTraceRun, getToolUseTraceSteps } from './tool-use-trace-store';
 import type {
@@ -988,8 +988,13 @@ export class StreamingCardController {
       // 流式中间帧使用同步 resolveImages（不等待异步上传）
       const resolvedText = this.imageResolver.resolveImages(displayText);
 
+      // Safety net: strip any leaked thinking tags, then sanitize for CardKit
+      const sanitizedText = sanitizeCardKitMarkdown(
+        stripLeakedThinkingContent(resolvedText),
+      );
+
       if (this.cardKit.cardKitCardId) {
-        if (resolvedText !== this.text.lastFlushedText) {
+        if (sanitizedText !== this.text.lastFlushedText) {
           const prevSeq = this.cardKit.cardKitSequence;
           this.cardKit.cardKitSequence += 1;
           log.debug('flushCardUpdate: answer seq bump', {
@@ -1000,17 +1005,17 @@ export class StreamingCardController {
             cfg: this.deps.cfg,
             cardId: this.cardKit.cardKitCardId,
             elementId: STREAMING_ELEMENT_ID,
-            content: optimizeMarkdownStyle(resolvedText),
+            content: optimizeMarkdownStyle(sanitizedText),
             sequence: this.cardKit.cardKitSequence,
             accountId: this.deps.accountId,
           });
-          this.text.lastFlushedText = resolvedText;
+          this.text.lastFlushedText = sanitizedText;
         }
       } else {
         log.debug('flushCardUpdate: IM patch fallback');
         const flushDisplay = this.computeToolUseDisplay();
         const card = buildCardContent('streaming', {
-          text: this.reasoning.isReasoningPhase ? '' : resolvedText,
+          text: this.reasoning.isReasoningPhase ? '' : sanitizedText,
           reasoningText: this.reasoning.isReasoningPhase ? this.reasoning.accumulatedReasoningText : undefined,
           toolUseSteps: flushDisplay?.steps,
           toolUseTitleSuffix: this.computeToolUseTitleSuffix(flushDisplay),

--- a/tests/markdown-style-sanitize.test.ts
+++ b/tests/markdown-style-sanitize.test.ts
@@ -92,3 +92,47 @@ test('sanitizeCardKitMarkdown: does NOT escape < inside fenced code block', () =
 test('sanitizeCardKitMarkdown: handles empty input', () => {
   assert.equal(sanitizeCardKitMarkdown(''), '');
 });
+
+test('sanitizeCardKitMarkdown: does NOT escape < inside double-backtick inline code', () => {
+  const input = 'Use ``x < 10`` in condition';
+  const result = sanitizeCardKitMarkdown(input);
+  assert.ok(result.includes('``x < 10``'), `Expected < preserved in double-backtick code, got: ${result}`);
+});
+
+test('sanitizeCardKitMarkdown: does NOT escape < inside fenced code block with language tag', () => {
+  const input = '```typescript\nconst x: Array<number> = [1];\n```';
+  const result = sanitizeCardKitMarkdown(input);
+  assert.ok(!result.includes('&lt;'), `Expected no &lt; in fenced code block, got: ${result}`);
+});
+
+test('sanitizeCardKitMarkdown: escapes < in long lines (no char limit)', () => {
+  const longComponent = '<' + 'A'.repeat(200) + '>';
+  const input = `Use ${longComponent} in your app`;
+  const result = sanitizeCardKitMarkdown(input);
+  assert.ok(result.includes('&lt;'), `Expected < to be escaped even in long lines, got: ${result}`);
+});
+
+test('sanitizeCardKitMarkdown: handles mixed fenced and inline code with angle brackets', () => {
+  const input = 'Use `<div>` before\n```html\n<span>hi</span>\n```\nand <p> after';
+  const result = sanitizeCardKitMarkdown(input);
+  // < in inline code preserved
+  assert.ok(result.includes('`<div>`'), `Expected inline code preserved, got: ${result}`);
+  // < in fenced code preserved
+  assert.ok(result.includes('<span>'), `Expected fenced code preserved, got: ${result}`);
+  // < outside code escaped
+  assert.ok(result.includes('&lt;p>'), `Expected bare < escaped, got: ${result}`);
+});
+
+test('sanitizeCardKitMarkdown: unclosed fenced code block with < inside gets protected', () => {
+  const input = 'text\n```js\nif (x < 10) {';
+  const result = sanitizeCardKitMarkdown(input);
+  assert.ok(!result.includes('&lt;'), `Expected < inside code block not escaped, got: ${result}`);
+});
+
+test('sanitizeCardKitMarkdown: multiple fenced code blocks preserve angle brackets', () => {
+  const input = '```\nfoo < bar\n```\noutside <tag>\n```\nbaz < qux\n```';
+  const result = sanitizeCardKitMarkdown(input);
+  assert.ok(result.includes('foo < bar'), `Expected < preserved in first code block`);
+  assert.ok(result.includes('baz < qux'), `Expected < preserved in second code block`);
+  assert.ok(result.includes('&lt;tag>'), `Expected bare < escaped outside code blocks`);
+});

--- a/tests/markdown-style-sanitize.test.ts
+++ b/tests/markdown-style-sanitize.test.ts
@@ -1,0 +1,94 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { stripLeakedThinkingContent, sanitizeCardKitMarkdown } from '../src/card/markdown-style.ts';
+
+// ---------------------------------------------------------------------------
+// stripLeakedThinkingContent
+// ---------------------------------------------------------------------------
+
+test('stripLeakedThinkingContent: removes fully-closed <thinking> block', () => {
+  const input = 'Hello <thinking>secret reasoning</thinking> world';
+  assert.equal(stripLeakedThinkingContent(input), 'Hello  world');
+});
+
+test('stripLeakedThinkingContent: removes fully-closed <think> block', () => {
+  const input = 'A <think>internal</think> B';
+  assert.equal(stripLeakedThinkingContent(input), 'A  B');
+});
+
+test('stripLeakedThinkingContent: removes unclosed tag at end (streaming)', () => {
+  const input = 'Answer text <thinking>still streaming...';
+  assert.equal(stripLeakedThinkingContent(input), 'Answer text ');
+});
+
+test('stripLeakedThinkingContent: removes orphaned closing tag', () => {
+  const input = '</thinking> leftover answer';
+  assert.equal(stripLeakedThinkingContent(input), ' leftover answer');
+});
+
+test('stripLeakedThinkingContent: handles <antthinking> variant', () => {
+  const input = '<antthinking>plan</antthinking>result';
+  assert.equal(stripLeakedThinkingContent(input), 'result');
+});
+
+test('stripLeakedThinkingContent: passes through clean text', () => {
+  const input = 'No thinking tags here';
+  assert.equal(stripLeakedThinkingContent(input), 'No thinking tags here');
+});
+
+test('stripLeakedThinkingContent: handles empty/null input', () => {
+  assert.equal(stripLeakedThinkingContent(''), '');
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeCardKitMarkdown
+// ---------------------------------------------------------------------------
+
+test('sanitizeCardKitMarkdown: closes unclosed triple-backtick fence', () => {
+  const input = 'Text\n```python\nprint("hello")';
+  const result = sanitizeCardKitMarkdown(input);
+  assert.ok(result.endsWith('\n```'), `Expected closing fence, got: ${result}`);
+});
+
+test('sanitizeCardKitMarkdown: leaves balanced fences untouched', () => {
+  const input = 'Before\n```\ncode\n```\nAfter';
+  assert.equal(sanitizeCardKitMarkdown(input), input);
+});
+
+test('sanitizeCardKitMarkdown: closes unclosed inline backtick', () => {
+  const input = 'Use the `command to run';
+  const result = sanitizeCardKitMarkdown(input);
+  // Should have even number of backticks
+  const count = (result.match(/`/g) || []).length;
+  assert.equal(count % 2, 0, `Backtick count should be even, got ${count}`);
+});
+
+test('sanitizeCardKitMarkdown: escapes bare angle brackets outside code', () => {
+  const input = 'Use <MyComponent> in your app';
+  const result = sanitizeCardKitMarkdown(input);
+  assert.ok(result.includes('&lt;'), `Expected escaped <, got: ${result}`);
+});
+
+test('sanitizeCardKitMarkdown: preserves <br> tags', () => {
+  const input = 'Line one<br>Line two';
+  const result = sanitizeCardKitMarkdown(input);
+  assert.ok(result.includes('<br>'), `Expected <br> preserved, got: ${result}`);
+});
+
+test('sanitizeCardKitMarkdown: does NOT escape < inside inline code', () => {
+  const input = 'Use `<div>` in your template';
+  const result = sanitizeCardKitMarkdown(input);
+  // The < inside backticks should remain unescaped
+  assert.ok(result.includes('`<div>`'), `Expected < preserved in inline code, got: ${result}`);
+});
+
+test('sanitizeCardKitMarkdown: does NOT escape < inside fenced code block', () => {
+  const input = '```html\n<div class="test">\n```';
+  const result = sanitizeCardKitMarkdown(input);
+  assert.ok(result.includes('<div'), `Expected < preserved in code block, got: ${result}`);
+});
+
+test('sanitizeCardKitMarkdown: handles empty input', () => {
+  assert.equal(sanitizeCardKitMarkdown(''), '');
+});


### PR DESCRIPTION
## Summary

- Add `stripLeakedThinkingContent()` as a channel-level safety net to remove any leaked `<thinking>`/`<think>`/`<thought>`/`<antthinking>` content from streaming card output
- Add `sanitizeCardKitMarkdown()` to prevent CardKit rendering truncation from:
  - Unclosed triple-backtick fences
  - Unbalanced inline backticks  
  - Bare angle brackets outside code context (preserves `<br>`/`<img>`)
- Uses **segment-based traversal** (not sentinel replacement) to correctly handle `<` inside inline code spans — avoids the known bug where sentinel approaches incorrectly escape angle brackets at code-span boundaries
- Wire both functions into `StreamingCardController.performFlush()` for both CardKit streaming and IM patch fallback paths

## Test plan

- [x] 15 unit tests covering all edge cases (`node --experimental-strip-types --test tests/markdown-style-sanitize.test.ts`)
- [ ] Manual: verify streaming card renders correctly with thinking model (e.g. Claude with extended thinking)
- [ ] Manual: verify code blocks with `<` in streaming don't get double-escaped
- [ ] Manual: verify unclosed backtick mid-stream doesn't break card layout