### PR TITLE
feat: add uat.ownerOnly and uat.allowedUsers for owner policy

### DIFF
--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -5,7 +5,7 @@
  * feishu_auth command — 飞书用户权限批量授权命令实现
  *
  * 直接复用 onboarding-auth.ts 的 triggerOnboarding() 函数。
- * 注意：此命令仅限应用 owner 执行（与 onboarding 逻辑一致）
+ * 注意：默认仅限应用 owner 执行；可通过 uat.ownerOnly / uat.allowedUsers 放宽
  */
 
 import type { OpenClawConfig } from 'openclaw/plugin-sdk';
@@ -16,7 +16,11 @@ import { LarkClient } from '../core/lark-client';
 import { getAppGrantedScopes, getAppInfo } from '../core/app-scope-checker';
 import { getStoredToken, tokenStatus } from '../core/token-store';
 import { filterSensitiveScopes } from '../core/tool-scopes';
-import { OwnerAccessDeniedError, assertOwnerAccessStrict } from '../core/owner-policy';
+import {
+  OwnerAccessDeniedError,
+  type OwnerAccessDeniedReason,
+  assertOwnerAccessStrict,
+} from '../core/owner-policy';
 import { openPlatformDomain } from '../core/domains';
 
 import type { FeishuLocale } from './locale';
@@ -31,7 +35,7 @@ const T: Record<
     noIdentity: string;
     accountIncomplete: (accountId: string) => string;
     missingSelfManage: (link: string) => string;
-    ownerOnly: string;
+    ownerDenied: (reason: OwnerAccessDeniedReason) => string;
     missingOfflineAccess: (link: string) => string;
     noUserScopes: string;
     allAuthorized: (count: number) => string;
@@ -43,7 +47,10 @@ const T: Record<
     accountIncomplete: (accountId) => `❌ 账号 ${accountId} 配置不完整`,
     missingSelfManage: (link) =>
       `❌ 应用缺少核心权限 application:application:self_manage，无法查询可授权 scope 列表。\n\n请管理员在飞书开放平台开通此权限后重试：[申请权限](${link})`,
-    ownerOnly: '❌ 此命令仅限应用 owner 执行\n\n如需授权，请联系应用管理员。',
+    ownerDenied: (reason) =>
+      reason === 'not_in_allowlist'
+        ? '❌ 您不在此应用的授权用户列表中\n\n请联系应用管理员，将您的 open_id 加入 uat.allowedUsers 配置。'
+        : '❌ 此命令仅限应用 owner 执行\n\n如需授权，请联系应用管理员。',
     missingOfflineAccess: (link) =>
       `❌ 应用缺少核心权限 offline_access，无法查询可授权 scope 列表。\n\n请管理员在飞书开放平台开通此权限后重试：[申请权限](${link})`,
     noUserScopes: '当前应用未开通任何用户级权限，无需授权。',
@@ -55,7 +62,10 @@ const T: Record<
     accountIncomplete: (accountId) => `❌ Account ${accountId} configuration is incomplete`,
     missingSelfManage: (link) =>
       `❌ App is missing the core permission application:application:self_manage and cannot query available scopes.\n\nPlease ask an admin to grant this permission on the Feishu Open Platform: [Apply](${link})`,
-    ownerOnly: '❌ This command is restricted to the app owner.\n\nPlease contact the app admin for authorization.',
+    ownerDenied: (reason) =>
+      reason === 'not_in_allowlist'
+        ? '❌ You are not in this app\'s authorized user list.\n\nPlease ask the app admin to add your open_id to uat.allowedUsers.'
+        : '❌ This command is restricted to the app owner.\n\nPlease contact the app admin for authorization.',
     missingOfflineAccess: (link) =>
       `❌ App is missing the core permission offline_access and cannot query available scopes.\n\nPlease ask an admin to grant this permission on the Feishu Open Platform: [Apply](${link})`,
     noUserScopes: 'No user-level permissions are enabled for this app. Authorization is not needed.',
@@ -73,7 +83,7 @@ type AuthResult =
   | { kind: 'no_identity' }
   | { kind: 'account_incomplete'; accountId: string }
   | { kind: 'missing_self_manage'; link: string }
-  | { kind: 'owner_only' }
+  | { kind: 'owner_denied'; reason: OwnerAccessDeniedReason }
   | { kind: 'missing_offline_access'; link: string }
   | { kind: 'no_user_scopes' }
   | { kind: 'all_authorized'; count: number }
@@ -91,8 +101,8 @@ function formatAuthResult(result: AuthResult, locale: FeishuLocale): string {
       return t.accountIncomplete(result.accountId);
     case 'missing_self_manage':
       return t.missingSelfManage(result.link);
-    case 'owner_only':
-      return t.ownerOnly;
+    case 'owner_denied':
+      return t.ownerDenied(result.reason);
     case 'missing_offline_access':
       return t.missingOfflineAccess(result.link);
     case 'no_user_scopes':
@@ -120,7 +130,7 @@ async function executeFeishuAuth(config: OpenClawConfig): Promise<AuthResult> {
     return { kind: 'no_identity' };
   }
 
-  // 提前检查 owner 身份，给出明确提示
+  // 提前检查 owner / allowlist 访问权限，给出明确提示
   const acct = getLarkAccount(config, ticket.accountId);
   if (!acct.configured) {
     return { kind: 'account_incomplete', accountId: ticket.accountId };
@@ -138,12 +148,12 @@ async function executeFeishuAuth(config: OpenClawConfig): Promise<AuthResult> {
     return { kind: 'missing_self_manage', link };
   }
 
-  // Owner 检查（fail-close: 授权命令安全优先）
+  // UAT 访问检查（默认 fail-close: 授权命令安全优先）
   try {
     await assertOwnerAccessStrict(acct, sdk, senderOpenId);
   } catch (err) {
     if (err instanceof OwnerAccessDeniedError) {
-      return { kind: 'owner_only' };
+      return { kind: 'owner_denied', reason: err.reason };
     }
     throw err;
   }

--- a/src/core/config-schema.ts
+++ b/src/core/config-schema.ts
@@ -121,6 +121,8 @@ const ReactionNotificationModeSchema = z.enum(['off', 'own', 'all']).optional();
 export const UATConfigSchema = z
   .object({
     enabled: z.boolean().optional(),
+    ownerOnly: z.boolean().optional(),
+    allowedUsers: z.array(z.string()).optional(),
     allowedScopes: z.array(z.string()).optional(),
     blockedScopes: z.array(z.string()).optional(),
   })

--- a/src/core/owner-policy.ts
+++ b/src/core/owner-policy.ts
@@ -11,10 +11,15 @@
 import type * as Lark from '@larksuiteoapi/node-sdk';
 import type { ConfiguredLarkAccount } from './types';
 import { getAppOwnerFallback } from './app-owner-fallback';
+import { larkLogger } from './lark-logger';
+
+const log = larkLogger('core/owner-policy');
 
 // ---------------------------------------------------------------------------
 // Error class
 // ---------------------------------------------------------------------------
+
+export type OwnerAccessDeniedReason = 'strict' | 'not_in_allowlist';
 
 /**
  * 非应用 owner 尝试执行 owner-only 操作时抛出。
@@ -25,12 +30,14 @@ import { getAppOwnerFallback } from './app-owner-fallback';
 export class OwnerAccessDeniedError extends Error {
   readonly userOpenId: string;
   readonly appOwnerId: string;
+  readonly reason: OwnerAccessDeniedReason;
 
-  constructor(userOpenId: string, appOwnerId: string) {
+  constructor(userOpenId: string, appOwnerId: string, reason: OwnerAccessDeniedReason = 'strict') {
     super('Permission denied: Only the app owner is authorized to use this feature.');
     this.name = 'OwnerAccessDeniedError';
     this.userOpenId = userOpenId;
     this.appOwnerId = appOwnerId;
+    this.reason = reason;
   }
 }
 
@@ -52,13 +59,32 @@ export async function assertOwnerAccessStrict(
   sdk: Lark.Client,
   userOpenId: string,
 ): Promise<void> {
+  const ownerOnly = account.config.uat?.ownerOnly ?? true;
+  const allowedUsers = new Set((account.config.uat?.allowedUsers ?? []).map((entry) => entry.trim()).filter(Boolean));
+
+  if (!ownerOnly && allowedUsers.size === 0) {
+    return;
+  }
+
   const ownerOpenId = await getAppOwnerFallback(account, sdk);
 
   if (!ownerOpenId) {
-    throw new OwnerAccessDeniedError(userOpenId, 'unknown');
+    if (!ownerOnly && allowedUsers.has(userOpenId)) {
+      log.warn(`allowing non-owner user ${userOpenId} for account ${account.accountId} via uat.allowedUsers without owner lookup`);
+      return;
+    }
+
+    throw new OwnerAccessDeniedError(userOpenId, 'unknown', ownerOnly ? 'strict' : 'not_in_allowlist');
   }
 
-  if (ownerOpenId !== userOpenId) {
-    throw new OwnerAccessDeniedError(userOpenId, ownerOpenId);
+  if (ownerOpenId === userOpenId) {
+    return;
   }
+
+  if (!ownerOnly && allowedUsers.has(userOpenId)) {
+    log.warn(`allowing non-owner user ${userOpenId} for account ${account.accountId} via uat.allowedUsers`);
+    return;
+  }
+
+  throw new OwnerAccessDeniedError(userOpenId, ownerOpenId, ownerOnly ? 'strict' : 'not_in_allowlist');
 }

--- a/src/tools/auto-auth.ts
+++ b/src/tools/auto-auth.ts
@@ -939,7 +939,10 @@ export async function handleInvokeErrorWithAutoAuth(err: unknown, cfg: ClawdbotC
   if (err instanceof OwnerAccessDeniedError) {
     return json({
       error: 'permission_denied',
-      message: '当前应用仅限所有者（App Owner）使用。您没有权限使用相关功能。',
+      message:
+        err.reason === 'not_in_allowlist'
+          ? '您不在此应用的授权用户列表中，请联系管理员将您的 open_id 加入 uat.allowedUsers 配置。'
+          : '当前应用仅限所有者（App Owner）使用。您没有权限使用相关功能。',
       user_open_id: err.userOpenId,
       // 注意：不序列化 err.appOwnerId，避免泄露 owner 的 open_id
     });

--- a/src/tools/oauth.ts
+++ b/src/tools/oauth.ts
@@ -281,10 +281,13 @@ export async function executeAuthorize(
     await assertOwnerAccessStrict(account, sdk, senderOpenId);
   } catch (err) {
     if (err instanceof OwnerAccessDeniedError) {
-      log.warn(`non-owner user ${senderOpenId} attempted to authorize`);
+      log.warn(`user ${senderOpenId} was denied authorization by owner policy`);
       return json({
         error: 'permission_denied',
-        message: '当前应用仅限所有者（App Owner）使用。您没有权限发起授权，无法使用相关功能。',
+        message:
+          err.reason === 'not_in_allowlist'
+            ? '您不在此应用的授权用户列表中，请联系管理员将您的 open_id 加入 uat.allowedUsers 配置。'
+            : '当前应用仅限所有者（App Owner）使用。您没有权限发起授权，无法使用相关功能。',
       });
     }
     throw err;

--- a/tests/accounts-merge.test.ts
+++ b/tests/accounts-merge.test.ts
@@ -197,6 +197,27 @@ describe('mergeAccountConfig – deep merge for nested objects', () => {
     expect(account.config.allowFrom).toEqual(['*']);
   });
 
+  it('nested uat.allowedUsers arrays replace rather than merge', () => {
+    const cfg = makeCfg({
+      appId: 'base',
+      appSecret: 'secret',
+      uat: { ownerOnly: false, allowedUsers: ['ou_base_a', 'ou_base_b'] },
+      accounts: {
+        a: {
+          appId: 'a',
+          appSecret: 'sa',
+          uat: { allowedUsers: ['ou_account_only'] },
+        },
+      },
+    });
+
+    const account = getLarkAccount(cfg, 'a');
+    expect(account.config.uat).toEqual({
+      ownerOnly: false,
+      allowedUsers: ['ou_account_only'],
+    });
+  });
+
   it('scalar fields override correctly', () => {
     const cfg = makeCfg({
       appId: 'base',

--- a/tests/auth-command.test.ts
+++ b/tests/auth-command.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getTicketMock, getLarkAccountMock, getAppInfoMock, assertOwnerAccessStrictMock } = vi.hoisted(() => ({
+  getTicketMock: vi.fn(),
+  getLarkAccountMock: vi.fn(),
+  getAppInfoMock: vi.fn(),
+  assertOwnerAccessStrictMock: vi.fn(),
+}));
+
+vi.mock('../src/tools/onboarding-auth', () => ({
+  triggerOnboarding: vi.fn(),
+}));
+
+vi.mock('../src/core/lark-ticket', () => ({
+  getTicket: getTicketMock,
+}));
+
+vi.mock('../src/core/accounts', () => ({
+  getLarkAccount: getLarkAccountMock,
+}));
+
+vi.mock('../src/core/lark-client', () => ({
+  LarkClient: {
+    fromAccount: vi.fn(() => ({ sdk: {} })),
+  },
+}));
+
+vi.mock('../src/core/app-scope-checker', () => ({
+  getAppGrantedScopes: vi.fn(),
+  getAppInfo: getAppInfoMock,
+}));
+
+vi.mock('../src/core/token-store', () => ({
+  getStoredToken: vi.fn(),
+  tokenStatus: vi.fn(),
+}));
+
+vi.mock('../src/core/tool-scopes', () => ({
+  filterSensitiveScopes: vi.fn((scopes: string[]) => scopes),
+}));
+
+vi.mock('../src/core/domains', () => ({
+  openPlatformDomain: vi.fn(() => 'https://open.feishu.cn'),
+}));
+
+vi.mock('../src/core/owner-policy', () => {
+  class MockOwnerAccessDeniedError extends Error {
+    readonly userOpenId: string;
+    readonly appOwnerId: string;
+    readonly reason: 'strict' | 'not_in_allowlist';
+
+    constructor(userOpenId: string, appOwnerId: string, reason: 'strict' | 'not_in_allowlist') {
+      super('mock owner denied');
+      this.name = 'OwnerAccessDeniedError';
+      this.userOpenId = userOpenId;
+      this.appOwnerId = appOwnerId;
+      this.reason = reason;
+    }
+  }
+
+  return {
+    OwnerAccessDeniedError: MockOwnerAccessDeniedError,
+    assertOwnerAccessStrict: assertOwnerAccessStrictMock,
+  };
+});
+
+import { runFeishuAuthI18n } from '../src/commands/auth';
+import { OwnerAccessDeniedError } from '../src/core/owner-policy';
+
+describe('runFeishuAuthI18n owner denial messages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    getTicketMock.mockReturnValue({
+      senderOpenId: 'ou_user',
+      accountId: 'default',
+    });
+
+    getLarkAccountMock.mockReturnValue({
+      accountId: 'default',
+      enabled: true,
+      configured: true,
+      appId: 'cli_app',
+      appSecret: 'secret',
+      brand: 'feishu',
+      config: {},
+    });
+
+    getAppInfoMock.mockResolvedValue({ ok: true });
+  });
+
+  it('returns owner-only copy when strict mode denies access', async () => {
+    assertOwnerAccessStrictMock.mockRejectedValue(new OwnerAccessDeniedError('ou_user', 'ou_owner', 'strict'));
+
+    const result = await runFeishuAuthI18n({} as never);
+
+    expect(result.zh_cn).toContain('仅限应用 owner 执行');
+    expect(result.en_us).toContain('restricted to the app owner');
+  });
+
+  it('returns allowlist copy when user is not in uat.allowedUsers', async () => {
+    assertOwnerAccessStrictMock.mockRejectedValue(
+      new OwnerAccessDeniedError('ou_user', 'ou_owner', 'not_in_allowlist'),
+    );
+
+    const result = await runFeishuAuthI18n({} as never);
+
+    expect(result.zh_cn).toContain('授权用户列表');
+    expect(result.zh_cn).toContain('uat.allowedUsers');
+    expect(result.en_us).toContain('authorized user list');
+    expect(result.en_us).toContain('uat.allowedUsers');
+  });
+});

--- a/tests/owner-policy.test.ts
+++ b/tests/owner-policy.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ConfiguredLarkAccount } from '../src/core/types';
+
+const { getAppOwnerFallbackMock, warnMock } = vi.hoisted(() => ({
+  getAppOwnerFallbackMock: vi.fn(),
+  warnMock: vi.fn(),
+}));
+
+vi.mock('../src/core/app-owner-fallback', () => ({
+  getAppOwnerFallback: getAppOwnerFallbackMock,
+}));
+
+vi.mock('../src/core/lark-logger', () => ({
+  larkLogger: () => ({
+    info: vi.fn(),
+    warn: warnMock,
+    error: vi.fn(),
+  }),
+}));
+
+import { OwnerAccessDeniedError, assertOwnerAccessStrict } from '../src/core/owner-policy';
+
+function makeAccount(uat?: { ownerOnly?: boolean; allowedUsers?: string[] }): ConfiguredLarkAccount {
+  return {
+    accountId: 'default',
+    enabled: true,
+    configured: true,
+    appId: 'cli_app',
+    appSecret: 'secret',
+    brand: 'feishu',
+    config: {
+      appId: 'cli_app',
+      appSecret: 'secret',
+      uat,
+    } as ConfiguredLarkAccount['config'],
+  };
+}
+
+describe('assertOwnerAccessStrict', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects non-owner by default with strict reason', async () => {
+    getAppOwnerFallbackMock.mockResolvedValue('ou_owner');
+
+    await expect(assertOwnerAccessStrict(makeAccount(), {} as never, 'ou_user')).rejects.toMatchObject({
+      name: 'OwnerAccessDeniedError',
+      reason: 'strict',
+      userOpenId: 'ou_user',
+      appOwnerId: 'ou_owner',
+    } satisfies Partial<OwnerAccessDeniedError>);
+  });
+
+  it('short-circuits when ownerOnly is false and no allowlist is configured', async () => {
+    await expect(
+      assertOwnerAccessStrict(makeAccount({ ownerOnly: false }), {} as never, 'ou_any_user'),
+    ).resolves.toBeUndefined();
+
+    expect(getAppOwnerFallbackMock).not.toHaveBeenCalled();
+  });
+
+  it('allows allowlisted non-owner users when ownerOnly is false', async () => {
+    getAppOwnerFallbackMock.mockResolvedValue('ou_owner');
+
+    await expect(
+      assertOwnerAccessStrict(
+        makeAccount({ ownerOnly: false, allowedUsers: ['ou_allowed'] }),
+        {} as never,
+        'ou_allowed',
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(warnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects users outside uat.allowedUsers with not_in_allowlist reason', async () => {
+    getAppOwnerFallbackMock.mockResolvedValue('ou_owner');
+
+    await expect(
+      assertOwnerAccessStrict(
+        makeAccount({ ownerOnly: false, allowedUsers: ['ou_allowed'] }),
+        {} as never,
+        'ou_denied',
+      ),
+    ).rejects.toMatchObject({
+      name: 'OwnerAccessDeniedError',
+      reason: 'not_in_allowlist',
+      userOpenId: 'ou_denied',
+      appOwnerId: 'ou_owner',
+    } satisfies Partial<OwnerAccessDeniedError>);
+  });
+
+  it('falls back to pure allowlist when owner lookup fails in allowlist mode', async () => {
+    getAppOwnerFallbackMock.mockResolvedValue(undefined);
+
+    await expect(
+      assertOwnerAccessStrict(
+        makeAccount({ ownerOnly: false, allowedUsers: ['ou_allowed'] }),
+        {} as never,
+        'ou_allowed',
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(warnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed when owner lookup fails in strict mode', async () => {
+    getAppOwnerFallbackMock.mockResolvedValue(undefined);
+
+    await expect(assertOwnerAccessStrict(makeAccount(), {} as never, 'ou_user')).rejects.toMatchObject({
+      name: 'OwnerAccessDeniedError',
+      reason: 'strict',
+      userOpenId: 'ou_user',
+      appOwnerId: 'unknown',
+    } satisfies Partial<OwnerAccessDeniedError>);
+  });
+});


### PR DESCRIPTION
## Summary

Makes the previous “app owner only” OAuth / UAT policy configurable:

- Extends `UATConfigSchema` with `ownerOnly` and `allowedUsers`
- `owner-policy`: strict mode, allowlist, or relaxed when `ownerOnly` is false
- `/auth`, OAuth, and auto-auth: error messages reflect the denial reason
- Tests: owner-policy, auth-command, accounts-merge

<!-- Relates to / closes: (issue number if any) -->