### PR TITLE
feat: bridge ticket and resume auth in spawned agent session

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "zod": "^4.3.6"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.3.22"
+    "openclaw": ">=2026.3.28"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -64,7 +64,7 @@
     "fs-extra": "^11.3.2",
     "globals": "^16.2.0",
     "minimist": "^1.2.8",
-    "openclaw": "^2026.3.22",
+    "openclaw": "^2026.3.28",
     "prettier": "^3.8.1",
     "tsdown": "^0.21.4",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ importers:
         specifier: ^1.2.8
         version: 1.2.8
       openclaw:
-        specifier: ^2026.3.22
-        version: 2026.3.23(@napi-rs/canvas@0.1.96)
+        specifier: ^2026.3.28
+        version: 2026.3.28(@napi-rs/canvas@0.1.96)
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
@@ -72,8 +72,8 @@ importers:
 
 packages:
 
-  '@agentclientprotocol/sdk@0.16.1':
-    resolution: {integrity: sha512-1ad+Sc/0sCtZGHthxxvgEUo5Wsbw16I+aF+YwdiLnPwkZG8KAGUEAPK6LM6Pf69lCyJPt1Aomk1d+8oE3C4ZEw==}
+  '@agentclientprotocol/sdk@0.17.0':
+    resolution: {integrity: sha512-inBMYAEd9t4E+ULZK2os9kmLG5jbPvMLbPvY71XDDem1YteW/uDwkahg6OwsGR3tvvgVhYbRJ9mJCp2VXqG4xQ==}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
@@ -110,80 +110,80 @@ packages:
     resolution: {integrity: sha512-0k9d0oO6nw3Y6jtgs1cmMPNuwAVPQahIoshKK3NDfhVQR1wNC90/gSpdfa9GKswe8XRq/ZZlq7ny0qM1rd/Hkg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/client-bedrock@3.1016.0':
-    resolution: {integrity: sha512-9WT6UyRw3SsiOW9JBElXnPGRBjzCoQlFmMHxGeptCPlrbPq+K64k6TrbN8Lrt4I6v4umzAeF7gU09KVPPAoXHg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/core@3.973.20':
-    resolution: {integrity: sha512-i3GuX+lowD892F3IuJf8o6AbyDupMTdyTxQrCJGcn71ni5hTZ82L4nQhcdumxZ7XPJRJJVHS/CR3uYOIIs0PVA==}
+  '@aws-sdk/client-bedrock@3.1020.0':
+    resolution: {integrity: sha512-OIM38upZjWsi62070cOm2nZAJsIeZC26KhOFDt8T6gmzbfcoz7XgkJ6eK9/JFfFagoFykUvXX0nfbcqtryWY0A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/core@3.973.24':
     resolution: {integrity: sha512-vvf82RYQu2GidWAuQq+uIzaPz9V0gSCXVqdVzRosgl5rXcspXOpSD3wFreGGW6AYymPr97Z69kjVnLePBxloDw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.972.18':
-    resolution: {integrity: sha512-X0B8AlQY507i5DwjLByeU2Af4ARsl9Vr84koDcXCbAkplmU+1xBFWxEPrWRAoh56waBne/yJqEloSwvRf4x6XA==}
+  '@aws-sdk/core@3.973.26':
+    resolution: {integrity: sha512-A/E6n2W42ruU+sfWk+mMUOyVXbsSgGrY3MJ9/0Az5qUdG67y8I6HYzzoAa+e/lzxxl1uCYmEL6BTMi9ZiZnplQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-env@3.972.22':
     resolution: {integrity: sha512-cXp0VTDWT76p3hyK5D51yIKEfpf6/zsUvMfaB8CkyqadJxMQ8SbEeVroregmDlZbtG31wkj9ei0WnftmieggLg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-http@3.972.20':
-    resolution: {integrity: sha512-ey9Lelj001+oOfrbKmS6R2CJAiXX7QKY4Vj9VJv6L2eE6/VjD8DocHIoYqztTm70xDLR4E1jYPTKfIui+eRNDA==}
+  '@aws-sdk/credential-provider-env@3.972.24':
+    resolution: {integrity: sha512-FWg8uFmT6vQM7VuzELzwVo5bzExGaKHdubn0StjgrcU5FvuLExUe+k06kn/40uKv59rYzhez8eFNM4yYE/Yb/w==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.24':
     resolution: {integrity: sha512-h694K7+tRuepSRJr09wTvQfaEnjzsKZ5s7fbESrVds02GT/QzViJ94/HCNwM7bUfFxqpPXHxulZfL6Cou0dwPg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-ini@3.972.20':
-    resolution: {integrity: sha512-5flXSnKHMloObNF+9N0cupKegnH1Z37cdVlpETVgx8/rAhCe+VNlkcZH3HDg2SDn9bI765S+rhNPXGDJJPfbtA==}
+  '@aws-sdk/credential-provider-http@3.972.26':
+    resolution: {integrity: sha512-CY4ppZ+qHYqcXqBVi//sdHST1QK3KzOEiLtpLsc9W2k2vfZPKExGaQIsOwcyvjpjUEolotitmd3mUNY56IwDEA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.24':
     resolution: {integrity: sha512-O46fFmv0RDFWiWEA9/e6oW92BnsyAXuEgTTasxHligjn2RCr9L/DK773m/NoFaL3ZdNAUz8WxgxunleMnHAkeQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-login@3.972.20':
-    resolution: {integrity: sha512-gEWo54nfqp2jABMu6HNsjVC4hDLpg9HC8IKSJnp0kqWtxIJYHTmiLSsIfI4ScQjxEwpB+jOOH8dOLax1+hy/Hw==}
+  '@aws-sdk/credential-provider-ini@3.972.27':
+    resolution: {integrity: sha512-Um26EsNSUfVUX0wUXnUA1W3wzKhVy6nviEElsh5lLZUYj9bk6DXOPnpte0gt+WHubcVfVsRk40bbm4KaroTEag==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.24':
     resolution: {integrity: sha512-sIk8oa6AzDoUhxsR11svZESqvzGuXesw62Rl2oW6wguZx8i9cdGCvkFg+h5K7iucUZP8wyWibUbJMc+J66cu5g==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-node@3.972.21':
-    resolution: {integrity: sha512-hah8if3/B/Q+LBYN5FukyQ1Mym6PLPDsBOBsIgNEYD6wLyZg0UmUF/OKIVC3nX9XH8TfTPuITK+7N/jenVACWA==}
+  '@aws-sdk/credential-provider-login@3.972.27':
+    resolution: {integrity: sha512-t3ehEtHomGZwg5Gixw4fYbYtG9JBnjfAjSDabxhPEu/KLLUp0BB37/APX7MSKXQhX6ZH7pseuACFJ19NrAkNdg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.25':
     resolution: {integrity: sha512-m7dR0Dsva2P+VUpL+VkC0WwiDby5pgmWXkRVDB5rlwv0jXJrQJf7YMtCoM8Wjk0H9jPeCYOxOXXcIgp/qp5Alg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-process@3.972.18':
-    resolution: {integrity: sha512-Tpl7SRaPoOLT32jbTWchPsn52hYYgJ0kpiFgnwk8pxTANQdUymVSZkzFvv1+oOgZm1CrbQUP9MBeoMZ9IzLZjA==}
+  '@aws-sdk/credential-provider-node@3.972.28':
+    resolution: {integrity: sha512-rren+P6k5rShG5PX61iVi40kKdueyuMLBRTctQbyR5LooO9Ygr5L6R7ilG7RF1957NSH3KC3TU206fZuKwjSpQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.22':
     resolution: {integrity: sha512-Os32s8/4gTZjBk5BtoS/cuTILaj+K72d0dVG7TCJX/fC4598cxwLDmf1AEHEpER5oL3K//yETjvFaz0V8oO5Xw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.972.20':
-    resolution: {integrity: sha512-p+R+PYR5Z7Gjqf/6pvbCnzEHcqPCpLzR7Yf127HjJ6EAb4hUcD+qsNRnuww1sB/RmSeCLxyay8FMyqREw4p1RA==}
+  '@aws-sdk/credential-provider-process@3.972.24':
+    resolution: {integrity: sha512-Q2k/XLrFXhEztPHqj4SLCNID3hEPdlhh1CDLBpNnM+1L8fq7P+yON9/9M1IGN/dA5W45v44ylERfXtDAlmMNmw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.24':
     resolution: {integrity: sha512-PaFv7snEfypU2yXkpvfyWgddEbDLtgVe51wdZlinhc2doubBjUzJZZpgwuF2Jenl1FBydMhNpMjD6SBUM3qdSA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-web-identity@3.972.20':
-    resolution: {integrity: sha512-rWCmh8o7QY4CsUj63qopzMzkDq/yPpkrpb+CnjBEFSOg/02T/we7sSTVg4QsDiVS9uwZ8VyONhq98qt+pIh3KA==}
+  '@aws-sdk/credential-provider-sso@3.972.27':
+    resolution: {integrity: sha512-CWXeGjlbBuHcm9appZUgXKP2zHDyTti0/+gXpSFJ2J3CnSwf1KWjicjN0qG2ozkMH6blrrzMrimeIOEYNl238Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.972.24':
     resolution: {integrity: sha512-J6H4R1nvr3uBTqD/EeIPAskrBtET4WFfNhpFySr2xW7bVZOXpQfPjrLSIx65jcNjBmLXzWq8QFLdVoGxiGG/SA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.27':
+    resolution: {integrity: sha512-CUY4hQIFswdQNEsRGEzGBUKGMK5KpqmNDdu2ROMgI+45PLFS8H0y3Tm7kvM16uvvw3n1pVxk85tnRVUTgtaa1w==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/eventstream-handler-node@3.972.11':
@@ -206,28 +206,32 @@ packages:
     resolution: {integrity: sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-user-agent@3.972.21':
-    resolution: {integrity: sha512-62XRl1GDYPpkt7cx1AX1SPy9wgNE9Iw/NPuurJu4lmhCWS7sGKO+kS53TQ8eRmIxy3skmvNInnk0ZbWrU5Dpyg==}
+  '@aws-sdk/middleware-recursion-detection@3.972.9':
+    resolution: {integrity: sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-user-agent@3.972.25':
     resolution: {integrity: sha512-QxiMPofvOt8SwSynTOmuZfvvPM1S9QfkESBxB22NMHTRXCJhR5BygLl8IXfC4jELiisQgwsgUby21GtXfX3f/g==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-user-agent@3.972.27':
+    resolution: {integrity: sha512-TIRLO5UR2+FVUGmhYoAwVkKhcVzywEDX/5LzR9tjy1h8FQAXOtFg2IqgmwvxU7y933rkTn9rl6AdgcAUgQ1/Kg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-websocket@3.972.13':
     resolution: {integrity: sha512-Gp6EWIqHX5wmsOR5ZxWyyzEU8P0xBdSxkm6VHEwXwBqScKZ7QWRoj6ZmHpr+S44EYb5tuzGya4ottsogSu2W3A==}
     engines: {node: '>= 14.0.0'}
-
-  '@aws-sdk/nested-clients@3.996.10':
-    resolution: {integrity: sha512-SlDol5Z+C7Ivnc2rKGqiqfSUmUZzY1qHfVs9myt/nxVwswgfpjdKahyTzLTx802Zfq0NFRs7AejwKzzzl5Co2w==}
-    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/nested-clients@3.996.14':
     resolution: {integrity: sha512-fSESKvh1VbfjtV3QMnRkCPZWkUbQof6T/DOpiLp33yP2wA+rbwwnZeG3XT3Ekljgw2I8X4XaQPnw+zSR8yxJ5Q==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/region-config-resolver@3.972.8':
-    resolution: {integrity: sha512-1eD4uhTDeambO/PNIDVG19A6+v4NdD7xzwLHDutHsUqz0B+i661MwQB2eYO4/crcCvCiQG4SRm1k81k54FEIvw==}
+  '@aws-sdk/nested-clients@3.996.17':
+    resolution: {integrity: sha512-7B0HIX0tEFmOSJuWzdHZj1WhMXSryM+h66h96ZkqSncoY7J6wq61KOu4Kr57b/YnJP3J/EeQYVFulgR281h+7A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.972.10':
+    resolution: {integrity: sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/region-config-resolver@3.972.9':
@@ -242,8 +246,8 @@ packages:
     resolution: {integrity: sha512-3OSD4y110nisRhHzFOjoEeHU4GQL4KpzkX9PxzWaiZe0Yg2+thZKM0Pn9DjYwezH5JYfh/K++xK/SE0IHGrmCQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/token-providers@3.1016.0':
-    resolution: {integrity: sha512-KrNDd96OeS5To21DX8Zzb9MmANNm+fn+xO+ZkxLoJ6gl/xD5s8elYdQsCT5lOBLALHgqihVZtVHKMMPC+yib6w==}
+  '@aws-sdk/token-providers@3.1020.0':
+    resolution: {integrity: sha512-T61KA/VKl0zVUubdxigr1ut7SEpwE1/4CIKb14JDLyTAOne2yWKtQE1dDCSHl0UqrZNwW/bTt+EBHfQbslZJdw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.6':
@@ -274,8 +278,8 @@ packages:
       aws-crt:
         optional: true
 
-  '@aws-sdk/util-user-agent-node@3.973.7':
-    resolution: {integrity: sha512-Hz6EZMUAEzqUd7e+vZ9LE7mn+5gMbxltXy18v+YSFY+9LBJz15wkNZvw5JqfX3z0FS9n3bgUtz3L5rAsfh4YlA==}
+  '@aws-sdk/util-user-agent-node@3.973.13':
+    resolution: {integrity: sha512-s1dCJ0J9WU9UPkT3FFqhKTSquYTkqWXGRaapHFyWwwJH86ZussewhNST5R5TwXVL1VSHq4aJVl9fWK+svaRVCQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       aws-crt: '>=1.0.0'
@@ -283,12 +287,12 @@ packages:
       aws-crt:
         optional: true
 
-  '@aws-sdk/xml-builder@3.972.11':
-    resolution: {integrity: sha512-iitV/gZKQMvY9d7ovmyFnFuTHbBAtrmLnvaSb/3X8vOKyevwtpmEtyc8AdhVWZe0pI/1GsHxlEvQeOePFzy7KQ==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/xml-builder@3.972.15':
     resolution: {integrity: sha512-PxMRlCFNiQnke9YR29vjFQwz4jq+6Q04rOVFeTDR2K7Qpv9h9FOWOxG+zJjageimYbWqE3bTuLjmryWHAWbvaA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.16':
+    resolution: {integrity: sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
@@ -706,29 +710,37 @@ packages:
     resolution: {integrity: sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==}
     hasBin: true
 
-  '@mariozechner/pi-agent-core@0.61.1':
-    resolution: {integrity: sha512-ELZsyx6INGBYXPAbYTAiRWtkmnwAlcXOOVPY434BE605TBdpzMrXF5gNckKdEyCCWYJiLzSKpHaAzWwB7Vx2nA==}
+  '@mariozechner/pi-agent-core@0.63.1':
+    resolution: {integrity: sha512-h0B20xfs/iEVR2EC4gwiE8hKI1TPeB8REdRJMgV+uXKH7gpeIZ9+s8Dp9nX35ZR0QUjkNey2+ULk2DxQtdg14Q==}
     engines: {node: '>=20.0.0'}
 
-  '@mariozechner/pi-ai@0.61.1':
-    resolution: {integrity: sha512-BOk8xwluIgauX93qgC9qyrWteKKnk6pNDM8szE1m/EJKMhcJ/jIJpgAUQgj4yXiwSMtcZm30h2Po97gqqXTIIg==}
+  '@mariozechner/pi-ai@0.63.1':
+    resolution: {integrity: sha512-wjgwY+yfrFO6a9QdAfjWpH7iSrDean6GsKDDMohNcLCy6PreMxHOZvNM0NwJARL1tZoZovr7ikAQfLGFZbnjsw==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
-  '@mariozechner/pi-coding-agent@0.61.1':
-    resolution: {integrity: sha512-w0QTn+LFFdyFhpaaYDOacGwBjW4MKYrl40b6LPfKDuVJ+9fDfHl3kWkbx6xJb9brk6M5lEFMheC82UIQdkeK3Q==}
+  '@mariozechner/pi-coding-agent@0.63.1':
+    resolution: {integrity: sha512-XSoMyLtuMA7ePK1UBWqSJ/BBdtBdJUHY9nbtnNyG6GeW7Gbgd+iqljIuwmAUf8wlYL981UIfYM/WIPQ6t/dIxw==}
     engines: {node: '>=20.6.0'}
     hasBin: true
 
-  '@mariozechner/pi-tui@0.61.1':
-    resolution: {integrity: sha512-J3EI1gU5knUf1dXiHJsimDP4IRXLG7QJ1NVykU/yWOJoBPAgG6/qjjPPRcaUA7MYMUfKi+Z/zzGOyQSCVAajPA==}
+  '@mariozechner/pi-tui@0.63.1':
+    resolution: {integrity: sha512-G5p+eh1EPkFCNaaggX6vRrqttnDscK6npgmEOknoCQXZtch8XNgh9Lf3VJ0A2lZXSgR7IntG5dfXHPH/Ki64wA==}
     engines: {node: '>=20.0.0'}
+
+  '@matrix-org/matrix-sdk-crypto-nodejs@0.4.0':
+    resolution: {integrity: sha512-+qqgpn39XFSbsD0dFjssGO9vHEP7sTyfs8yTpt8vuqWpUpF20QMwpCZi0jpYw7GxjErNTsMshopuo8677DfGEA==}
+    engines: {node: '>= 22'}
+
+  '@matrix-org/matrix-sdk-crypto-wasm@18.0.0':
+    resolution: {integrity: sha512-88+n+dvxLI1cjS10UIlKXVYK7TGWbpAnnaDC9fow7ch/hCvdu3dFhJ3tS3/13N9s9+1QFXB4FFuommj+tHJPhQ==}
+    engines: {node: '>= 18'}
 
   '@mistralai/mistralai@1.14.1':
     resolution: {integrity: sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==}
 
-  '@modelcontextprotocol/sdk@1.27.1':
-    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
+  '@modelcontextprotocol/sdk@1.28.0':
+    resolution: {integrity: sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -1081,20 +1093,16 @@ packages:
     resolution: {integrity: sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/config-resolver@4.4.11':
-    resolution: {integrity: sha512-YxFiiG4YDAtX7WMN7RuhHZLeTmRRAOyCbr+zB8e3AQzHPnUhS8zXjB1+cniPVQI3xbWsQPM0X2aaIkO/ME0ymw==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/config-resolver@4.4.13':
     resolution: {integrity: sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/core@3.23.11':
-    resolution: {integrity: sha512-952rGf7hBRnhUIaeLp6q4MptKW8sPFe5VvkoZ5qIzFAtx6c/QZ/54FS3yootsyUSf9gJX/NBqEBNdNR7jMIlpQ==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/core@3.23.12':
     resolution: {integrity: sha512-o9VycsYNtgC+Dy3I0yrwCqv9CWicDnke0L7EVOrZtJpjb2t0EjaEofmMrYc0T1Kn3yk32zm6cspxF9u9Bj7e5w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.23.13':
+    resolution: {integrity: sha512-J+2TT9D6oGsUVXVEMvz8h2EmdVnkBiy2auCie4aSJMvKlzUtO5hqjEzXhoCUkIMo7gAYjbQcN0g/MMSXEhDs1Q==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/credential-provider-imds@4.2.12':
@@ -1145,28 +1153,28 @@ packages:
     resolution: {integrity: sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-endpoint@4.4.25':
-    resolution: {integrity: sha512-dqjLwZs2eBxIUG6Qtw8/YZ4DvzHGIf0DA18wrgtfP6a50UIO7e2nY0FPdcbv5tVJKqWCCU5BmGMOUwT7Puan+A==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/middleware-endpoint@4.4.27':
     resolution: {integrity: sha512-T3TFfUgXQlpcg+UdzcAISdZpj4Z+XECZ/cefgA6wLBd6V4lRi0svN2hBouN/be9dXQ31X4sLWz3fAQDf+nt6BA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-retry@4.4.42':
-    resolution: {integrity: sha512-vbwyqHRIpIZutNXZpLAozakzamcINaRCpEy1MYmK6xBeW3xN+TyPRA123GjXnuxZIjc9848MRRCugVMTXxC4Eg==}
+  '@smithy/middleware-endpoint@4.4.28':
+    resolution: {integrity: sha512-p1gfYpi91CHcs5cBq982UlGlDrxoYUX6XdHSo91cQ2KFuz6QloHosO7Jc60pJiVmkWrKOV8kFYlGFFbQ2WUKKQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-retry@4.4.44':
     resolution: {integrity: sha512-Y1Rav7m5CFRPQyM4CI0koD/bXjyjJu3EQxZZhtLGD88WIrBrQ7kqXM96ncd6rYnojwOo/u9MXu57JrEvu/nLrA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-serde@4.2.14':
-    resolution: {integrity: sha512-+CcaLoLa5apzSRtloOyG7lQvkUw2ZDml3hRh4QiG9WyEPfW5Ke/3tPOPiPjUneuT59Tpn8+c3RVaUvvkkwqZwg==}
+  '@smithy/middleware-retry@4.4.45':
+    resolution: {integrity: sha512-td1PxpwDIaw5/oP/xIRxBGxJKoF1L4DBAwbZ8wjMuXBYOP/r2ZE/Ocou+mBHx/yk9knFEtDBwhSrYVn+Mz4pHw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-serde@4.2.15':
     resolution: {integrity: sha512-ExYhcltZSli0pgAKOpQQe1DLFBLryeZ22605y/YS+mQpdNWekum9Ujb/jMKfJKgjtz1AZldtwA/wCYuKJgjjlg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.2.16':
+    resolution: {integrity: sha512-beqfV+RZ9RSv+sQqor3xroUUYgRFCGRw6niGstPG8zO9LgTl0B0MCucxjmrH/2WwksQN7UUgI7KNANoZv+KALA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-stack@4.2.12':
@@ -1177,12 +1185,12 @@ packages:
     resolution: {integrity: sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/node-http-handler@4.4.16':
-    resolution: {integrity: sha512-ULC8UCS/HivdCB3jhi+kLFYe4B5gxH2gi9vHBfEIiRrT2jfKiZNiETJSlzRtE6B26XbBHjPtc8iZKSNqMol9bw==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/node-http-handler@4.5.0':
     resolution: {integrity: sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.5.1':
+    resolution: {integrity: sha512-ejjxdAXjkPIs9lyYyVutOGNOraqUE9v/NjGMKwwFrfOM354wfSD8lmlj8hVwUzQmlLLF4+udhfCX9Exnbmvfzw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/property-provider@4.2.12':
@@ -1213,12 +1221,12 @@ packages:
     resolution: {integrity: sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/smithy-client@4.12.5':
-    resolution: {integrity: sha512-UqwYawyqSr/aog8mnLnfbPurS0gi4G7IYDcD28cUIBhsvWs1+rQcL2IwkUQ+QZ7dibaoRzhNF99fAQ9AUcO00w==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/smithy-client@4.12.7':
     resolution: {integrity: sha512-q3gqnwml60G44FECaEEsdQMplYhDMZYCtYhMCzadCnRnnHIobZJjegmdoUo6ieLQlPUzvrMdIJUpx6DoPmzANQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.12.8':
+    resolution: {integrity: sha512-aJaAX7vHe5i66smoSSID7t4rKY08PbD8EBU7DOloixvhOozfYWdcSYE4l6/tjkZ0vBZhGjheWzB2mh31sLgCMA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.13.1':
@@ -1253,20 +1261,20 @@ packages:
     resolution: {integrity: sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-defaults-mode-browser@4.3.41':
-    resolution: {integrity: sha512-M1w1Ux0rSVvBOxIIiqbxvZvhnjQ+VUjJrugtORE90BbadSTH+jsQL279KRL3Hv0w69rE7EuYkV/4Lepz/NBW9g==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/util-defaults-mode-browser@4.3.43':
     resolution: {integrity: sha512-Qd/0wCKMaXxev/z00TvNzGCH2jlKKKxXP1aDxB6oKwSQthe3Og2dMhSayGCnsma1bK/kQX1+X7SMP99t6FgiiQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-defaults-mode-node@4.2.44':
-    resolution: {integrity: sha512-YPze3/lD1KmWuZsl9JlfhcgGLX7AXhSoaCDtiPntUjNW5/YY0lOHjkcgxyE9x/h5vvS1fzDifMGjzqnNlNiqOQ==}
+  '@smithy/util-defaults-mode-browser@4.3.44':
+    resolution: {integrity: sha512-eZg6XzaCbVr2S5cAErU5eGBDaOVTuTo1I65i4tQcHENRcZ8rMWhQy1DaIYUSLyZjsfXvmCqZrstSMYyGFocvHA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-defaults-mode-node@4.2.47':
     resolution: {integrity: sha512-qSRbYp1EQ7th+sPFuVcVO05AE0QH635hycdEXlpzIahqHHf2Fyd/Zl+8v0XYMJ3cgDVPa0lkMefU7oNUjAP+DQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-node@4.2.48':
+    resolution: {integrity: sha512-FqOKTlqSaoV3nzO55pMs5NBnZX8EhoI0DGmn9kbYeXWppgHD6dchyuj2HLqp4INJDJbSrj6OFYJkAh/WhSzZPg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-endpoints@3.3.3':
@@ -1285,12 +1293,12 @@ packages:
     resolution: {integrity: sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-stream@4.5.19':
-    resolution: {integrity: sha512-v4sa+3xTweL1CLO2UP0p7tvIMH/Rq1X4KKOxd568mpe6LSLMQCnDHs4uv7m3ukpl3HvcN2JH6jiCS0SNRXKP/w==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/util-stream@4.5.20':
     resolution: {integrity: sha512-4yXLm5n/B5SRBR2p8cZ90Sbv4zL4NKsgxdzCzp/83cXw2KxLEumt5p+GAVyRNZgQOSrzXn9ARpO0lUe8XSlSDw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.5.21':
+    resolution: {integrity: sha512-KzSg+7KKywLnkoKejRtIBXDmwBfjGvg1U1i/etkC7XSWUyFCoLno1IohV2c74IzQqdhX5y3uE44r/8/wuK+A7Q==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-uri-escape@4.2.2':
@@ -1336,6 +1344,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/events@3.0.3':
+    resolution: {integrity: sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==}
 
   '@types/jsesc@2.5.1':
     resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
@@ -1588,6 +1599,9 @@ packages:
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
+  another-json@0.2.0:
+    resolution: {integrity: sha512-/Ndrl68UQLhnCdsAzEXLMFuOR546o2qbYRqCglaNHbjXrwG1ayTcdwr3zkSGOGtGXDyR5X9nCFfnyG2AFJIsqg==}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -1639,6 +1653,9 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base-x@5.0.1:
+    resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -1671,6 +1688,9 @@ packages:
   brace-expansion@5.0.4:
     resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
     engines: {node: 18 || 20 || >=22}
+
+  bs58@6.0.0:
+    resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
 
   buffer-alloc-unsafe@1.1.0:
     resolution: {integrity: sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==}
@@ -2060,6 +2080,10 @@ packages:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
 
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
     engines: {node: '>=18.0.0'}
@@ -2106,15 +2130,8 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fast-xml-builder@1.1.3:
-    resolution: {integrity: sha512-1o60KoFw2+LWKQu3IdcfcFlGTW4dpqEWmjhYec6H82AYZU2TVBXep6tMl8Z1Y+wM+ZrzCwe3BZ9Vyd9N2rIvmg==}
-
   fast-xml-builder@1.1.4:
     resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
-
-  fast-xml-parser@5.4.1:
-    resolution: {integrity: sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==}
-    hasBin: true
 
   fast-xml-parser@5.5.8:
     resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
@@ -2147,6 +2164,10 @@ packages:
   file-type@21.3.4:
     resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
     engines: {node: '>=20'}
+
+  file-type@22.0.0:
+    resolution: {integrity: sha512-cmBmnYo8Zymabm2+qAP7jTFbKF10bQpYmxoGfuZbRFRcq00BRddJdGNH/P7GA1EMpJy5yQbqa9B7yROb3z8Ziw==}
+    engines: {node: '>=22'}
 
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
@@ -2329,8 +2350,8 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
-  hono@4.12.8:
-    resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
+  hono@4.12.9:
+    resolution: {integrity: sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==}
     engines: {node: '>=16.9.0'}
 
   hookable@6.1.0:
@@ -2424,6 +2445,10 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-network-error@1.3.1:
+    resolution: {integrity: sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==}
+    engines: {node: '>=16'}
+
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
@@ -2506,6 +2531,10 @@ packages:
 
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  jwt-decode@4.0.0:
+    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
+    engines: {node: '>=18'}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -2619,6 +2648,10 @@ packages:
   lodash.pickby@4.6.0:
     resolution: {integrity: sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==}
 
+  loglevel@1.9.2:
+    resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
+    engines: {node: '>= 0.6.0'}
+
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
@@ -2648,6 +2681,16 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  matrix-events-sdk@0.0.1:
+    resolution: {integrity: sha512-1QEOsXO+bhyCroIe2/A5OwaxHvBm7EsSQ46DEDn8RBIfQwN5HWBpFvyWWR4QY0KHPPnnJdI99wgRiAl7Ad5qaA==}
+
+  matrix-js-sdk@41.2.0:
+    resolution: {integrity: sha512-kVLDKm/bUlwlHoDKRemshs27LCnOnNpmsVKtbCOM5F5D/E1SkrKldou+vQ/lk4PyXTvu9/qglkd2m0pBwJ5opg==}
+    engines: {node: '>=22.0.0'}
+
+  matrix-widget-api@1.17.0:
+    resolution: {integrity: sha512-5FHoo3iEP3Bdlv5jsYPWOqj+pGdFQNLWnJLiB0V7Ygne7bb+Gsj3ibyFyHWC6BVw+Z+tSW4ljHpO17I9TwStwQ==}
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
@@ -2734,6 +2777,11 @@ packages:
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
 
+  node-downloader-helper@2.1.11:
+    resolution: {integrity: sha512-882fH2C9AWdiPCwz/2beq5t8FGMZK9Dx8TJUOIxzMCbvG7XUKM5BuJwN5f0NKo4SCQK6jR4p2TPm54mYGdGchQ==}
+    engines: {node: '>=14.18'}
+    hasBin: true
+
   node-edge-tts@1.2.10:
     resolution: {integrity: sha512-bV2i4XU54D45+US0Zm1HcJRkifuB3W438dWyuJEHLQdKxnuqlI1kim2MOvR6Q3XUQZvfF9PoDyR1Rt7aeXhPdQ==}
     hasBin: true
@@ -2772,6 +2820,10 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  oidc-client-ts@3.5.0:
+    resolution: {integrity: sha512-l2q8l9CTCTOlbX+AnK4p3M+4CEpKpyQhle6blQkdFhm0IsBqsxm15bYaSa11G7pWdsYr6epdsRZxJpCyCRbT8A==}
+    engines: {node: '>=18'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -2791,13 +2843,13 @@ packages:
       zod:
         optional: true
 
-  openclaw@2026.3.23:
-    resolution: {integrity: sha512-CSenO9Q+WePEzhzr3vIgx70GLanQVLcwgtItxT7gy1XtE7uiAVLBTqOxn2nc6BGGX3R3u9RqOpUh/vyAPvameA==}
-    engines: {node: '>=22.16.0'}
+  openclaw@2026.3.28:
+    resolution: {integrity: sha512-n7ZS3zdimB2H/GfnylyG8xWXVrmlsSPHZdNEIEPe54Sl5XYuYD5yxilGYV0DWowgtsM5ysFEQMMMArdC/O77Jw==}
+    engines: {node: '>=22.14.0'}
     hasBin: true
     peerDependencies:
       '@napi-rs/canvas': ^0.1.89
-      node-llama-cpp: 3.16.2
+      node-llama-cpp: 3.18.1
     peerDependenciesMeta:
       node-llama-cpp:
         optional: true
@@ -2826,6 +2878,10 @@ packages:
   p-retry@4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
     engines: {node: '>=8'}
+
+  p-retry@7.1.1:
+    resolution: {integrity: sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==}
+    engines: {node: '>=20'}
 
   p-timeout@4.1.0:
     resolution: {integrity: sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==}
@@ -2872,10 +2928,6 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
-
-  path-expression-matcher@1.1.3:
-    resolution: {integrity: sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==}
-    engines: {node: '>=14.0.0'}
 
   path-expression-matcher@1.2.0:
     resolution: {integrity: sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==}
@@ -3077,6 +3129,10 @@ packages:
     resolution: {integrity: sha512-jLYV0DORrzY3xaz/S9ydJL6Iz7essZeAfnAavsJ+zsJGZ1MOnsS52yRjU3uF3pJa/lla7+wisp//fxOwOH8SKQ==}
     engines: {node: '>= 0.10'}
 
+  sdp-transform@3.0.0:
+    resolution: {integrity: sha512-gfYVRGxjHkGF2NPeUWHw5u6T/KGFtS5/drPms73gaSuMaVHKCY3lpLnGDfswVQO0kddeePoti09AwhYP4zA8dQ==}
+    hasBin: true
+
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
@@ -3239,6 +3295,10 @@ packages:
     resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
     engines: {node: '>=18'}
 
+  strtok3@10.3.5:
+    resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
+    engines: {node: '>=18'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -3247,8 +3307,8 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
-  tar@7.5.12:
-    resolution: {integrity: sha512-9TsuLcdhOn4XztcQqhNyq1KOwOOED/3k58JAvtULiYqbO8B/0IBAAIE1hj0Svmm58k27TmcigyDI0deMlgG3uw==}
+  tar@7.5.13:
+    resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
     engines: {node: '>=18'}
 
   telegraf@4.16.3:
@@ -3381,9 +3441,12 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@7.24.5:
-    resolution: {integrity: sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==}
+  undici@7.24.6:
+    resolution: {integrity: sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==}
     engines: {node: '>=20.18.1'}
+
+  unhomoglyph@1.0.6:
+    resolution: {integrity: sha512-7uvcWI3hWshSADBu4JpnyYbTVc7YlhF5GDW/oPD5AxIxl34k4wXR3WDkPnzLxkN32LiTCTKMQLtKVZiwki3zGg==}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -3603,7 +3666,7 @@ packages:
 
 snapshots:
 
-  '@agentclientprotocol/sdk@0.16.1(zod@4.3.6)':
+  '@agentclientprotocol/sdk@0.17.0(zod@4.3.6)':
     dependencies:
       zod: 4.3.6
 
@@ -3658,72 +3721,26 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/credential-provider-node': 3.972.21
+      '@aws-sdk/core': 3.973.24
+      '@aws-sdk/credential-provider-node': 3.972.25
       '@aws-sdk/eventstream-handler-node': 3.972.11
       '@aws-sdk/middleware-eventstream': 3.972.8
       '@aws-sdk/middleware-host-header': 3.972.8
       '@aws-sdk/middleware-logger': 3.972.8
       '@aws-sdk/middleware-recursion-detection': 3.972.8
-      '@aws-sdk/middleware-user-agent': 3.972.21
-      '@aws-sdk/middleware-websocket': 3.972.13
-      '@aws-sdk/region-config-resolver': 3.972.8
-      '@aws-sdk/token-providers': 3.1009.0
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/util-endpoints': 3.996.5
-      '@aws-sdk/util-user-agent-browser': 3.972.8
-      '@aws-sdk/util-user-agent-node': 3.973.7
-      '@smithy/config-resolver': 4.4.11
-      '@smithy/core': 3.23.11
-      '@smithy/eventstream-serde-browser': 4.2.12
-      '@smithy/eventstream-serde-config-resolver': 4.3.12
-      '@smithy/eventstream-serde-node': 4.2.12
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/hash-node': 4.2.12
-      '@smithy/invalid-dependency': 4.2.12
-      '@smithy/middleware-content-length': 4.2.12
-      '@smithy/middleware-endpoint': 4.4.25
-      '@smithy/middleware-retry': 4.4.42
-      '@smithy/middleware-serde': 4.2.14
-      '@smithy/middleware-stack': 4.2.12
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/node-http-handler': 4.4.16
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/smithy-client': 4.12.5
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.41
-      '@smithy/util-defaults-mode-node': 4.2.44
-      '@smithy/util-endpoints': 3.3.3
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-retry': 4.2.12
-      '@smithy/util-stream': 4.5.19
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/client-bedrock@3.1016.0':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.24
-      '@aws-sdk/credential-provider-node': 3.972.25
-      '@aws-sdk/middleware-host-header': 3.972.8
-      '@aws-sdk/middleware-logger': 3.972.8
-      '@aws-sdk/middleware-recursion-detection': 3.972.8
       '@aws-sdk/middleware-user-agent': 3.972.25
+      '@aws-sdk/middleware-websocket': 3.972.13
       '@aws-sdk/region-config-resolver': 3.972.9
-      '@aws-sdk/token-providers': 3.1016.0
+      '@aws-sdk/token-providers': 3.1009.0
       '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.5
       '@aws-sdk/util-user-agent-browser': 3.972.8
       '@aws-sdk/util-user-agent-node': 3.973.11
       '@smithy/config-resolver': 4.4.13
       '@smithy/core': 3.23.12
+      '@smithy/eventstream-serde-browser': 4.2.12
+      '@smithy/eventstream-serde-config-resolver': 4.3.12
+      '@smithy/eventstream-serde-node': 4.2.12
       '@smithy/fetch-http-handler': 5.3.15
       '@smithy/hash-node': 4.2.12
       '@smithy/invalid-dependency': 4.2.12
@@ -3746,26 +3763,56 @@ snapshots:
       '@smithy/util-endpoints': 3.3.3
       '@smithy/util-middleware': 4.2.12
       '@smithy/util-retry': 4.2.12
+      '@smithy/util-stream': 4.5.20
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/core@3.973.20':
+  '@aws-sdk/client-bedrock@3.1020.0':
     dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/credential-provider-node': 3.972.28
+      '@aws-sdk/middleware-host-header': 3.972.8
+      '@aws-sdk/middleware-logger': 3.972.8
+      '@aws-sdk/middleware-recursion-detection': 3.972.9
+      '@aws-sdk/middleware-user-agent': 3.972.27
+      '@aws-sdk/region-config-resolver': 3.972.10
+      '@aws-sdk/token-providers': 3.1020.0
       '@aws-sdk/types': 3.973.6
-      '@aws-sdk/xml-builder': 3.972.11
-      '@smithy/core': 3.23.11
+      '@aws-sdk/util-endpoints': 3.996.5
+      '@aws-sdk/util-user-agent-browser': 3.972.8
+      '@aws-sdk/util-user-agent-node': 3.973.13
+      '@smithy/config-resolver': 4.4.13
+      '@smithy/core': 3.23.13
+      '@smithy/fetch-http-handler': 5.3.15
+      '@smithy/hash-node': 4.2.12
+      '@smithy/invalid-dependency': 4.2.12
+      '@smithy/middleware-content-length': 4.2.12
+      '@smithy/middleware-endpoint': 4.4.28
+      '@smithy/middleware-retry': 4.4.45
+      '@smithy/middleware-serde': 4.2.16
+      '@smithy/middleware-stack': 4.2.12
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/property-provider': 4.2.12
+      '@smithy/node-http-handler': 4.5.1
       '@smithy/protocol-http': 5.3.12
-      '@smithy/signature-v4': 5.3.12
-      '@smithy/smithy-client': 4.12.5
+      '@smithy/smithy-client': 4.12.8
       '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
       '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.44
+      '@smithy/util-defaults-mode-node': 4.2.48
+      '@smithy/util-endpoints': 3.3.3
       '@smithy/util-middleware': 4.2.12
+      '@smithy/util-retry': 4.2.12
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
 
   '@aws-sdk/core@3.973.24':
     dependencies:
@@ -3783,12 +3830,20 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-env@3.972.18':
+  '@aws-sdk/core@3.973.26':
     dependencies:
-      '@aws-sdk/core': 3.973.20
       '@aws-sdk/types': 3.973.6
+      '@aws-sdk/xml-builder': 3.972.16
+      '@smithy/core': 3.23.13
+      '@smithy/node-config-provider': 4.3.12
       '@smithy/property-provider': 4.2.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/signature-v4': 5.3.12
+      '@smithy/smithy-client': 4.12.8
       '@smithy/types': 4.13.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.22':
@@ -3799,17 +3854,12 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-http@3.972.20':
+  '@aws-sdk/credential-provider-env@3.972.24':
     dependencies:
-      '@aws-sdk/core': 3.973.20
+      '@aws-sdk/core': 3.973.26
       '@aws-sdk/types': 3.973.6
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/node-http-handler': 4.4.16
       '@smithy/property-provider': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/smithy-client': 4.12.5
       '@smithy/types': 4.13.1
-      '@smithy/util-stream': 4.5.19
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.24':
@@ -3825,24 +3875,18 @@ snapshots:
       '@smithy/util-stream': 4.5.20
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-ini@3.972.20':
+  '@aws-sdk/credential-provider-http@3.972.26':
     dependencies:
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/credential-provider-env': 3.972.18
-      '@aws-sdk/credential-provider-http': 3.972.20
-      '@aws-sdk/credential-provider-login': 3.972.20
-      '@aws-sdk/credential-provider-process': 3.972.18
-      '@aws-sdk/credential-provider-sso': 3.972.20
-      '@aws-sdk/credential-provider-web-identity': 3.972.20
-      '@aws-sdk/nested-clients': 3.996.10
+      '@aws-sdk/core': 3.973.26
       '@aws-sdk/types': 3.973.6
-      '@smithy/credential-provider-imds': 4.2.12
+      '@smithy/fetch-http-handler': 5.3.15
+      '@smithy/node-http-handler': 4.5.1
       '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/smithy-client': 4.12.8
       '@smithy/types': 4.13.1
+      '@smithy/util-stream': 4.5.21
       tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
 
   '@aws-sdk/credential-provider-ini@3.972.24':
     dependencies:
@@ -3863,13 +3907,19 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-login@3.972.20':
+  '@aws-sdk/credential-provider-ini@3.972.27':
     dependencies:
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/nested-clients': 3.996.10
+      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/credential-provider-env': 3.972.24
+      '@aws-sdk/credential-provider-http': 3.972.26
+      '@aws-sdk/credential-provider-login': 3.972.27
+      '@aws-sdk/credential-provider-process': 3.972.24
+      '@aws-sdk/credential-provider-sso': 3.972.27
+      '@aws-sdk/credential-provider-web-identity': 3.972.27
+      '@aws-sdk/nested-clients': 3.996.17
       '@aws-sdk/types': 3.973.6
+      '@smithy/credential-provider-imds': 4.2.12
       '@smithy/property-provider': 4.2.12
-      '@smithy/protocol-http': 5.3.12
       '@smithy/shared-ini-file-loader': 4.4.7
       '@smithy/types': 4.13.1
       tslib: 2.8.1
@@ -3889,17 +3939,13 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-node@3.972.21':
+  '@aws-sdk/credential-provider-login@3.972.27':
     dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.18
-      '@aws-sdk/credential-provider-http': 3.972.20
-      '@aws-sdk/credential-provider-ini': 3.972.20
-      '@aws-sdk/credential-provider-process': 3.972.18
-      '@aws-sdk/credential-provider-sso': 3.972.20
-      '@aws-sdk/credential-provider-web-identity': 3.972.20
+      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/nested-clients': 3.996.17
       '@aws-sdk/types': 3.973.6
-      '@smithy/credential-provider-imds': 4.2.12
       '@smithy/property-provider': 4.2.12
+      '@smithy/protocol-http': 5.3.12
       '@smithy/shared-ini-file-loader': 4.4.7
       '@smithy/types': 4.13.1
       tslib: 2.8.1
@@ -3923,14 +3969,22 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-process@3.972.18':
+  '@aws-sdk/credential-provider-node@3.972.28':
     dependencies:
-      '@aws-sdk/core': 3.973.20
+      '@aws-sdk/credential-provider-env': 3.972.24
+      '@aws-sdk/credential-provider-http': 3.972.26
+      '@aws-sdk/credential-provider-ini': 3.972.27
+      '@aws-sdk/credential-provider-process': 3.972.24
+      '@aws-sdk/credential-provider-sso': 3.972.27
+      '@aws-sdk/credential-provider-web-identity': 3.972.27
       '@aws-sdk/types': 3.973.6
+      '@smithy/credential-provider-imds': 4.2.12
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
       '@smithy/types': 4.13.1
       tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
 
   '@aws-sdk/credential-provider-process@3.972.22':
     dependencies:
@@ -3941,18 +3995,14 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-sso@3.972.20':
+  '@aws-sdk/credential-provider-process@3.972.24':
     dependencies:
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/nested-clients': 3.996.10
-      '@aws-sdk/token-providers': 3.1009.0
+      '@aws-sdk/core': 3.973.26
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
       '@smithy/types': 4.13.1
       tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
 
   '@aws-sdk/credential-provider-sso@3.972.24':
     dependencies:
@@ -3967,10 +4017,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-web-identity@3.972.20':
+  '@aws-sdk/credential-provider-sso@3.972.27':
     dependencies:
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/nested-clients': 3.996.10
+      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/nested-clients': 3.996.17
+      '@aws-sdk/token-providers': 3.1020.0
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
@@ -3983,6 +4034,18 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.973.24
       '@aws-sdk/nested-clients': 3.996.14
+      '@aws-sdk/types': 3.973.6
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.27':
+    dependencies:
+      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/nested-clients': 3.996.17
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
@@ -4026,15 +4089,12 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-user-agent@3.972.21':
+  '@aws-sdk/middleware-recursion-detection@3.972.9':
     dependencies:
-      '@aws-sdk/core': 3.973.20
       '@aws-sdk/types': 3.973.6
-      '@aws-sdk/util-endpoints': 3.996.5
-      '@smithy/core': 3.23.11
+      '@aws/lambda-invoke-store': 0.2.4
       '@smithy/protocol-http': 5.3.12
       '@smithy/types': 4.13.1
-      '@smithy/util-retry': 4.2.12
       tslib: 2.8.1
 
   '@aws-sdk/middleware-user-agent@3.972.25':
@@ -4043,6 +4103,17 @@ snapshots:
       '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.5
       '@smithy/core': 3.23.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-retry': 4.2.12
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.972.27':
+    dependencies:
+      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/util-endpoints': 3.996.5
+      '@smithy/core': 3.23.13
       '@smithy/protocol-http': 5.3.12
       '@smithy/types': 4.13.1
       '@smithy/util-retry': 4.2.12
@@ -4062,49 +4133,6 @@ snapshots:
       '@smithy/util-hex-encoding': 4.2.2
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
-
-  '@aws-sdk/nested-clients@3.996.10':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/middleware-host-header': 3.972.8
-      '@aws-sdk/middleware-logger': 3.972.8
-      '@aws-sdk/middleware-recursion-detection': 3.972.8
-      '@aws-sdk/middleware-user-agent': 3.972.21
-      '@aws-sdk/region-config-resolver': 3.972.8
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/util-endpoints': 3.996.5
-      '@aws-sdk/util-user-agent-browser': 3.972.8
-      '@aws-sdk/util-user-agent-node': 3.973.7
-      '@smithy/config-resolver': 4.4.11
-      '@smithy/core': 3.23.11
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/hash-node': 4.2.12
-      '@smithy/invalid-dependency': 4.2.12
-      '@smithy/middleware-content-length': 4.2.12
-      '@smithy/middleware-endpoint': 4.4.25
-      '@smithy/middleware-retry': 4.4.42
-      '@smithy/middleware-serde': 4.2.14
-      '@smithy/middleware-stack': 4.2.12
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/node-http-handler': 4.4.16
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/smithy-client': 4.12.5
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.41
-      '@smithy/util-defaults-mode-node': 4.2.44
-      '@smithy/util-endpoints': 3.3.3
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-retry': 4.2.12
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
 
   '@aws-sdk/nested-clients@3.996.14':
     dependencies:
@@ -4149,10 +4177,53 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/region-config-resolver@3.972.8':
+  '@aws-sdk/nested-clients@3.996.17':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/middleware-host-header': 3.972.8
+      '@aws-sdk/middleware-logger': 3.972.8
+      '@aws-sdk/middleware-recursion-detection': 3.972.9
+      '@aws-sdk/middleware-user-agent': 3.972.27
+      '@aws-sdk/region-config-resolver': 3.972.10
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/util-endpoints': 3.996.5
+      '@aws-sdk/util-user-agent-browser': 3.972.8
+      '@aws-sdk/util-user-agent-node': 3.973.13
+      '@smithy/config-resolver': 4.4.13
+      '@smithy/core': 3.23.13
+      '@smithy/fetch-http-handler': 5.3.15
+      '@smithy/hash-node': 4.2.12
+      '@smithy/invalid-dependency': 4.2.12
+      '@smithy/middleware-content-length': 4.2.12
+      '@smithy/middleware-endpoint': 4.4.28
+      '@smithy/middleware-retry': 4.4.45
+      '@smithy/middleware-serde': 4.2.16
+      '@smithy/middleware-stack': 4.2.12
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/node-http-handler': 4.5.1
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/smithy-client': 4.12.8
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.44
+      '@smithy/util-defaults-mode-node': 4.2.48
+      '@smithy/util-endpoints': 3.3.3
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-retry': 4.2.12
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/region-config-resolver@3.972.10':
     dependencies:
       '@aws-sdk/types': 3.973.6
-      '@smithy/config-resolver': 4.4.11
+      '@smithy/config-resolver': 4.4.13
       '@smithy/node-config-provider': 4.3.12
       '@smithy/types': 4.13.1
       tslib: 2.8.1
@@ -4167,8 +4238,8 @@ snapshots:
 
   '@aws-sdk/token-providers@3.1009.0':
     dependencies:
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/nested-clients': 3.996.10
+      '@aws-sdk/core': 3.973.24
+      '@aws-sdk/nested-clients': 3.996.14
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
@@ -4189,10 +4260,10 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/token-providers@3.1016.0':
+  '@aws-sdk/token-providers@3.1020.0':
     dependencies:
-      '@aws-sdk/core': 3.973.24
-      '@aws-sdk/nested-clients': 3.996.14
+      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/nested-clients': 3.996.17
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
@@ -4241,22 +4312,22 @@ snapshots:
       '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/util-user-agent-node@3.973.7':
+  '@aws-sdk/util-user-agent-node@3.973.13':
     dependencies:
-      '@aws-sdk/middleware-user-agent': 3.972.21
+      '@aws-sdk/middleware-user-agent': 3.972.27
       '@aws-sdk/types': 3.973.6
       '@smithy/node-config-provider': 4.3.12
       '@smithy/types': 4.13.1
       '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/xml-builder@3.972.11':
+  '@aws-sdk/xml-builder@3.972.15':
     dependencies:
       '@smithy/types': 4.13.1
-      fast-xml-parser: 5.4.1
+      fast-xml-parser: 5.5.8
       tslib: 2.8.1
 
-  '@aws-sdk/xml-builder@3.972.15':
+  '@aws-sdk/xml-builder@3.972.16':
     dependencies:
       '@smithy/types': 4.13.1
       fast-xml-parser: 5.5.8
@@ -4365,14 +4436,14 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@google/genai@1.45.0(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))':
+  '@google/genai@1.45.0(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))':
     dependencies:
       google-auth-library: 10.6.1
       p-retry: 4.6.2
       protobufjs: 7.5.4
       ws: 8.20.0
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.28.0(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -4387,9 +4458,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@hono/node-server@1.19.9(hono@4.12.8)':
+  '@hono/node-server@1.19.9(hono@4.12.9)':
     dependencies:
-      hono: 4.12.8
+      hono: 4.12.9
 
   '@humanfs/core@0.19.1': {}
 
@@ -4623,9 +4694,9 @@ snapshots:
       std-env: 3.10.0
       yoctocolors: 2.1.2
 
-  '@mariozechner/pi-agent-core@0.61.1(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
+  '@mariozechner/pi-agent-core@0.63.1(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.61.1(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.63.1(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -4635,11 +4706,11 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.61.1(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
+  '@mariozechner/pi-ai@0.63.1(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.1009.0
-      '@google/genai': 1.45.0(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))
+      '@google/genai': 1.45.0(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))
       '@mistralai/mistralai': 1.14.1
       '@sinclair/typebox': 0.34.48
       ajv: 8.18.0
@@ -4648,7 +4719,7 @@ snapshots:
       openai: 6.26.0(ws@8.20.0)(zod@4.3.6)
       partial-json: 0.1.7
       proxy-agent: 6.5.0
-      undici: 7.24.5
+      undici: 7.24.6
       zod-to-json-schema: 3.25.1(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -4659,13 +4730,14 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-coding-agent@0.61.1(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
+  '@mariozechner/pi-coding-agent@0.63.1(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.61.1(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.61.1(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
-      '@mariozechner/pi-tui': 0.61.1
+      '@mariozechner/pi-agent-core': 0.63.1(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.63.1(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.63.1
       '@silvia-odwyer/photon-node': 0.3.4
+      ajv: 8.18.0
       chalk: 5.6.2
       cli-highlight: 2.1.11
       diff: 8.0.3
@@ -4678,7 +4750,7 @@ snapshots:
       minimatch: 10.2.4
       proper-lockfile: 4.1.2
       strip-ansi: 7.2.0
-      undici: 7.24.5
+      undici: 7.24.6
       yaml: 2.8.3
     optionalDependencies:
       '@mariozechner/clipboard': 0.3.2
@@ -4691,7 +4763,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-tui@0.61.1':
+  '@mariozechner/pi-tui@0.63.1':
     dependencies:
       '@types/mime-types': 2.1.4
       chalk: 5.6.2
@@ -4700,6 +4772,16 @@ snapshots:
       mime-types: 3.0.2
     optionalDependencies:
       koffi: 2.15.2
+
+  '@matrix-org/matrix-sdk-crypto-nodejs@0.4.0':
+    dependencies:
+      https-proxy-agent: 7.0.6
+      node-downloader-helper: 2.1.11
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  '@matrix-org/matrix-sdk-crypto-wasm@18.0.0': {}
 
   '@mistralai/mistralai@1.14.1':
     dependencies:
@@ -4710,9 +4792,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.28.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.9(hono@4.12.8)
+      '@hono/node-server': 1.19.9(hono@4.12.9)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -4722,7 +4804,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.1(express@5.2.1)
-      hono: 4.12.8
+      hono: 4.12.9
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -4942,15 +5024,6 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/config-resolver@4.4.11':
-    dependencies:
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-config-provider': 4.2.2
-      '@smithy/util-endpoints': 3.3.3
-      '@smithy/util-middleware': 4.2.12
-      tslib: 2.8.1
-
   '@smithy/config-resolver@4.4.13':
     dependencies:
       '@smithy/node-config-provider': 4.3.12
@@ -4958,19 +5031,6 @@ snapshots:
       '@smithy/util-config-provider': 4.2.2
       '@smithy/util-endpoints': 3.3.3
       '@smithy/util-middleware': 4.2.12
-      tslib: 2.8.1
-
-  '@smithy/core@3.23.11':
-    dependencies:
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-stream': 4.5.19
-      '@smithy/util-utf8': 4.2.2
-      '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
   '@smithy/core@3.23.12':
@@ -4982,6 +5042,19 @@ snapshots:
       '@smithy/util-body-length-browser': 4.2.2
       '@smithy/util-middleware': 4.2.12
       '@smithy/util-stream': 4.5.20
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/core@3.23.13':
+    dependencies:
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-stream': 4.5.21
       '@smithy/util-utf8': 4.2.2
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
@@ -5058,17 +5131,6 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/middleware-endpoint@4.4.25':
-    dependencies:
-      '@smithy/core': 3.23.11
-      '@smithy/middleware-serde': 4.2.14
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-middleware': 4.2.12
-      tslib: 2.8.1
-
   '@smithy/middleware-endpoint@4.4.27':
     dependencies:
       '@smithy/core': 3.23.12
@@ -5080,16 +5142,15 @@ snapshots:
       '@smithy/util-middleware': 4.2.12
       tslib: 2.8.1
 
-  '@smithy/middleware-retry@4.4.42':
+  '@smithy/middleware-endpoint@4.4.28':
     dependencies:
+      '@smithy/core': 3.23.13
+      '@smithy/middleware-serde': 4.2.16
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/service-error-classification': 4.2.12
-      '@smithy/smithy-client': 4.12.5
+      '@smithy/shared-ini-file-loader': 4.4.7
       '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
       '@smithy/util-middleware': 4.2.12
-      '@smithy/util-retry': 4.2.12
-      '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
   '@smithy/middleware-retry@4.4.44':
@@ -5104,16 +5165,28 @@ snapshots:
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
-  '@smithy/middleware-serde@4.2.14':
+  '@smithy/middleware-retry@4.4.45':
     dependencies:
-      '@smithy/core': 3.23.11
+      '@smithy/node-config-provider': 4.3.12
       '@smithy/protocol-http': 5.3.12
+      '@smithy/service-error-classification': 4.2.12
+      '@smithy/smithy-client': 4.12.8
       '@smithy/types': 4.13.1
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-retry': 4.2.12
+      '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
   '@smithy/middleware-serde@4.2.15':
     dependencies:
       '@smithy/core': 3.23.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-serde@4.2.16':
+    dependencies:
+      '@smithy/core': 3.23.13
       '@smithy/protocol-http': 5.3.12
       '@smithy/types': 4.13.1
       tslib: 2.8.1
@@ -5130,7 +5203,7 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/node-http-handler@4.4.16':
+  '@smithy/node-http-handler@4.5.0':
     dependencies:
       '@smithy/abort-controller': 4.2.12
       '@smithy/protocol-http': 5.3.12
@@ -5138,9 +5211,8 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/node-http-handler@4.5.0':
+  '@smithy/node-http-handler@4.5.1':
     dependencies:
-      '@smithy/abort-controller': 4.2.12
       '@smithy/protocol-http': 5.3.12
       '@smithy/querystring-builder': 4.2.12
       '@smithy/types': 4.13.1
@@ -5187,16 +5259,6 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/smithy-client@4.12.5':
-    dependencies:
-      '@smithy/core': 3.23.11
-      '@smithy/middleware-endpoint': 4.4.25
-      '@smithy/middleware-stack': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-stream': 4.5.19
-      tslib: 2.8.1
-
   '@smithy/smithy-client@4.12.7':
     dependencies:
       '@smithy/core': 3.23.12
@@ -5205,6 +5267,16 @@ snapshots:
       '@smithy/protocol-http': 5.3.12
       '@smithy/types': 4.13.1
       '@smithy/util-stream': 4.5.20
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.12.8':
+    dependencies:
+      '@smithy/core': 3.23.13
+      '@smithy/middleware-endpoint': 4.4.28
+      '@smithy/middleware-stack': 4.2.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-stream': 4.5.21
       tslib: 2.8.1
 
   '@smithy/types@4.13.1':
@@ -5245,13 +5317,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/util-defaults-mode-browser@4.3.41':
-    dependencies:
-      '@smithy/property-provider': 4.2.12
-      '@smithy/smithy-client': 4.12.5
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@smithy/util-defaults-mode-browser@4.3.43':
     dependencies:
       '@smithy/property-provider': 4.2.12
@@ -5259,13 +5324,10 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/util-defaults-mode-node@4.2.44':
+  '@smithy/util-defaults-mode-browser@4.3.44':
     dependencies:
-      '@smithy/config-resolver': 4.4.11
-      '@smithy/credential-provider-imds': 4.2.12
-      '@smithy/node-config-provider': 4.3.12
       '@smithy/property-provider': 4.2.12
-      '@smithy/smithy-client': 4.12.5
+      '@smithy/smithy-client': 4.12.8
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
@@ -5276,6 +5338,16 @@ snapshots:
       '@smithy/node-config-provider': 4.3.12
       '@smithy/property-provider': 4.2.12
       '@smithy/smithy-client': 4.12.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-node@4.2.48':
+    dependencies:
+      '@smithy/config-resolver': 4.4.13
+      '@smithy/credential-provider-imds': 4.2.12
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/property-provider': 4.2.12
+      '@smithy/smithy-client': 4.12.8
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
@@ -5300,10 +5372,10 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/util-stream@4.5.19':
+  '@smithy/util-stream@4.5.20':
     dependencies:
       '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/node-http-handler': 4.4.16
+      '@smithy/node-http-handler': 4.5.0
       '@smithy/types': 4.13.1
       '@smithy/util-base64': 4.3.2
       '@smithy/util-buffer-from': 4.2.2
@@ -5311,10 +5383,10 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/util-stream@4.5.20':
+  '@smithy/util-stream@4.5.21':
     dependencies:
       '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/node-http-handler': 4.5.0
+      '@smithy/node-http-handler': 4.5.1
       '@smithy/types': 4.13.1
       '@smithy/util-base64': 4.3.2
       '@smithy/util-buffer-from': 4.2.2
@@ -5369,6 +5441,8 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/events@3.0.3': {}
 
   '@types/jsesc@2.5.1': {}
 
@@ -5622,6 +5696,8 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  another-json@0.2.0: {}
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
@@ -5664,6 +5740,8 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base-x@5.0.1: {}
+
   base64-js@1.5.1: {}
 
   basic-ftp@5.2.0: {}
@@ -5702,6 +5780,10 @@ snapshots:
   brace-expansion@5.0.4:
     dependencies:
       balanced-match: 4.0.4
+
+  bs58@6.0.0:
+    dependencies:
+      base-x: 5.0.1
 
   buffer-alloc-unsafe@1.1.0:
     optional: true
@@ -6076,6 +6158,8 @@ snapshots:
   event-target-shim@5.0.1:
     optional: true
 
+  events@3.3.0: {}
+
   eventsource-parser@3.0.6: {}
 
   eventsource@3.0.7:
@@ -6157,18 +6241,9 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fast-xml-builder@1.1.3:
-    dependencies:
-      path-expression-matcher: 1.1.3
-
   fast-xml-builder@1.1.4:
     dependencies:
       path-expression-matcher: 1.2.0
-
-  fast-xml-parser@5.4.1:
-    dependencies:
-      fast-xml-builder: 1.1.3
-      strnum: 2.2.0
 
   fast-xml-parser@5.5.8:
     dependencies:
@@ -6201,6 +6276,15 @@ snapshots:
     dependencies:
       '@tokenizer/inflate': 0.4.1
       strtok3: 10.3.4
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  file-type@22.0.0:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.5
       token-types: 6.1.2
       uint8array-extras: 1.5.0
     transitivePeerDependencies:
@@ -6431,7 +6515,7 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
-  hono@4.12.8: {}
+  hono@4.12.9: {}
 
   hookable@6.1.0: {}
 
@@ -6511,6 +6595,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-network-error@1.3.1: {}
+
   is-plain-obj@4.1.0: {}
 
   is-promise@4.0.0: {}
@@ -6585,6 +6671,8 @@ snapshots:
     dependencies:
       jwa: 2.0.1
       safe-buffer: 5.2.1
+
+  jwt-decode@4.0.0: {}
 
   keyv@4.5.4:
     dependencies:
@@ -6673,6 +6761,8 @@ snapshots:
 
   lodash.pickby@4.6.0: {}
 
+  loglevel@1.9.2: {}
+
   long@5.3.2: {}
 
   lru-cache@10.4.3: {}
@@ -6697,6 +6787,30 @@ snapshots:
   marked@15.0.12: {}
 
   math-intrinsics@1.1.0: {}
+
+  matrix-events-sdk@0.0.1: {}
+
+  matrix-js-sdk@41.2.0:
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@matrix-org/matrix-sdk-crypto-wasm': 18.0.0
+      another-json: 0.2.0
+      bs58: 6.0.0
+      content-type: 1.0.5
+      jwt-decode: 4.0.0
+      loglevel: 1.9.2
+      matrix-events-sdk: 0.0.1
+      matrix-widget-api: 1.17.0
+      oidc-client-ts: 3.5.0
+      p-retry: 7.1.1
+      sdp-transform: 3.0.0
+      unhomoglyph: 1.0.6
+      uuid: 13.0.0
+
+  matrix-widget-api@1.17.0:
+    dependencies:
+      '@types/events': 3.0.3
+      events: 3.3.0
 
   mdurl@2.0.0: {}
 
@@ -6759,6 +6873,9 @@ snapshots:
 
   node-domexception@1.0.0: {}
 
+  node-downloader-helper@2.1.11:
+    optional: true
+
   node-edge-tts@1.2.10:
     dependencies:
       https-proxy-agent: 7.0.6
@@ -6797,6 +6914,10 @@ snapshots:
 
   obug@2.1.1: {}
 
+  oidc-client-ts@3.5.0:
+    dependencies:
+      jwt-decode: 4.0.0
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -6810,20 +6931,20 @@ snapshots:
       ws: 8.20.0
       zod: 4.3.6
 
-  openclaw@2026.3.23(@napi-rs/canvas@0.1.96):
+  openclaw@2026.3.28(@napi-rs/canvas@0.1.96):
     dependencies:
-      '@agentclientprotocol/sdk': 0.16.1(zod@4.3.6)
+      '@agentclientprotocol/sdk': 0.17.0(zod@4.3.6)
       '@anthropic-ai/vertex-sdk': 0.14.4(zod@4.3.6)
-      '@aws-sdk/client-bedrock': 3.1016.0
+      '@aws-sdk/client-bedrock': 3.1020.0
       '@clack/prompts': 1.1.0
       '@homebridge/ciao': 1.3.5
       '@line/bot-sdk': 10.6.0
       '@lydell/node-pty': 1.2.0-beta.3
-      '@mariozechner/pi-agent-core': 0.61.1(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.61.1(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
-      '@mariozechner/pi-coding-agent': 0.61.1(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
-      '@mariozechner/pi-tui': 0.61.1
-      '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
+      '@mariozechner/pi-agent-core': 0.63.1(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.63.1(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-coding-agent': 0.63.1(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.63.1
+      '@modelcontextprotocol/sdk': 1.28.0(zod@4.3.6)
       '@mozilla/readability': 0.6.0
       '@napi-rs/canvas': 0.1.96
       '@sinclair/typebox': 0.34.48
@@ -6835,9 +6956,9 @@ snapshots:
       croner: 10.0.1
       dotenv: 17.3.1
       express: 5.2.1
-      file-type: 21.3.4
+      file-type: 22.0.0
       gaxios: 7.1.4
-      hono: 4.12.8
+      hono: 4.12.9
       ipaddr.js: 2.3.0
       jiti: 2.6.1
       json5: 2.2.3
@@ -6845,6 +6966,7 @@ snapshots:
       linkedom: 0.18.12
       long: 5.3.2
       markdown-it: 14.1.1
+      matrix-js-sdk: 41.2.0
       node-edge-tts: 1.2.10
       osc-progress: 0.3.0
       pdfjs-dist: 5.5.207
@@ -6852,14 +6974,15 @@ snapshots:
       qrcode-terminal: 0.12.0
       sharp: 0.34.5
       sqlite-vec: 0.1.7
-      tar: 7.5.12
+      tar: 7.5.13
       tslog: 4.10.2
-      undici: 7.24.5
+      undici: 7.24.6
       uuid: 13.0.0
       ws: 8.20.0
       yaml: 2.8.3
       zod: 4.3.6
     optionalDependencies:
+      '@matrix-org/matrix-sdk-crypto-nodejs': 0.4.0
       openshell: 0.1.0
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -6903,6 +7026,10 @@ snapshots:
     dependencies:
       '@types/retry': 0.12.0
       retry: 0.13.1
+
+  p-retry@7.1.1:
+    dependencies:
+      is-network-error: 1.3.1
 
   p-timeout@4.1.0:
     optional: true
@@ -6948,8 +7075,6 @@ snapshots:
   partial-json@0.1.7: {}
 
   path-exists@4.0.0: {}
-
-  path-expression-matcher@1.1.3: {}
 
   path-expression-matcher@1.2.0: {}
 
@@ -7180,6 +7305,8 @@ snapshots:
   sandwich-stream@2.0.2:
     optional: true
 
+  sdp-transform@3.0.0: {}
+
   semver@7.7.4: {}
 
   send@1.2.1:
@@ -7375,13 +7502,17 @@ snapshots:
     dependencies:
       '@tokenizer/token': 0.3.0
 
+  strtok3@10.3.5:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
 
   tapable@2.3.0: {}
 
-  tar@7.5.12:
+  tar@7.5.13:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -7515,7 +7646,9 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@7.24.5: {}
+  undici@7.24.6: {}
+
+  unhomoglyph@1.0.6: {}
 
   unicorn-magic@0.3.0: {}
 

--- a/src/card/reply-dispatcher-types.ts
+++ b/src/card/reply-dispatcher-types.ts
@@ -135,7 +135,8 @@ export interface ReplyDispatcher {
   sendBlockReply: (payload: ReplyPayload) => boolean;
   sendFinalReply: (payload: ReplyPayload) => boolean;
   waitForIdle: () => Promise<void>;
-  getQueuedCounts: () => Record<string, number>;
+  getQueuedCounts: () => Record<'tool' | 'block' | 'final', number>;
+  getFailedCounts: () => Record<'tool' | 'block' | 'final', number>;
   markComplete: () => void;
 }
 

--- a/src/core/auth-resume-target.ts
+++ b/src/core/auth-resume-target.ts
@@ -1,0 +1,20 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+export interface AuthResumeTarget {
+  agentId: string;
+  sessionKey: string;
+  accountId: string;
+  chatId: string;
+  chatType: 'p2p' | 'group';
+  threadId?: string;
+}
+
+const store = new AsyncLocalStorage<AuthResumeTarget>();
+
+export function withAuthResumeTarget<T>(target: AuthResumeTarget, fn: () => T | Promise<T>): T | Promise<T> {
+  return store.run(target, fn);
+}
+
+export function getAuthResumeTarget(): AuthResumeTarget | undefined {
+  return store.getStore();
+}

--- a/src/messaging/inbound/dispatch-context.ts
+++ b/src/messaging/inbound/dispatch-context.ts
@@ -16,6 +16,7 @@ import type { LarkAccount } from '../../core/types';
 import { LarkClient } from '../../core/lark-client';
 import { larkLogger } from '../../core/lark-logger';
 import { isThreadCapableGroup } from '../../core/chat-info-cache';
+import type { AuthResumeTarget } from '../../core/auth-resume-target';
 
 const log = larkLogger('inbound/dispatch-context');
 
@@ -40,7 +41,34 @@ export interface DispatchContext {
   envelopeOptions: ReturnType<typeof LarkClient.runtime.channel.reply.resolveEnvelopeFormatOptions>;
   route: ReturnType<typeof LarkClient.runtime.channel.routing.resolveAgentRoute>;
   threadSessionKey?: string;
+  routeOverrideApplied?: boolean;
   commandAuthorized?: boolean;
+}
+
+function resolveSessionRouteOverride(params: {
+  ctx: MessageContext;
+  account: LarkAccount;
+  route: ReturnType<typeof LarkClient.runtime.channel.routing.resolveAgentRoute>;
+  override?: AuthResumeTarget;
+}): { route: ReturnType<typeof LarkClient.runtime.channel.routing.resolveAgentRoute>; applied: boolean } {
+  const { ctx, account, route, override } = params;
+  if (!override) return { route, applied: false };
+  if (!override.agentId || !override.sessionKey) return { route, applied: false };
+  if (override.accountId !== account.accountId) return { route, applied: false };
+  if (override.chatId !== ctx.chatId) return { route, applied: false };
+  if (override.chatType !== ctx.chatType) return { route, applied: false };
+  const overrideThreadId = override.threadId ?? undefined;
+  const messageThreadId = ctx.threadId ?? undefined;
+  if (overrideThreadId !== messageThreadId) return { route, applied: false };
+
+  return {
+    route: {
+      ...route,
+      agentId: override.agentId,
+      sessionKey: override.sessionKey,
+    },
+    applied: true,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -74,6 +102,7 @@ export function buildDispatchContext(params: {
   accountScopedCfg: ClawdbotConfig;
   runtime?: RuntimeEnv;
   commandAuthorized?: boolean;
+  sessionRouteOverride?: AuthResumeTarget;
 }): DispatchContext {
   const { ctx, account, accountScopedCfg } = params;
 
@@ -92,7 +121,7 @@ export function buildDispatchContext(params: {
   const envelopeOptions = core.channel.reply.resolveEnvelopeFormatOptions(accountScopedCfg);
 
   // ---- Route resolution ----
-  const route = core.channel.routing.resolveAgentRoute({
+  const resolvedRoute = core.channel.routing.resolveAgentRoute({
     cfg: accountScopedCfg,
     channel: 'feishu',
     accountId: account.accountId,
@@ -100,6 +129,12 @@ export function buildDispatchContext(params: {
       kind: isGroup ? 'group' : 'direct',
       id: isGroup ? ctx.chatId : ctx.senderId,
     },
+  });
+  const { route, applied: routeOverrideApplied } = resolveSessionRouteOverride({
+    ctx,
+    account,
+    route: resolvedRoute,
+    override: params.sessionRouteOverride,
   });
 
   // ---- System event ----
@@ -138,6 +173,7 @@ export function buildDispatchContext(params: {
     envelopeOptions,
     route,
     threadSessionKey: undefined,
+    routeOverrideApplied,
     commandAuthorized: params.commandAuthorized,
   };
 }

--- a/src/messaging/inbound/dispatch.ts
+++ b/src/messaging/inbound/dispatch.ts
@@ -47,6 +47,7 @@ import { type DispatchContext, buildDispatchContext, resolveThreadSessionKey } f
 import type { PermissionError } from './permission';
 import { mentionedBot } from './mention';
 import { resolveRespondToMentionAll } from './gate';
+import type { AuthResumeTarget } from '../../core/auth-resume-target';
 
 const log = larkLogger('inbound/dispatch');
 
@@ -175,6 +176,7 @@ export async function dispatchToAgent(params: {
   defaultGroupConfig?: FeishuGroupConfig;
   /** When true, the reply dispatcher skips typing indicators. */
   skipTyping?: boolean;
+  sessionRouteOverride?: AuthResumeTarget;
 }): Promise<void> {
   // 1. Derive shared context (including route resolution + system event)
   const dc = buildDispatchContext(params);
@@ -198,7 +200,7 @@ export async function dispatchToAgent(params: {
   }
 
   // 1b. Resolve thread session isolation (async: may query group info API)
-  if (dc.isThread && dc.ctx.threadId) {
+  if (!dc.routeOverrideApplied && dc.isThread && dc.ctx.threadId) {
     dc.threadSessionKey = await resolveThreadSessionKey({
       accountScopedCfg: dc.accountScopedCfg,
       account: dc.account,

--- a/src/messaging/inbound/handler-registry.ts
+++ b/src/messaging/inbound/handler-registry.ts
@@ -9,6 +9,7 @@
  */
 
 import type { ClawdbotConfig, RuntimeEnv } from 'openclaw/plugin-sdk';
+import type { AuthResumeTarget } from '../../core/auth-resume-target';
 import type { FeishuMessageEvent } from '../types';
 
 export interface InboundHandlerParams {
@@ -20,6 +21,7 @@ export interface InboundHandlerParams {
   replyToMessageId?: string;
   forceMention?: boolean;
   skipTyping?: boolean;
+  sessionRouteOverride?: AuthResumeTarget;
 }
 
 type InboundHandler = (params: InboundHandlerParams) => Promise<void>;

--- a/src/messaging/inbound/handler.ts
+++ b/src/messaging/inbound/handler.ts
@@ -40,6 +40,7 @@ import { type GateResult, checkMessageGate, readFeishuAllowFromStore } from './g
 import { injectInboundHandler } from './handler-registry';
 import { dispatchToAgent } from './dispatch';
 import { resolveFeishuGroupConfig, splitLegacyGroupAllowFrom } from './policy';
+import type { AuthResumeTarget } from '../../core/auth-resume-target';
 
 const logger = larkLogger('inbound/handler');
 
@@ -63,8 +64,20 @@ export async function handleFeishuMessage(params: {
   forceMention?: boolean;
   /** When true, skip the typing indicator for this dispatch (e.g. reactions). */
   skipTyping?: boolean;
+  sessionRouteOverride?: AuthResumeTarget;
 }): Promise<void> {
-  const { cfg, event, botOpenId, runtime, chatHistories, accountId, replyToMessageId, forceMention, skipTyping } =
+  const {
+    cfg,
+    event,
+    botOpenId,
+    runtime,
+    chatHistories,
+    accountId,
+    replyToMessageId,
+    forceMention,
+    skipTyping,
+    sessionRouteOverride,
+  } =
     params;
 
   // 1. Account resolution
@@ -220,6 +233,7 @@ export async function handleFeishuMessage(params: {
       groupConfig,
       defaultGroupConfig,
       skipTyping,
+      sessionRouteOverride,
     });
   } catch (err) {
     error(`feishu[${account.accountId}]: failed to dispatch message: ${String(err)}`);

--- a/src/messaging/inbound/synthetic-message.ts
+++ b/src/messaging/inbound/synthetic-message.ts
@@ -10,6 +10,7 @@
 
 import type { ClawdbotConfig } from 'openclaw/plugin-sdk';
 import { enqueueFeishuChatTask } from '../../channel/chat-queue';
+import type { AuthResumeTarget } from '../../core/auth-resume-target';
 import { withTicket } from '../../core/lark-ticket';
 import { getInboundHandler } from './handler-registry';
 
@@ -23,6 +24,7 @@ export async function dispatchSyntheticTextMessage(params: {
   replyToMessageId: string;
   chatType?: 'p2p' | 'group';
   threadId?: string;
+  sessionRouteOverride?: AuthResumeTarget;
   runtime?: {
     log?: (msg: string) => void;
     error?: (msg: string) => void;
@@ -40,6 +42,7 @@ export async function dispatchSyntheticTextMessage(params: {
     replyToMessageId,
     chatType,
     threadId,
+    sessionRouteOverride,
     runtime,
     forceMention = true,
   } = params;
@@ -83,6 +86,7 @@ export async function dispatchSyntheticTextMessage(params: {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             runtime: runtime as any,
             replyToMessageId,
+            sessionRouteOverride,
           }),
       );
     },

--- a/src/tools/auto-auth.ts
+++ b/src/tools/auto-auth.ts
@@ -44,6 +44,8 @@ import { LarkClient } from '../core/lark-client';
 import { createCardEntity, sendCardByCardId, updateCardKitCardForAuth } from '../card/cardkit';
 import { OwnerAccessDeniedError } from '../core/owner-policy';
 import { dispatchSyntheticTextMessage } from '../messaging/inbound/synthetic-message';
+import type { AuthResumeTarget } from '../core/auth-resume-target';
+import { getAuthResumeTarget } from '../core/auth-resume-target';
 import { executeAuthorize } from './oauth';
 import { formatToolResult, getResolvedConfig } from './helpers';
 import type { ToolResult } from './helpers';
@@ -260,6 +262,7 @@ interface PendingAppAuthFlow {
   tokenType?: 'user' | 'tenant';
   cfg: ClawdbotConfig;
   ticket: LarkTicket;
+  resumeTarget?: AuthResumeTarget;
 }
 
 /** TTL：15 分钟后自动清理，防止内存泄漏。 */
@@ -711,6 +714,7 @@ async function sendAppScopeCard(params: {
     tokenType,
     cfg,
     ticket,
+    resumeTarget: getAuthResumeTarget(),
   };
   appAuthFlows.register(operationId, flow, dedup, activeCardKey);
 
@@ -881,6 +885,7 @@ export async function handleCardAction(data: unknown, cfg: ClawdbotConfig, accou
           replyToMessageId: flow.ticket.messageId,
           chatType: flow.ticket.chatType,
           threadId: flow.ticket.threadId,
+          sessionRouteOverride: flow.resumeTarget,
           runtime: syntheticRuntime,
         });
         log.info('synthetic message dispatched after app-auth-only completion');
@@ -893,6 +898,7 @@ export async function handleCardAction(data: unknown, cfg: ClawdbotConfig, accou
           forceAuth: true, // 应用权限刚经历移除→补回，不信任本地 UAT 缓存
           cfg: flow.cfg,
           ticket: flow.ticket,
+          resumeTarget: flow.resumeTarget,
         });
       }
     } catch (err) {

--- a/src/tools/helpers.ts
+++ b/src/tools/helpers.ts
@@ -8,14 +8,20 @@
  */
 
 import type { ClawdbotConfig, OpenClawPluginApi } from 'openclaw/plugin-sdk';
+import type { AnyAgentTool, OpenClawPluginToolContext, OpenClawPluginToolFactory } from 'openclaw/plugin-sdk/core';
 import type { Client as LarkSdkClient } from '@larksuiteoapi/node-sdk';
 import { getEnabledLarkAccounts, getLarkAccount } from '../core/accounts';
 import { LarkClient, getResolvedConfig } from '../core/lark-client';
+import type { AuthResumeTarget } from '../core/auth-resume-target';
+import { withAuthResumeTarget } from '../core/auth-resume-target';
+import { normalizeFeishuTarget, parseFeishuRouteTarget } from '../core/targets';
 import type { LarkAccount } from '../core/types';
-import { getTicket } from '../core/lark-ticket';
+import type { LarkTicket } from '../core/lark-ticket';
+import { getTicket, withTicket } from '../core/lark-ticket';
 import type { ToolClient } from '../core/tool-client';
 import { createToolClient } from '../core/tool-client';
 import { shouldRegisterTool } from '../core/tools-config';
+import { getMessageFeishu } from '../messaging/shared/message-lookup';
 
 // ---------------------------------------------------------------------------
 // 类型定义
@@ -275,27 +281,175 @@ export function checkToolRegistration(api: OpenClawPluginApi, toolName: string):
  * registerTool(api, { name: 'feishu_my_tool', ... });
  * ```
  */
+function isFeishuToolContext(ctx: OpenClawPluginToolContext): boolean {
+  const channel = ctx.deliveryContext?.channel ?? ctx.messageChannel;
+  return channel === 'feishu' || channel === 'lark';
+}
+
+function buildSyntheticTicket(params: {
+  ctx: OpenClawPluginToolContext;
+  toolCallId: string;
+}): LarkTicket | null {
+  if (!isFeishuToolContext(params.ctx)) {
+    return null;
+  }
+
+  const to = params.ctx.deliveryContext?.to;
+  if (!to) {
+    return null;
+  }
+
+  const route = parseFeishuRouteTarget(to);
+  const chatId = normalizeFeishuTarget(route.target) ?? route.target;
+  const chatType: LarkTicket['chatType'] | undefined = route.target.startsWith('chat:')
+    ? 'group'
+    : route.target.startsWith('user:') || route.target.startsWith('open_id:')
+      ? 'p2p'
+      : undefined;
+  const accountId = String(params.ctx.deliveryContext?.accountId ?? params.ctx.agentAccountId ?? 'default');
+  const threadId = params.ctx.deliveryContext?.threadId ?? route.threadId;
+  const messageId = route.replyToMessageId
+    ? route.replyToMessageId
+    : params.ctx.sessionId
+      ? `session:${params.ctx.sessionId}`
+      : `tool:${params.toolCallId}`;
+
+  return {
+    messageId,
+    chatId,
+    accountId,
+    startTime: Date.now(),
+    senderOpenId: params.ctx.requesterSenderId,
+    chatType,
+    ...(threadId != null ? { threadId: String(threadId) } : {}),
+  };
+}
+
+function buildAuthResumeTarget(ctx: OpenClawPluginToolContext): AuthResumeTarget | null {
+  if (!isFeishuToolContext(ctx)) {
+    return null;
+  }
+
+  const to = ctx.deliveryContext?.to;
+  if (!to || !ctx.agentId || !ctx.sessionKey) {
+    return null;
+  }
+
+  const route = parseFeishuRouteTarget(to);
+  const chatId = normalizeFeishuTarget(route.target) ?? route.target;
+  const chatType: AuthResumeTarget['chatType'] | undefined = route.target.startsWith('chat:')
+    ? 'group'
+    : route.target.startsWith('user:') || route.target.startsWith('open_id:')
+      ? 'p2p'
+      : undefined;
+  const accountId = String(ctx.deliveryContext?.accountId ?? ctx.agentAccountId ?? 'default');
+  const threadId = ctx.deliveryContext?.threadId ?? route.threadId;
+
+  if (!chatType) {
+    return null;
+  }
+
+  return {
+    agentId: ctx.agentId,
+    sessionKey: ctx.sessionKey,
+    accountId,
+    chatId,
+    chatType,
+    ...(threadId != null ? { threadId: String(threadId) } : {}),
+  };
+}
+
+function wrapToolExecuteWithTicket(params: {
+  tool: AnyAgentTool | AnyAgentTool[] | null | undefined;
+  ctx: OpenClawPluginToolContext;
+  cfg: ClawdbotConfig;
+}): AnyAgentTool | AnyAgentTool[] | null | undefined {
+  if (!params.tool) return params.tool;
+  if (Array.isArray(params.tool)) {
+    return params.tool.map((item) => wrapToolExecuteWithTicket({ tool: item, ctx: params.ctx, cfg: params.cfg }) as any);
+  }
+
+  const tool = params.tool as any;
+  if (typeof tool?.execute !== 'function') return params.tool;
+
+  const originalExecute = tool.execute.bind(tool);
+
+  return {
+    ...tool,
+    execute: async (toolCallId: string, args: unknown) => {
+      if (getTicket()) {
+        return await originalExecute(toolCallId, args);
+      }
+
+      const ticket = buildSyntheticTicket({ ctx: params.ctx, toolCallId });
+      if (!ticket) {
+        return await originalExecute(toolCallId, args);
+      }
+
+      let effectiveTicket = ticket;
+      const resumeTarget = buildAuthResumeTarget(params.ctx);
+
+      if (!effectiveTicket.senderOpenId && effectiveTicket.messageId.startsWith('om_')) {
+        try {
+          const resolvedCfg = getResolvedConfig(params.cfg);
+          const info = await getMessageFeishu({
+            cfg: resolvedCfg,
+            messageId: effectiveTicket.messageId,
+            accountId: effectiveTicket.accountId,
+          });
+          if (info?.senderId) {
+            const resolvedChatType: LarkTicket['chatType'] | undefined =
+              info.chatType === 'p2p' || info.chatType === 'group' ? info.chatType : undefined;
+            effectiveTicket = {
+              ...effectiveTicket,
+              senderOpenId: info.senderId,
+              ...(info.chatId ? { chatId: info.chatId } : {}),
+              ...(resolvedChatType ? { chatType: resolvedChatType } : {}),
+              ...(!effectiveTicket.threadId && info.threadId ? { threadId: info.threadId } : {}),
+            };
+          }
+        } catch {
+        }
+      }
+
+      const run = async () =>
+        await withTicket(effectiveTicket, async () => {
+          return await originalExecute(toolCallId, args);
+        });
+
+      return resumeTarget ? await withAuthResumeTarget(resumeTarget, run) : await run();
+    },
+  };
+}
+
 export function registerTool(
   api: OpenClawPluginApi,
   tool: Parameters<OpenClawPluginApi['registerTool']>[0],
   opts?: Parameters<OpenClawPluginApi['registerTool']>[1],
 ): boolean {
-  // 提取工具名称
   const toolName = typeof tool === 'function' ? tool.name : (tool as { name?: string }).name;
 
   if (!toolName) {
-    // 如果无法提取工具名，直接注册（不拦截）
     api.registerTool(tool, opts);
     return true;
   }
 
-  // 检查是否应该注册
   if (!checkToolRegistration(api, toolName)) {
     return false;
   }
 
-  // 通过检查，调用原始的 registerTool
-  api.registerTool(tool, opts);
+  const cfg = api.config;
+  const wrapped = (ctx: OpenClawPluginToolContext) => {
+    if (typeof tool === 'function') {
+      const resolved = (tool as OpenClawPluginToolFactory)(ctx);
+      return wrapToolExecuteWithTicket({ tool: resolved, ctx, cfg }) as any;
+    }
+    return wrapToolExecuteWithTicket({ tool: tool as any, ctx, cfg }) as any;
+  };
+  const effectiveOpts =
+    opts ?? (typeof tool === 'function' ? undefined : ({ name: toolName } as Parameters<OpenClawPluginApi['registerTool']>[1]));
+
+  api.registerTool(wrapped, effectiveOpts);
   return true;
 }
 

--- a/src/tools/oauth.ts
+++ b/src/tools/oauth.ts
@@ -23,6 +23,8 @@ import { getLarkAccount } from '../core/accounts';
 import { OwnerAccessDeniedError, assertOwnerAccessStrict } from '../core/owner-policy';
 import { LarkClient } from '../core/lark-client';
 import { getAppGrantedScopes } from '../core/app-scope-checker';
+import type { AuthResumeTarget } from '../core/auth-resume-target';
+import { getAuthResumeTarget } from '../core/auth-resume-target';
 import type { LarkTicket } from '../core/lark-ticket';
 import { getTicket } from '../core/lark-ticket';
 import { larkLogger } from '../core/lark-logger';
@@ -80,6 +82,7 @@ interface PendingFlow {
   superseded: boolean;
   /** 当前 flow 请求的 scope（空格分隔），用于后续 scope 合并 */
   scope?: string;
+  resumeTarget?: AuthResumeTarget;
 }
 
 const pendingFlows = new Map<string, PendingFlow>();
@@ -249,6 +252,7 @@ export interface ExecuteAuthorizeParams {
   onAuthComplete?: () => void | Promise<void>; // 授权完成回调（用于批量授权链式触发）
   cfg: ClawdbotConfig;
   ticket: LarkTicket | undefined;
+  resumeTarget?: AuthResumeTarget;
 }
 
 /**
@@ -272,8 +276,10 @@ export async function executeAuthorize(
     onAuthComplete,
     cfg,
     ticket,
+    resumeTarget: resumeTargetParam,
   } = params;
   const { appId, appSecret, brand, accountId } = account;
+  const resumeTarget = resumeTargetParam ?? getAuthResumeTarget();
 
   // 0. Check if the user is the app owner (fail-close: 安全优先).
   const sdk = LarkClient.fromAccount(account).sdk;
@@ -527,6 +533,7 @@ export async function executeAuthorize(
     messageId: ticket?.messageId ?? '',
     superseded: false,
     scope: effectiveScope,
+    resumeTarget,
   };
   pendingFlows.set(flowKey, currentFlow);
   let pendingFlowDelete = false;
@@ -637,6 +644,7 @@ export async function executeAuthorize(
               replyToMessageId: ticket.messageId,
               chatType: ticket.chatType,
               threadId: ticket.threadId,
+              sessionRouteOverride: currentFlow.resumeTarget,
               runtime: syntheticRuntime,
             });
             log.info(`synthetic message queued (${status})`);

--- a/tests/dispatch-session-override.test.ts
+++ b/tests/dispatch-session-override.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockResolveAgentRoute = vi.fn();
+const mockEnqueueSystemEvent = vi.fn();
+const mockResolveThreadSessionKey = vi.fn();
+const mockDispatchReplyFromConfig = vi.fn();
+const mockCreateFeishuReplyDispatcher = vi.fn();
+
+vi.mock('../src/core/lark-client', () => ({
+  LarkClient: {
+    runtime: {
+      channel: {
+        routing: {
+          resolveAgentRoute: (...args: unknown[]) => mockResolveAgentRoute(...args),
+        },
+        reply: {
+          resolveEnvelopeFormatOptions: () => ({}),
+          dispatchReplyFromConfig: (...args: unknown[]) => mockDispatchReplyFromConfig(...args),
+        },
+        commands: {
+          isControlCommandMessage: () => false,
+        },
+      },
+      system: {
+        enqueueSystemEvent: (...args: unknown[]) => mockEnqueueSystemEvent(...args),
+      },
+    },
+  },
+}));
+
+vi.mock('../src/messaging/inbound/dispatch-builders', () => ({
+  buildMessageBody: () => 'body',
+  buildEnvelopeWithHistory: () => ({ combinedBody: 'combined', historyKey: undefined }),
+  buildBodyForAgent: () => 'body-for-agent',
+  buildInboundPayload: () => ({ body: 'payload' }),
+}));
+
+vi.mock('../src/card/reply-dispatcher', () => ({
+  createFeishuReplyDispatcher: (...args: unknown[]) => mockCreateFeishuReplyDispatcher(...args),
+}));
+
+vi.mock('../src/messaging/inbound/dispatch-commands', () => ({
+  dispatchPermissionNotification: vi.fn(),
+  dispatchSystemCommand: vi.fn(),
+}));
+
+vi.mock('../src/channel/chat-queue', () => ({
+  buildQueueKey: () => 'queue',
+  registerActiveDispatcher: vi.fn(),
+  threadScopedKey: () => 'history',
+  unregisterActiveDispatcher: vi.fn(),
+}));
+
+vi.mock('../src/channel/abort-detect', () => ({
+  isLikelyAbortText: () => false,
+}));
+
+vi.mock('../src/core/chat-info-cache', () => ({
+  isThreadCapableGroup: vi.fn(),
+}));
+
+vi.mock('../src/commands/doctor', () => ({
+  runFeishuDoctorI18n: vi.fn(),
+}));
+
+vi.mock('../src/commands/auth', () => ({
+  runFeishuAuthI18n: vi.fn(),
+}));
+
+vi.mock('../src/commands/index', () => ({
+  getFeishuHelpI18n: vi.fn(),
+  runFeishuStartI18n: vi.fn(),
+}));
+
+vi.mock('../src/messaging/outbound/send', () => ({
+  buildI18nMarkdownCard: vi.fn(),
+  sendCardFeishu: vi.fn(),
+  sendMessageFeishu: vi.fn(),
+}));
+
+vi.mock('../src/messaging/inbound/mention', () => ({
+  mentionedBot: () => false,
+}));
+
+vi.mock('../src/messaging/inbound/gate', () => ({
+  resolveRespondToMentionAll: () => false,
+}));
+
+vi.mock('../src/messaging/inbound/dispatch-context', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    resolveThreadSessionKey: (...args: unknown[]) => mockResolveThreadSessionKey(...args),
+  };
+});
+
+import { buildDispatchContext } from '../src/messaging/inbound/dispatch-context';
+import { dispatchToAgent } from '../src/messaging/inbound/dispatch';
+
+function createMessageContext() {
+  return {
+    chatId: 'oc_123',
+    messageId: 'om_1',
+    senderId: 'ou_1',
+    senderName: 'U',
+    chatType: 'group' as const,
+    content: 'hello',
+    contentType: 'text',
+    resources: [],
+    mentions: [],
+    mentionAll: false,
+    threadId: 'omt_1',
+    rawMessage: {
+      message_id: 'om_1',
+      chat_id: 'oc_123',
+      chat_type: 'group' as const,
+      message_type: 'text',
+      content: JSON.stringify({ text: 'hello' }),
+      thread_id: 'omt_1',
+    },
+    rawSender: {
+      sender_id: { open_id: 'ou_1' },
+    },
+  };
+}
+
+describe('dispatch session override', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResolveAgentRoute.mockReturnValue({
+      agentId: 'agent_main',
+      sessionKey: 'session_main',
+    });
+    mockDispatchReplyFromConfig.mockResolvedValue({
+      queuedFinal: true,
+      counts: { final: 1 },
+    });
+    mockCreateFeishuReplyDispatcher.mockReturnValue({
+      dispatcher: { waitForIdle: vi.fn().mockResolvedValue(undefined) },
+      replyOptions: {},
+      markDispatchIdle: vi.fn(),
+      markFullyComplete: vi.fn(),
+      abortCard: vi.fn(),
+    });
+    mockResolveThreadSessionKey.mockResolvedValue('thread_session');
+  });
+
+  it('applies override only when account/chat/chatType/thread all match', () => {
+    const ctx = createMessageContext();
+    const account = { accountId: 'default', config: {} } as any;
+    const dc = buildDispatchContext({
+      ctx,
+      account,
+      accountScopedCfg: {} as any,
+      sessionRouteOverride: {
+        agentId: 'agent_sub',
+        sessionKey: 'session_sub',
+        accountId: 'default',
+        chatId: 'oc_123',
+        chatType: 'group',
+        threadId: 'omt_1',
+      },
+    });
+
+    expect(dc.route).toMatchObject({
+      agentId: 'agent_sub',
+      sessionKey: 'session_sub',
+    });
+    expect(dc.routeOverrideApplied).toBe(true);
+
+    const ignored = buildDispatchContext({
+      ctx,
+      account,
+      accountScopedCfg: {} as any,
+      sessionRouteOverride: {
+        agentId: 'agent_sub',
+        sessionKey: 'session_sub',
+        accountId: 'default',
+        chatId: 'oc_123',
+        chatType: 'group',
+        threadId: 'omt_other',
+      },
+    });
+
+    expect(ignored.route).toMatchObject({
+      agentId: 'agent_main',
+      sessionKey: 'session_main',
+    });
+    expect(ignored.routeOverrideApplied).toBe(false);
+  });
+
+  it('skips thread session resolution when override has been applied', async () => {
+    await dispatchToAgent({
+      ctx: createMessageContext(),
+      mediaPayload: {},
+      account: { accountId: 'default', config: { threadSession: true } } as any,
+      accountScopedCfg: {} as any,
+      historyLimit: 0,
+      sessionRouteOverride: {
+        agentId: 'agent_sub',
+        sessionKey: 'session_sub',
+        accountId: 'default',
+        chatId: 'oc_123',
+        chatType: 'group',
+        threadId: 'omt_1',
+      },
+    });
+
+    expect(mockResolveThreadSessionKey).not.toHaveBeenCalled();
+    expect(mockCreateFeishuReplyDispatcher.mock.calls[0]![0]).toMatchObject({
+      agentId: 'agent_sub',
+      sessionKey: 'session_sub',
+    });
+  });
+});

--- a/tests/synthetic-message-session.test.ts
+++ b/tests/synthetic-message-session.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockWithTicket = vi.fn();
+const mockEnqueueFeishuChatTask = vi.fn();
+const mockHandleFeishuMessage = vi.fn();
+
+vi.mock('../src/core/lark-ticket', () => ({
+  withTicket: (...args: unknown[]) => mockWithTicket(...args),
+}));
+
+vi.mock('../src/channel/chat-queue', () => ({
+  enqueueFeishuChatTask: (...args: unknown[]) => mockEnqueueFeishuChatTask(...args),
+}));
+
+vi.mock('../src/messaging/inbound/handler-registry', () => ({
+  getInboundHandler: () => mockHandleFeishuMessage,
+}));
+
+import { dispatchSyntheticTextMessage } from '../src/messaging/inbound/synthetic-message';
+
+describe('dispatchSyntheticTextMessage session override', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWithTicket.mockImplementation(async (_ticket: unknown, fn: () => unknown) => await fn());
+    mockEnqueueFeishuChatTask.mockImplementation(({ task }: { task: () => Promise<void> }) => ({
+      status: 'queued',
+      promise: task(),
+    }));
+  });
+
+  it('forwards sessionRouteOverride to inbound handler and ticket context', async () => {
+    await dispatchSyntheticTextMessage({
+      cfg: {} as any,
+      accountId: 'default',
+      chatId: 'oc_123',
+      senderOpenId: 'ou_123',
+      text: 'resume',
+      syntheticMessageId: 'om_synthetic',
+      replyToMessageId: 'om_origin',
+      chatType: 'group',
+      threadId: 'omt_1',
+      sessionRouteOverride: {
+        agentId: 'agent_sub',
+        sessionKey: 'session_sub',
+        accountId: 'default',
+        chatId: 'oc_123',
+        chatType: 'group',
+        threadId: 'omt_1',
+      },
+    });
+
+    expect(mockWithTicket).toHaveBeenCalledTimes(1);
+    expect(mockWithTicket.mock.calls[0]![0]).toMatchObject({
+      messageId: 'om_synthetic',
+      chatId: 'oc_123',
+      accountId: 'default',
+      senderOpenId: 'ou_123',
+      chatType: 'group',
+      threadId: 'omt_1',
+    });
+
+    expect(mockHandleFeishuMessage).toHaveBeenCalledTimes(1);
+    expect(mockHandleFeishuMessage.mock.calls[0]![0]).toMatchObject({
+      accountId: 'default',
+      replyToMessageId: 'om_origin',
+      sessionRouteOverride: {
+        agentId: 'agent_sub',
+        sessionKey: 'session_sub',
+        accountId: 'default',
+        chatId: 'oc_123',
+        chatType: 'group',
+        threadId: 'omt_1',
+      },
+    });
+  });
+});

--- a/tests/tool-registration-ticket.test.ts
+++ b/tests/tool-registration-ticket.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Tests for tool registration ticket bridging.
+ *
+ * When a tool runs outside the Feishu inbound message pipeline (e.g. in a spawned
+ * subagent gateway run), the Feishu plugin previously had no LarkTicket set in
+ * AsyncLocalStorage, causing auth flows to degrade and skip sending cards.
+ *
+ * The helpers.registerTool wrapper should synthesize a ticket from the
+ * OpenClawPluginToolContext and execute the tool under withTicket().
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetTicket = vi.fn();
+const mockWithTicket = vi.fn();
+const mockGetMessageFeishu = vi.fn();
+const mockWithAuthResumeTarget = vi.fn();
+
+vi.mock('../src/core/lark-ticket', () => ({
+  getTicket: (...args: unknown[]) => mockGetTicket(...args),
+  withTicket: (...args: unknown[]) => mockWithTicket(...args),
+}));
+
+vi.mock('../src/messaging/shared/message-lookup', () => ({
+  getMessageFeishu: (...args: unknown[]) => mockGetMessageFeishu(...args),
+}));
+
+vi.mock('../src/core/auth-resume-target', () => ({
+  withAuthResumeTarget: (...args: unknown[]) => mockWithAuthResumeTarget(...args),
+  getAuthResumeTarget: vi.fn(),
+}));
+
+vi.mock('../src/core/tools-config', () => ({
+  shouldRegisterTool: () => true,
+}));
+
+vi.mock('../src/core/lark-client', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    getResolvedConfig: (cfg: unknown) => cfg,
+  };
+});
+
+// Import under test (after mocks)
+import { registerTool } from '../src/tools/helpers';
+
+describe('tools/helpers registerTool ticket wrapper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWithAuthResumeTarget.mockImplementation(async (_target: unknown, fn: () => unknown) => await fn());
+  });
+  it('wraps tool execute with a synthetic ticket when ticket is missing', async () => {
+    mockGetTicket.mockReturnValue(undefined);
+    mockWithTicket.mockImplementation(async (_ticket: unknown, fn: () => unknown) => await fn());
+
+    const originalExecute = vi.fn().mockResolvedValue({ ok: true });
+
+    const registrations: Array<{ tool: any; opts: any }> = [];
+    const api = {
+      config: {},
+      logger: { debug: vi.fn() },
+      registerTool: (tool: any, opts: any) => {
+        registrations.push({ tool, opts });
+      },
+    } as any;
+
+    registerTool(api, { name: 'feishu_test', execute: originalExecute } as any);
+
+    expect(registrations).toHaveLength(1);
+    expect(typeof registrations[0]!.tool).toBe('function');
+    expect(registrations[0]!.opts).toEqual({ name: 'feishu_test' });
+
+    const wrappedTool = registrations[0]!.tool({
+      deliveryContext: {
+        channel: 'feishu',
+        to: 'chat:oc_123',
+        accountId: 'default',
+        threadId: 'th_1',
+      },
+      agentId: 'agent_sub',
+      sessionKey: 'session_sub',
+      sessionId: 'session-1',
+      requesterSenderId: 'ou_owner',
+      messageChannel: 'feishu',
+      agentAccountId: 'default',
+    });
+
+    await wrappedTool.execute('call-1', { foo: 'bar' });
+
+    expect(mockWithAuthResumeTarget).toHaveBeenCalledTimes(1);
+    expect(mockWithAuthResumeTarget.mock.calls[0]![0]).toMatchObject({
+      agentId: 'agent_sub',
+      sessionKey: 'session_sub',
+      accountId: 'default',
+      chatId: 'oc_123',
+      chatType: 'group',
+      threadId: 'th_1',
+    });
+
+    expect(mockWithTicket).toHaveBeenCalledTimes(1);
+    expect(mockWithTicket.mock.calls[0]![0]).toMatchObject({
+      messageId: 'session:session-1',
+      chatId: 'oc_123',
+      accountId: 'default',
+      senderOpenId: 'ou_owner',
+      chatType: 'group',
+      threadId: 'th_1',
+    });
+    expect(originalExecute).toHaveBeenCalledWith('call-1', { foo: 'bar' });
+  });
+
+  it('backfills senderOpenId from replyTo message when missing', async () => {
+    mockGetTicket.mockReturnValue(undefined);
+    mockWithTicket.mockImplementation(async (_ticket: unknown, fn: () => unknown) => await fn());
+    mockGetMessageFeishu.mockResolvedValue({
+      senderId: 'ou_backfilled',
+      chatId: 'oc_123',
+      threadId: 'omt_1',
+    });
+
+    const originalExecute = vi.fn().mockResolvedValue({ ok: true });
+
+    const registrations: Array<{ tool: any; opts: any }> = [];
+    const api = {
+      config: { any: 'cfg' },
+      logger: { debug: vi.fn() },
+      registerTool: (tool: any, opts: any) => {
+        registrations.push({ tool, opts });
+      },
+    } as any;
+
+    registerTool(api, { name: 'feishu_test_backfill', execute: originalExecute } as any);
+
+    const wrappedTool = registrations[0]!.tool({
+      deliveryContext: {
+        channel: 'feishu',
+        to: 'chat:oc_123#__feishu_reply_to=om_abc&__feishu_thread_id=omt_1',
+        accountId: 'default',
+      },
+      sessionId: 'session-ignored',
+      requesterSenderId: '',
+      messageChannel: 'feishu',
+      agentAccountId: 'default',
+    });
+
+    await wrappedTool.execute('call-3', { a: 1 });
+
+    expect(mockGetMessageFeishu).toHaveBeenCalledTimes(1);
+    expect(mockGetMessageFeishu.mock.calls[0]![0]).toMatchObject({
+      messageId: 'om_abc',
+      accountId: 'default',
+    });
+
+    expect(mockWithTicket).toHaveBeenCalledTimes(1);
+    expect(mockWithTicket.mock.calls[0]![0]).toMatchObject({
+      messageId: 'om_abc',
+      chatId: 'oc_123',
+      accountId: 'default',
+      senderOpenId: 'ou_backfilled',
+      chatType: 'group',
+      threadId: 'omt_1',
+    });
+    expect(originalExecute).toHaveBeenCalledWith('call-3', { a: 1 });
+  });
+
+  it('does not synthesize a ticket when deliveryContext.to is missing', async () => {
+    mockGetTicket.mockReturnValue(undefined);
+    mockWithTicket.mockImplementation(async (_ticket: unknown, fn: () => unknown) => await fn());
+
+    const originalExecute = vi.fn().mockResolvedValue({ ok: true });
+
+    const registrations: Array<{ tool: any; opts: any }> = [];
+    const api = {
+      config: {},
+      logger: { debug: vi.fn() },
+      registerTool: (tool: any, opts: any) => {
+        registrations.push({ tool, opts });
+      },
+    } as any;
+
+    registerTool(api, { name: 'feishu_test_missing_to', execute: originalExecute } as any);
+
+    const wrappedTool = registrations[0]!.tool({
+      deliveryContext: { channel: 'feishu', accountId: 'default' },
+      sessionId: 'session-4',
+      requesterSenderId: 'ou_owner',
+      messageChannel: 'feishu',
+      agentAccountId: 'default',
+    });
+
+    await wrappedTool.execute('call-4', { b: 2 });
+
+    expect(mockWithAuthResumeTarget).not.toHaveBeenCalled();
+    expect(mockWithTicket).not.toHaveBeenCalled();
+    expect(originalExecute).toHaveBeenCalledWith('call-4', { b: 2 });
+  });
+
+  it('wraps tools returned from a factory array', async () => {
+    mockGetTicket.mockReturnValue(undefined);
+    mockWithTicket.mockImplementation(async (_ticket: unknown, fn: () => unknown) => await fn());
+
+    const exec1 = vi.fn().mockResolvedValue({ ok: 1 });
+    const exec2 = vi.fn().mockResolvedValue({ ok: 2 });
+
+    function toolFactory(_ctx: any) {
+      return [
+        { name: 'feishu_test_factory_1', execute: exec1 },
+        { name: 'feishu_test_factory_2', execute: exec2 },
+      ];
+    }
+
+    const registrations: Array<{ tool: any; opts: any }> = [];
+    const api = {
+      config: {},
+      logger: { debug: vi.fn() },
+      registerTool: (tool: any, opts: any) => {
+        registrations.push({ tool, opts });
+      },
+    } as any;
+
+    registerTool(api, toolFactory as any);
+
+    const wrappedTools = registrations[0]!.tool({
+      deliveryContext: { channel: 'feishu', to: 'chat:oc_123', accountId: 'default' },
+      sessionId: 'session-5',
+      requesterSenderId: 'ou_owner',
+      messageChannel: 'feishu',
+      agentAccountId: 'default',
+    });
+
+    expect(Array.isArray(wrappedTools)).toBe(true);
+
+    await wrappedTools[0].execute('call-5', { x: 1 });
+    await wrappedTools[1].execute('call-6', { y: 2 });
+
+    expect(mockWithTicket).toHaveBeenCalledTimes(2);
+    expect(exec1).toHaveBeenCalledWith('call-5', { x: 1 });
+    expect(exec2).toHaveBeenCalledWith('call-6', { y: 2 });
+  });
+
+  it('does not wrap when ticket already exists', async () => {
+    mockGetTicket.mockReturnValue({ messageId: 'om_existing' });
+
+    const originalExecute = vi.fn().mockResolvedValue({ ok: true });
+
+    const registrations: Array<{ tool: any; opts: any }> = [];
+    const api = {
+      config: {},
+      logger: { debug: vi.fn() },
+      registerTool: (tool: any, opts: any) => {
+        registrations.push({ tool, opts });
+      },
+    } as any;
+
+    registerTool(api, { name: 'feishu_test2', execute: originalExecute } as any);
+
+    const wrappedTool = registrations[0]!.tool({
+      deliveryContext: {
+        channel: 'feishu',
+        to: 'chat:oc_123',
+        accountId: 'default',
+      },
+      sessionId: 'session-2',
+      requesterSenderId: 'ou_owner',
+      messageChannel: 'feishu',
+      agentAccountId: 'default',
+    });
+
+    await wrappedTool.execute('call-2', { baz: 1 });
+
+    expect(mockWithTicket).not.toHaveBeenCalled();
+    expect(originalExecute).toHaveBeenCalledWith('call-2', { baz: 1 });
+  });
+});


### PR DESCRIPTION
## 背景
在 spawned 子 agent 场景中，工具执行不一定发生在飞书入站消息管道内，导致插件侧 AsyncLocalStorage 中可能缺失 `LarkTicket`（消息投递上下文）。当工具需要 OAuth 授权时，会出现两类问题：

- 触发 `need_user_authorization` 后，可能无法向用户推送授权卡片/授权链接。
- 即使用户完成授权，授权完成后的 synthetic resume turn 可能会被路由回主会话/线程会话，而不是触发授权的子 agent 会话，导致原任务无法在正确上下文中续跑。

## 改动内容

### 1) spawned 子 agent 场景的 Ticket bridge（补齐 LarkTicket 上下文）
- 在工具注册阶段统一包装 `execute(...)`。
- 当 `LarkTicket` 缺失时，从 `OpenClawPluginToolContext.deliveryContext` 合成 ticket，并在 `withTicket(...)` 环境中执行工具。
- 在条件允许时 best-effort 回捞原消息补齐 `senderOpenId`，提升授权发起与校验的稳定性。

### 2) 授权完成后续跑回正确的子 agent 会话（sessionRouteOverride）
- 通过 AsyncLocalStorage 捕获并保存 resume 元信息（`AuthResumeTarget`：`agentId/sessionKey` + account/chat/thread 身份信息）。
- 在注入 synthetic inbound 消息时携带 `sessionRouteOverride`，并在入站链路中一路透传。
- dispatch 时仅在 account/chat/chatType/thread 完全匹配时才应用 override，覆盖 `route.agentId/sessionKey`。
- 当 override 已应用时跳过 threadSessionKey 派生，避免显式 sessionKey 被再次改写。

## 行为变化（Before / After）
- 修复前：spawned 子 agent 可能无法推送授权卡片；授权完成后续跑可能回到主会话/线程会话。
- 修复后：授权卡片可稳定投递到同一 chat/thread；授权完成后的续跑会回到触发授权的子 agent 会话。

## 测试
新增单测覆盖：
- 工具注册 wrapper + ticket 合成 + sender 回填
- sessionRouteOverride 严格匹配 + override 生效时跳过 threadSessionKey
- synthetic inbound 对 sessionRouteOverride 的透传

## Checklist
- [ ] 所有 commits 已按 CLA.md 添加 Signed-off-by（建议使用 `git commit -s`）
- [ ] `pnpm lint`
- [ ] `pnpm format:check`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`

## 参考
- Issue: #359 