### PR TITLE
fix: skip trailing <br> after table when followed by separator/heading/bold/EOF

### DIFF
--- a/src/card/markdown-style.ts
+++ b/src/card/markdown-style.ts
@@ -51,8 +51,12 @@ function _optimizeMarkdownStyle(text: string, cardVersion = 2): string {
     r = r.replace(/^([^|\n].*)\n(\|.+\|)/gm, '$1\n\n$2');
     // 4b. 表格前：在空行之前插入 <br>（即 \n\n| → \n<br>\n\n| ）
     r = r.replace(/\n\n((?:\|.+\|[^\S\n]*\n?)+)/g, '\n\n<br>\n\n$1');
-    // 4c. 表格后：在表格块末尾追加 <br>
-    r = r.replace(/((?:^\|.+\|[^\S\n]*\n?)+)/gm, '$1\n<br>\n');
+    // 4c. 表格后：在表格块末尾追加 <br>（跳过后接分隔线/标题/加粗/文末的情况）
+    r = r.replace(/((?:^\|.+\|[^\S\n]*\n?)+)/gm, (m, _table, offset) => {
+      const after = r.slice(offset + m.length).replace(/^\n+/, '');
+      if (!after || /^(---|#{4,5} |\*\*)/.test(after)) return m;
+      return m + '\n<br>\n';
+    });
     // 4d. 表格前是普通文本（非标题、非加粗行）时，只需 <br>，去掉多余空行
     //     "text\n\n<br>\n\n|" → "text\n<br>\n|"
     r = r.replace(/^((?!#{4,5} )(?!\*\*).+)\n\n(<br>)\n\n(\|)/gm, '$1\n$2\n$3');


### PR DESCRIPTION
## Summary

Fixes #281

- In `_optimizeMarkdownStyle` step 4c, the regex unconditionally appends `\n<br>\n` after every markdown table block
- Feishu card markdown renders this `<br>` as a visible empty row at the bottom of each table
- Changed step 4c to use a callback that checks what follows the table block, skipping the `<br>` when:
  - Table is followed by `---` (horizontal rule already provides spacing)
  - Table is followed by `**` (bold heading)
  - Table is followed by `####` / `#####` (heading)
  - Table is at the end of text (trailing `<br>` is meaningless)

## Test plan

- [ ] Set `channels.feishu.streaming: true` and `replyMode: "streaming"`
- [ ] Have agent reply with markdown containing tables followed by `---`, `**bold**`, headings, and at end of text
- [ ] Verify no extra empty row appears at the bottom of any table
- [ ] Verify normal table-to-paragraph spacing still works (non-skipped cases)