### PR TITLE
fix(channel): enable session lookup for announce target in multi-account setups

### DIFF
--- a/src/channel/plugin.ts
+++ b/src/channel/plugin.ts
@@ -80,6 +80,7 @@ export const feishuPlugin: ChannelPlugin<LarkAccount> = {
 
   meta: {
     ...meta,
+    preferSessionLookupForAnnounceTarget: true,
   },
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

In multi-account Feishu configurations, `sessions_send` announce delivery fails because `resolveAnnounceTarget()` takes a fast path that parses the session key but omits `accountId`, causing the outbound path to fall through to the default account — which has no credentials when `appId`/`appSecret` are configured per-account only.

Error: `LarkClient[default]: appId and appSecret are required`

This adds `preferSessionLookupForAnnounceTarget: true` to the channel plugin meta so the session-store lookup path is used, which correctly resolves `accountId` from `deliveryContext`.

## Changes

One-line addition in `src/channel/plugin.ts`:

```diff
  meta: {
    ...meta,
+   preferSessionLookupForAnnounceTarget: true,
  },
```

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (0 errors; 21 pre-existing warnings unchanged)
- [x] `pnpm format:check` passes
- [x] `pnpm test` passes (17 test files, 153 tests)
- [x] Manual: verified on production multi-account Feishu setup — `sessions_send` announce delivery succeeds with correct account credentials