### PR TITLE
fix: route all thread messages to thread, not just /new and /reset

### DIFF
--- a/src/messaging/inbound/dispatch.ts
+++ b/src/messaging/inbound/dispatch.ts
@@ -253,7 +253,7 @@ export async function dispatchToAgent(params: {
     ? params.groupConfig?.systemPrompt?.trim() || params.defaultGroupConfig?.systemPrompt?.trim() || undefined
     : undefined;
   const originatingTo =
-    isBareNewOrReset && dc.isThread
+    dc.isThread
       ? encodeFeishuRouteTarget({
           target: dc.feishuTo,
           replyToMessageId: params.replyToMessageId ?? params.ctx.messageId,


### PR DESCRIPTION
## Summary

Fixes a bug where subagent announce messages (and other non-command messages) in `threadSession` mode are sent to the group's main chat instead of the originating thread.

## Problem

When `threadSession` mode is active and an agent spawns a subagent, the subagent's completion/announce message lands in the **group top-level chat** instead of the **thread** where the conversation started.

### Root Cause

`originatingTo` only encoded `replyToMessageId` + `threadId` for `/new` and `/reset` commands (`isBareNewOrReset && dc.isThread`). For all other messages in a thread, `originatingTo` was left as the plain chat ID without thread routing info.

Without `replyToMessageId` in the outbound `to` field, the Feishu outbound adapter falls back to `im.message.create()` which **always sends to the group top-level**. Only `im.message.reply(message_id, reply_in_thread: true)` can target a thread.

### Fix

Remove the `isBareNewOrReset &&` gate so ALL thread messages encode the thread routing info into `originatingTo`. Non-thread messages are unaffected since `dc.isThread` is still required.

```diff
  const originatingTo =
-   isBareNewOrReset && dc.isThread
+   dc.isThread
      ? encodeFeishuRouteTarget({
          target: dc.feishuTo,
          replyToMessageId: params.replyToMessageId ?? params.ctx.messageId,
```

### Safety

- Non-thread messages: unaffected (`dc.isThread` still gates the condition)
- `isBareNewOrReset` variable: still used on line 356 for chat history clearing, not removed
- `deliveryContextKey()`: not affected for groups (only impacts DM sessions)

## Companion Fix

This fix works together with a core openclaw fix that adds `threadId` to `resolveFeishuSession()` in `outbound-session.ts` (the dedicated Feishu session resolver was missing `threadId` in its return value).