### PR TITLE
feat: support /allowlist command for Feishu DM and group allowlist edits

### DIFF
--- a/src/channel/plugin.ts
+++ b/src/channel/plugin.ts
@@ -13,7 +13,11 @@ import type { ChannelPlugin, ClawdbotConfig } from 'openclaw/plugin-sdk';
 import type { ChannelThreadingToolContext } from 'openclaw/plugin-sdk/channel-contract';
 import { DEFAULT_ACCOUNT_ID } from 'openclaw/plugin-sdk/account-id';
 import { PAIRING_APPROVED_MESSAGE } from 'openclaw/plugin-sdk/channel-status';
-import type { LarkAccount } from '../core/types';
+import {
+  buildDmGroupAccountAllowlistAdapter,
+  collectAllowlistOverridesFromRecord,
+} from 'openclaw/plugin-sdk/allowlist-config-edit';
+import type { LarkAccount, FeishuConfig, FeishuGroupConfig } from '../core/types';
 import { getDefaultLarkAccountId, getLarkAccount, getLarkAccountIds } from '../core/accounts';
 import { feishuOutbound } from '../messaging/outbound/outbound';
 import { feishuMessageActions } from '../messaging/outbound/actions';
@@ -55,6 +59,33 @@ function adaptDirectoryParams(params: {
     accountId: params.accountId ?? undefined,
   };
 }
+
+// ---------------------------------------------------------------------------
+// Allowlist adapter
+// ---------------------------------------------------------------------------
+
+function normalizeFeishuAllowFrom(params: { values: Array<string | number> }): string[] {
+  return params.values
+    .map((entry) => String(entry).trim())
+    .filter(Boolean)
+    .map((entry) => entry.toLowerCase());
+}
+
+const feishuAllowlistAdapter = buildDmGroupAccountAllowlistAdapter<LarkAccount>({
+  channelId: 'feishu',
+  resolveAccount: ({ cfg, accountId }) => getLarkAccount(cfg, accountId),
+  normalize: normalizeFeishuAllowFrom,
+  resolveDmAllowFrom: (account) => account.config?.allowFrom,
+  resolveGroupAllowFrom: (account) => account.config?.groupAllowFrom,
+  resolveDmPolicy: (account) => account.config?.dmPolicy,
+  resolveGroupPolicy: (account) => account.config?.groupPolicy,
+  resolveGroupOverrides: (account) =>
+    collectAllowlistOverridesFromRecord<FeishuGroupConfig>({
+      record: account.config?.groups as Record<string, FeishuGroupConfig | undefined> | undefined,
+      label: (key) => `group ${key}`,
+      resolveEntries: (group) => group.allowFrom,
+    }),
+});
 
 // ---------------------------------------------------------------------------
 // Meta
@@ -199,6 +230,12 @@ export const feishuPlugin: ChannelPlugin<LarkAccount> = {
         .filter(Boolean)
         .map((entry) => entry.toLowerCase()),
   },
+
+  // -------------------------------------------------------------------------
+  // Allowlist
+  // -------------------------------------------------------------------------
+
+  allowlist: feishuAllowlistAdapter,
 
   // -------------------------------------------------------------------------
   // Security


### PR DESCRIPTION
## Summary

- Implement the `allowlist` adapter (`readConfig` + `applyConfigEdit` + `supportsScope`) for the Feishu channel plugin, enabling `/allowlist add|remove dm|group <entry>` commands to directly modify `channels.feishu.allowFrom` and `groupAllowFrom` in `openclaw.json`.
- Built using the SDK's `buildDmGroupAccountAllowlistAdapter`, consistent with how Slack, Telegram, and other channels implement this.
- Per-group `allowFrom` overrides are also surfaced in `/allowlist list` output.

## Motivation

Previously the Feishu plugin did not implement `ChannelPlugin.allowlist`, so users received `⚠️ feishu does not support dm allowlist edits via /allowlist.` when running `/allowlist add dm ou_xxx`. This PR fills that gap.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — all 141 tests pass
- [x] No lint errors
- [x] Manual: start gateway, send `/allowlist list`, `/allowlist add dm ou_xxx`, `/allowlist remove dm ou_xxx` to verify