### PR TITLE
fix: prefer message body fileName over Content-Disposition for non-ASCII filenames

### DIFF
--- a/src/messaging/inbound/media-resolver.ts
+++ b/src/messaging/inbound/media-resolver.ts
@@ -53,7 +53,11 @@ export async function downloadResources(params: {
         contentType = await core.media.detectMime({ buffer: result.buffer });
       }
 
-      const fileName = result.fileName || res.fileName;
+      // Prefer the file name from the message body (res.fileName) over
+      // Content-Disposition (result.fileName), because Feishu may return
+      // raw UTF-8 bytes in the header that get misinterpreted as Latin1
+      // by Node.js HTTP clients, producing garbled non-ASCII filenames.
+      const fileName = res.fileName || result.fileName;
       const saved = await core.channel.media.saveMediaBuffer(result.buffer, contentType, 'inbound', maxBytes, fileName);
 
       const placeholder = inferPlaceholderFromType(res.type);


### PR DESCRIPTION
## Problem

Fixes #364

When downloading files with Chinese/CJK filenames from Feishu, the saved filenames are garbled (e.g., `ã_ç_å_è_.pdf` instead of `助英台.pdf`).

**Root cause:** Feishu returns raw UTF-8 bytes in the `Content-Disposition` header `filename` field. Node.js HTTP clients decode headers as Latin1 per HTTP/1.1 spec, producing garbled strings for non-ASCII characters.

## Fix

The message body already contains the correct UTF-8 `file_name`, extracted during the converter phase into `ResourceDescriptor.fileName`. The fix is a one-line priority swap in `media-resolver.ts`:

```diff
- const fileName = result.fileName || res.fileName;
+ const fileName = res.fileName || result.fileName;
```

`res.fileName` (from message body, always correct UTF-8) is now preferred over `result.fileName` (from Content-Disposition header, potentially garbled). The header value still serves as a fallback for cases where the message body doesn't include a filename (e.g., image messages).

## Why not fix the Content-Disposition parsing?

An earlier approach attempted Latin1→UTF-8 byte recovery on the header value, but that relies on heuristic detection (guessing whether a string is misencoded). Using the message body as the primary source is deterministic and zero-guesswork.