### PR TITLE
fix(skills): correct tool name references in SKILL.md files

### DIFF
--- a/skills/feishu-create-doc/SKILL.md
+++ b/skills/feishu-create-doc/SKILL.md
@@ -4,7 +4,7 @@ description: |
   创建飞书云文档。从 Lark-flavored Markdown 内容创建新的飞书云文档，支持指定创建位置（文件夹/知识库/知识空间）。
 ---
 
-# feishu_mcp_create_doc
+# feishu_create_doc
 
 通过 MCP 调用 `create-doc`，从 Lark-flavored Markdown 内容创建一个新的飞书云文档。
 

--- a/skills/feishu-fetch-doc/SKILL.md
+++ b/skills/feishu-fetch-doc/SKILL.md
@@ -4,7 +4,7 @@ description: |
   获取飞书云文档内容。返回文档的 Markdown 内容，支持处理文档中的图片、文件和画板（需配合 feishu_doc_media 工具）。
 ---
 
-# feishu_mcp_fetch_doc
+# feishu_fetch_doc
 
 获取飞书云文档的 Markdown 内容（Lark-flavored 格式）。
 
@@ -68,7 +68,7 @@ description: |
 
 | obj_type | 工具 | 传参 |
 |----------|------|------|
-| `docx` | `feishu_mcp_fetch_doc` | doc_id = obj_token |
+| `docx` | `feishu_fetch_doc` | doc_id = obj_token |
 | `sheet` | `feishu_sheet` | spreadsheet_token = obj_token |
 | `bitable` | `feishu_bitable_*` 系列 | app_token = obj_token |
 | 其他 | 告知用户暂不支持该类型 | — |
@@ -80,13 +80,13 @@ description: |
 
 1. 调用 `feishu_wiki_space_node`（action: get, token: ABC123）
 2. 返回 `obj_type: "docx"`, `obj_token: "doxcnXYZ789"`
-3. 调用 `feishu_mcp_fetch_doc`（doc_id: doxcnXYZ789）
+3. 调用 `feishu_fetch_doc`（doc_id: doxcnXYZ789）
 
 ## 工具组合
 
 | 需求 | 工具 |
 |------|------|
-| 获取文档文本 | `feishu_mcp_fetch_doc` |
+| 获取文档文本 | `feishu_fetch_doc` |
 | 下载图片/文件/画板 | `feishu_doc_media`（action: download） |
 | 解析 wiki token 类型 | `feishu_wiki_space_node`（action: get） |
 | 读写电子表格 | `feishu_sheet` |

--- a/skills/feishu-update-doc/SKILL.md
+++ b/skills/feishu-update-doc/SKILL.md
@@ -4,7 +4,7 @@ description: |
   更新飞书云文档。支持 7 种更新模式：追加、覆盖、定位替换、全文替换、前/后插入、删除。
 ---
 
-# feishu__update_doc
+# feishu_update_doc
 
 更新飞书云文档内容，支持 7 种更新模式。优先使用局部更新（replace_range/append/insert_before/insert_after），慎用 overwrite（会清空文档重写，可能丢失图片、评论等）。
 


### PR DESCRIPTION
## Summary

- `feishu-fetch-doc/SKILL.md`: `feishu_mcp_fetch_doc` → `feishu_fetch_doc` (4 occurrences)
- `feishu-create-doc/SKILL.md`: `feishu_mcp_create_doc` → `feishu_create_doc`
- `feishu-update-doc/SKILL.md`: `feishu__update_doc` → `feishu_update_doc`

The SKILL.md files reference tool names that don't match the actual registered names defined in `src/tools/mcp/doc/*.ts`. When the model reads a SKILL.md and tries to find the referenced tool, it fails and falls back to `web_fetch`, which gets redirected to the Feishu login page.

SKILL.md 中引用的工具名与实际注册名（定义在 `src/tools/mcp/doc/*.ts`）不一致。模型读了 SKILL.md 后找不到对应工具，退而使用 `web_fetch`，结果被重定向到登录页。

Fixes #336

## Test plan

- [x] Verified locally: after correcting tool names, model successfully calls `feishu_fetch_doc` and reads document content
- [x] Verified `feishu_wiki_space_node` → `feishu_fetch_doc` routing works as described in SKILL.md