### PR TITLE
update task api

### DIFF
--- a/skills/feishu-task/SKILL.md
+++ b/skills/feishu-task/SKILL.md
@@ -8,7 +8,7 @@ description: |
   (2) 需要创建、管理任务清单
   (3) 需要查看任务列表或清单内的任务
   (4) 用户提到"任务"、"待办"、"to-do"、"清单"、"task"
-  (5) 需要设置任务负责人、关注人、截止时间
+  (5) 需要设置任务负责人、关注人、截止时间、添加成员
 ---
 
 # 飞书任务管理
@@ -16,6 +16,7 @@ description: |
 ## 🚨 执行前必读
 
 - ✅ **时间格式**：ISO 8601 / RFC 3339（带时区），例如 `2026-02-28T17:00:00+08:00`
+- ✅ **身份授权**：工具支持 `auth_type` 为 `tenant`（默认，应用身份）或 `user`（用户身份）。
 - ✅ **current_user_id 强烈建议**：从消息上下文的 SenderId 获取（ou_...），工具会自动添加为 follower（如不在 members 中），确保创建者可以编辑任务
 - ✅ **patch/get 必须**：task_guid
 - ✅ **tasklist.tasks 必须**：tasklist_guid
@@ -28,12 +29,13 @@ description: |
 
 | 用户意图 | 工具 | action | 必填参数 | 强烈建议 | 常用可选 |
 |---------|------|--------|---------|---------|---------|
-| 新建待办 | feishu_task_task | create | summary | current_user_id（SenderId） | members, due, description |
-| 查未完成任务 | feishu_task_task | list | - | completed=false | page_size |
-| 获取任务详情 | feishu_task_task | get | task_guid | - | - |
-| 完成任务 | feishu_task_task | patch | task_guid, completed_at | - | - |
-| 反完成任务 | feishu_task_task | patch | task_guid, completed_at="0" | - | - |
-| 改截止时间 | feishu_task_task | patch | task_guid, due | - | - |
+| 新建待办 | feishu_task_task | create | summary | current_user_id（SenderId） | members, due, description, auth_type |
+| 查未完成任务 | feishu_task_task | list | - | completed=false | page_size, auth_type |
+| 获取任务详情 | feishu_task_task | get | task_guid | - | auth_type |
+| 完成任务 | feishu_task_task | patch | task_guid, completed_at | - | auth_type |
+| 反完成任务 | feishu_task_task | patch | task_guid, completed_at="0" | - | auth_type |
+| 改截止时间 | feishu_task_task | patch | task_guid, due | - | auth_type |
+| 添加任务成员 | feishu_task_task | add_members | task_guid, members[] | - | auth_type |
 | 创建清单 | feishu_task_tasklist | create | name | - | members |
 | 查看清单任务 | feishu_task_tasklist | tasks | tasklist_guid | - | completed |
 | 添加清单成员 | feishu_task_tasklist | add_members | tasklist_guid, members[] | - | - |
@@ -42,38 +44,39 @@ description: |
 
 ## 🎯 核心约束（Schema 未透露的知识）
 
-### 1. 当前工具使用用户身份（已内置保护）
+### 1. 授权身份与可见性 (auth_type)
 
-**工具使用 `user_access_token`（用户身份）**
-
-这意味着：
-- ✅ 创建任务时可以指定任意成员（包括只分配给别人）
-- ⚠️ 只能查看和编辑**自己是成员的任务**
-- ⚠️ **如果创建时没把自己加入成员，后续无法编辑该任务**
+**工具支持两种调用身份 `auth_type`**：
+- **`tenant` (默认)**：应用身份（tenant_access_token）。通常推荐使用应用身份。如果创建的任务没有把用户加入成员，用户可能看不见。
+- **`user`**：用户身份（user_access_token）。用于需要严格代表用户操作或查询用户私有任务的场景。
+  - ⚠️ 使用 `user` 身份时，只能查看和编辑**自己是成员的任务**。
+  - ⚠️ **如果创建时没把自己加入成员，后续无法编辑该任务**。
 
 **自动保护机制**：
 - 传入 `current_user_id` 参数（从 SenderId 获取）
 - 如果 `members` 中不包含 `current_user_id`，工具会**自动添加为 follower**
-- 确保创建者始终可以编辑任务
+- 确保创建者始终可以编辑和查看任务
 
-**推荐用法**：创建任务时始终传 `current_user_id`，工具会自动处理成员关系。
+### 2. 任务成员的角色与类型
 
-### 2. 任务成员的角色说明
-
-- **assignee（负责人）**：负责完成任务，可以编辑任务
-- **follower（关注人）**：关注任务进展，接收通知
+- **角色 (role)**：
+  - **assignee（负责人）**：负责完成任务，可以编辑任务
+  - **follower（关注人）**：关注任务进展，接收通知
+- **类型 (type)**：
+  - **user（默认，用户）**：普通的飞书用户
+  - **app（应用/机器人）**：如果是把机器人自己或者其他应用加入任务，必须指定 `type: "app"`
 
 **添加成员示例**：
 ```json
 {
   "members": [
-    {"id": "ou_xxx", "role": "assignee"},  // 负责人
-    {"id": "ou_yyy", "role": "follower"}   // 关注人
+    {"id": "ou_xxx", "role": "assignee", "type": "user"},  // 负责人（用户）
+    {"id": "cli_yyy", "role": "follower", "type": "app"}   // 关注人（机器人/应用）
   ]
 }
 ```
 
-**说明**：`id` 使用用户的 `open_id`（从消息上下文的 SenderId 获取）
+**说明**：`id` 默认使用 `open_id`。
 
 ### 3. 任务清单角色冲突
 
@@ -133,12 +136,13 @@ description: |
   "summary": "准备周会材料",
   "description": "整理本周工作进展和下周计划",
   "current_user_id": "ou_发送者的open_id",
+  "auth_type": "tenant",
   "due": {
     "timestamp": "2026-02-28 17:00:00",
     "is_all_day": false
   },
   "members": [
-    {"id": "ou_协作者的open_id", "role": "assignee"}
+    {"id": "ou_协作者的open_id", "role": "assignee", "type": "user"}
   ]
 }
 ```
@@ -147,7 +151,7 @@ description: |
 - `summary` 是必填字段
 - `current_user_id` 强烈建议传入（从 SenderId 获取），工具会自动添加为 follower
 - `members` 可以只包含其他协作者，当前用户会被自动添加
-- 时间使用北京时间字符串格式
+- 时间使用带时区的 ISO 8601 格式
 
 ### 场景 2: 查询我负责的未完成任务
 
@@ -155,11 +159,25 @@ description: |
 {
   "action": "list",
   "completed": false,
-  "page_size": 20
+  "page_size": 20,
+  "auth_type": "user"
 }
 ```
 
-### 场景 3: 完成任务
+### 场景 3: 为现有任务添加机器人或成员
+
+```json
+{
+  "action": "add_members",
+  "task_guid": "任务的guid",
+  "auth_type": "tenant",
+  "members": [
+    {"id": "cli_机器人的app_id", "role": "follower", "type": "app"}
+  ]
+}
+```
+
+### 场景 4: 完成任务
 
 ```json
 {
@@ -169,7 +187,7 @@ description: |
 }
 ```
 
-### 场景 4: 反完成任务（恢复未完成状态）
+### 场景 5: 反完成任务（恢复未完成状态）
 
 ```json
 {
@@ -179,7 +197,7 @@ description: |
 }
 ```
 
-### 场景 5: 创建清单并添加协作者
+### 场景 6: 创建清单并添加协作者
 
 ```json
 {
@@ -192,7 +210,7 @@ description: |
 }
 ```
 
-### 场景 6: 查看清单内的未完成任务
+### 场景 7: 查看清单内的未完成任务
 
 ```json
 {
@@ -202,7 +220,7 @@ description: |
 }
 ```
 
-### 场景 7: 全天任务
+### 场景 8: 全天任务
 
 ```json
 {
@@ -222,10 +240,11 @@ description: |
 | 错误现象 | 根本原因 | 解决方案 |
 |---------|---------|---------|
 | **创建后无法编辑任务** | 创建时未将自己加入 members | 创建时至少将当前用户（SenderId）加为 assignee 或 follower |
-| **patch 失败提示 task_guid 缺失** | 未传 task_guid 参数 | patch/get 必须传 task_guid |
+| **patch 失败提示 task_guid 缺失** | 未传 task_guid 参数 | patch/get/add_members 必须传 task_guid |
 | **tasks 失败提示 tasklist_guid 缺失** | 未传 tasklist_guid 参数 | tasklist.tasks action 必须传 tasklist_guid |
 | **反完成失败** | completed_at 格式错误 | 使用 `"0"` 字符串，不是数字 0 |
 | **时间不对** | 使用了 Unix 时间戳 | 改用 ISO 8601 格式（带时区）：`2024-01-01T00:00:00+08:00` |
+| **添加机器人失败** | 未指定成员 type 为 app | 将机器人的 type 指定为 `"app"` |
 
 ---
 

--- a/skills/feishu-task/SKILL.md
+++ b/skills/feishu-task/SKILL.md
@@ -1,16 +1,15 @@
-***
-
+---
 name: feishu-task
 description: |
-飞书任务管理工具,用于创建、查询、更新任务和清单。
+  飞书任务管理工具,用于创建、查询、更新任务和清单。
 
-**当以下情况时使用此 Skill**:
-(1) 需要创建、查询、更新任务
-(2) 需要创建、管理任务清单
-(3) 需要查看任务列表或清单内的任务
-(4) 用户提到"任务"、"待办"、"to-do"、"清单"、"task"
-(5) 需要设置任务负责人、关注人、截止时间、添加成员
----------------------------
+  **当以下情况时使用此 Skill**:
+  (1) 需要创建、查询、更新任务
+  (2) 需要创建、管理任务清单
+  (3) 需要查看任务列表或清单内的任务
+  (4) 用户提到"任务"、"待办"、"to-do"、"清单"、"task"
+  (5) 需要设置任务负责人、关注人、截止时间、添加成员
+---
 
 # 飞书任务管理
 
@@ -18,44 +17,42 @@ description: |
 
 - ✅ **时间格式**：ISO 8601 / RFC 3339（带时区），例如 `2026-02-28T17:00:00+08:00`
 - ✅ **身份授权**：工具支持 `auth_type` 为 `user`（默认，用户身份）或 `tenant`（应用身份）。
-- ✅ **current\_user\_id 强烈建议**：从消息上下文的 SenderId 获取（ou\_...），工具会自动添加为 follower（如不在 members 中），确保创建者可以编辑任务
-- ✅ **patch/get 必须**：task\_guid
-- ✅ **tasklist.tasks 必须**：tasklist\_guid
-- ✅ **完成任务**：completed\_at = "2026-02-26 15:00:00"
-- ✅ **反完成（恢复未完成）**：completed\_at = "0"
+- ✅ **current_user_id 强烈建议**：从消息上下文的 SenderId 获取（ou_...），工具会自动添加为 follower（如不在 members 中），确保创建者可以编辑任务
+- ✅ **patch/get 必须**：task_guid
+- ✅ **tasklist.tasks 必须**：tasklist_guid
+- ✅ **完成任务**：completed_at = "2026-02-26 15:00:00"
+- ✅ **反完成（恢复未完成）**：completed_at = "0"
 
-***
+---
 
 ## 📋 快速索引：意图 → 工具 → 必填参数
 
-| 用户意图   | 工具                     | action       | 必填参数                          | 强烈建议                        | 常用可选                                  |
-| ------ | ---------------------- | ------------ | ----------------------------- | --------------------------- | ------------------------------------- |
-| 新建待办   | feishu\_task\_task     | create       | summary                       | current\_user\_id（SenderId） | members, due, description, auth\_type |
-| 查未完成任务 | feishu\_task\_task     | list         | -                             | completed=false             | page\_size, auth\_type                |
-| 获取任务详情 | feishu\_task\_task     | get          | task\_guid                    | -                           | auth\_type                            |
-| 完成任务   | feishu\_task\_task     | patch        | task\_guid, completed\_at     | -                           | auth\_type                            |
-| 反完成任务  | feishu\_task\_task     | patch        | task\_guid, completed\_at="0" | -                           | auth\_type                            |
-| 改截止时间  | feishu\_task\_task     | patch        | task\_guid, due               | -                           | auth\_type                            |
-| 添加任务成员 | feishu\_task\_task     | add\_members | task\_guid, members\[]        | -                           | auth\_type                            |
-| 创建清单   | feishu\_task\_tasklist | create       | name                          | -                           | members                               |
-| 查看清单任务 | feishu\_task\_tasklist | tasks        | tasklist\_guid                | -                           | completed                             |
-| 添加清单成员 | feishu\_task\_tasklist | add\_members | tasklist\_guid, members\[]    | -                           | -                                     |
+| 用户意图 | 工具 | action | 必填参数 | 强烈建议 | 常用可选 |
+|---------|------|--------|---------|---------|---------|
+| 新建待办 | feishu_task_task | create | summary | current_user_id（SenderId） | members, due, description, auth_type |
+| 查未完成任务 | feishu_task_task | list | - | completed=false | page_size, auth_type |
+| 获取任务详情 | feishu_task_task | get | task_guid | - | auth_type |
+| 完成任务 | feishu_task_task | patch | task_guid, completed_at | - | auth_type |
+| 反完成任务 | feishu_task_task | patch | task_guid, completed_at="0" | - | auth_type |
+| 改截止时间 | feishu_task_task | patch | task_guid, due | - | auth_type |
+| 添加任务成员 | feishu_task_task | add_members | task_guid, members[] | - | auth_type |
+| 创建清单 | feishu_task_tasklist | create | name | - | members |
+| 查看清单任务 | feishu_task_tasklist | tasks | tasklist_guid | - | completed |
+| 添加清单成员 | feishu_task_tasklist | add_members | tasklist_guid, members[] | - | - |
 
-***
+---
 
 ## 🎯 核心约束（Schema 未透露的知识）
 
-### 1. 授权身份与可见性 (auth\_type)
+### 1. 授权身份与可见性 (auth_type)
 
-**工具支持两种调用身份** **`auth_type`**：
-
-- **`tenant`**：应用身份（tenant\_access\_token）。通常推荐使用应用身份。如果创建的任务没有把用户加入成员，用户可能看不见。
-- **`user`** **(默认)**：用户身份（user\_access\_token）。用于需要严格代表用户操作或查询用户私有任务的场景。
+**工具支持两种调用身份 `auth_type`**：
+- **`user` (默认)**：用户身份（user_access_token）。用于需要严格代表用户操作或查询用户私有任务的场景。
   - ⚠️ 使用 `user` 身份时，只能查看和编辑**自己是成员的任务**。
   - ⚠️ **如果创建时没把自己加入成员，后续无法编辑该任务**。
+- **`tenant`**：应用身份（tenant_access_token）。当用户身份不满足要求时，使用应用身份。如果创建的任务没有把用户加入成员，用户可能看不见。
 
 **自动保护机制**：
-
 - 传入 `current_user_id` 参数（从 SenderId 获取）
 - 如果 `members` 中不包含 `current_user_id`，工具会**自动添加为 follower**
 - 确保创建者始终可以编辑和查看任务
@@ -70,7 +67,6 @@ description: |
   - **app（应用/机器人）**：如果是把机器人自己或者其他应用加入任务，必须指定 `type: "app"`
 
 **添加成员示例**：
-
 ```json
 {
   "members": [
@@ -90,10 +86,9 @@ description: |
 
 **建议**：不要在 `members` 中包含创建人，只添加其他协作成员
 
-### 4. completed\_at 的三种用法
+### 4. completed_at 的三种用法
 
 **1) 完成任务（设置完成时间）**：
-
 ```json
 {
   "action": "patch",
@@ -103,7 +98,6 @@ description: |
 ```
 
 **2) 反完成（恢复未完成状态）**：
-
 ```json
 {
   "action": "patch",
@@ -113,7 +107,6 @@ description: |
 ```
 
 **3) 毫秒时间戳**（不推荐，除非上层已严格生成）：
-
 ```json
 {
   "completed_at": "1740545400000"  // 毫秒时间戳字符串
@@ -122,16 +115,16 @@ description: |
 
 ### 5. 清单成员的角色
 
-| 成员类型     | 角色            | 说明           |
-| -------- | ------------- | ------------ |
-| user（用户） | owner         | 所有者，可转让所有权   |
-| user（用户） | editor        | 可编辑，可修改清单和任务 |
-| user（用户） | viewer        | 可查看，只读权限     |
-| chat（群组） | editor/viewer | 整个群组获得权限     |
+| 成员类型 | 角色 | 说明 |
+|---------|------|------|
+| user（用户） | owner | 所有者，可转让所有权 |
+| user（用户） | editor | 可编辑，可修改清单和任务 |
+| user（用户） | viewer | 可查看，只读权限 |
+| chat（群组） | editor/viewer | 整个群组获得权限 |
 
 **说明**：创建清单时，创建者自动成为 owner，无需在 members 中指定。
 
-***
+---
 
 ## 📌 使用场景示例
 
@@ -155,7 +148,6 @@ description: |
 ```
 
 **说明**：
-
 - `summary` 是必填字段
 - `current_user_id` 强烈建议传入（从 SenderId 获取），工具会自动添加为 follower
 - `members` 可以只包含其他协作者，当前用户会被自动添加
@@ -241,20 +233,20 @@ description: |
 }
 ```
 
-***
+---
 
 ## 🔍 常见错误与排查
 
-| 错误现象                             | 根本原因                 | 解决方案                                            |
-| -------------------------------- | -------------------- | ----------------------------------------------- |
-| **创建后无法编辑任务**                    | 创建时未将自己加入 members    | 创建时至少将当前用户（SenderId）加为 assignee 或 follower      |
-| **patch 失败提示 task\_guid 缺失**     | 未传 task\_guid 参数     | patch/get/add\_members 必须传 task\_guid           |
-| **tasks 失败提示 tasklist\_guid 缺失** | 未传 tasklist\_guid 参数 | tasklist.tasks action 必须传 tasklist\_guid        |
-| **反完成失败**                        | completed\_at 格式错误   | 使用 `"0"` 字符串，不是数字 0                             |
-| **时间不对**                         | 使用了 Unix 时间戳         | 改用 ISO 8601 格式（带时区）：`2024-01-01T00:00:00+08:00` |
-| **添加机器人失败**                      | 未指定成员 type 为 app     | 将机器人的 type 指定为 `"app"`                          |
+| 错误现象 | 根本原因 | 解决方案 |
+|---------|---------|---------|
+| **创建后无法编辑任务** | 创建时未将自己加入 members | 创建时至少将当前用户（SenderId）加为 assignee 或 follower |
+| **patch 失败提示 task_guid 缺失** | 未传 task_guid 参数 | patch/get/add_members 必须传 task_guid |
+| **tasks 失败提示 tasklist_guid 缺失** | 未传 tasklist_guid 参数 | tasklist.tasks action 必须传 tasklist_guid |
+| **反完成失败** | completed_at 格式错误 | 使用 `"0"` 字符串，不是数字 0 |
+| **时间不对** | 使用了 Unix 时间戳 | 改用 ISO 8601 格式（带时区）：`2024-01-01T00:00:00+08:00` |
+| **添加机器人失败** | 未指定成员 type 为 app | 将机器人的 type 指定为 `"app"` |
 
-***
+---
 
 ## 📚 附录：背景知识
 
@@ -271,7 +263,6 @@ description: |
 ```
 
 **核心概念**：
-
 - **任务（Task）**：独立的待办事项，有唯一的 `task_guid`
 - **清单（Tasklist）**：组织多个任务的容器，有唯一的 `tasklist_guid`
 - **负责人（assignee）**：可以编辑任务并标记完成
@@ -280,13 +271,12 @@ description: |
 
 ### B. 如何获取 GUID
 
-- **task\_guid**：创建任务后从返回值的 `task.guid` 获取，或通过 `list` 查询
-- **tasklist\_guid**：创建清单后从返回值的 `tasklist.guid` 获取，或通过 `list` 查询
+- **task_guid**：创建任务后从返回值的 `task.guid` 获取，或通过 `list` 查询
+- **tasklist_guid**：创建清单后从返回值的 `tasklist.guid` 获取，或通过 `list` 查询
 
 ### C. 如何将任务加入清单
 
 创建任务时指定 `tasklists` 参数：
-
 ```json
 {
   "action": "create",
@@ -303,7 +293,6 @@ description: |
 ### D. 重复任务如何创建
 
 使用 `repeat_rule` 参数，采用 RRULE 格式：
-
 ```json
 {
   "action": "create",
@@ -315,9 +304,9 @@ description: |
 
 **说明**：只有设置了截止时间的任务才能设置重复规则。
 
+
 ### E. 数据权限
 
 - 只能操作自己有权限的任务（作为成员的任务）
 - 只能操作自己有权限的清单（作为成员的清单）
 - 将任务加入清单需要同时拥有任务和清单的编辑权限
-

--- a/skills/feishu-task/SKILL.md
+++ b/skills/feishu-task/SKILL.md
@@ -1,58 +1,61 @@
----
+***
+
 name: feishu-task
 description: |
-  飞书任务管理工具,用于创建、查询、更新任务和清单。
+飞书任务管理工具,用于创建、查询、更新任务和清单。
 
-  **当以下情况时使用此 Skill**:
-  (1) 需要创建、查询、更新任务
-  (2) 需要创建、管理任务清单
-  (3) 需要查看任务列表或清单内的任务
-  (4) 用户提到"任务"、"待办"、"to-do"、"清单"、"task"
-  (5) 需要设置任务负责人、关注人、截止时间、添加成员
----
+**当以下情况时使用此 Skill**:
+(1) 需要创建、查询、更新任务
+(2) 需要创建、管理任务清单
+(3) 需要查看任务列表或清单内的任务
+(4) 用户提到"任务"、"待办"、"to-do"、"清单"、"task"
+(5) 需要设置任务负责人、关注人、截止时间、添加成员
+---------------------------
 
 # 飞书任务管理
 
 ## 🚨 执行前必读
 
 - ✅ **时间格式**：ISO 8601 / RFC 3339（带时区），例如 `2026-02-28T17:00:00+08:00`
-- ✅ **身份授权**：工具支持 `auth_type` 为 `tenant`（默认，应用身份）或 `user`（用户身份）。
-- ✅ **current_user_id 强烈建议**：从消息上下文的 SenderId 获取（ou_...），工具会自动添加为 follower（如不在 members 中），确保创建者可以编辑任务
-- ✅ **patch/get 必须**：task_guid
-- ✅ **tasklist.tasks 必须**：tasklist_guid
-- ✅ **完成任务**：completed_at = "2026-02-26 15:00:00"
-- ✅ **反完成（恢复未完成）**：completed_at = "0"
+- ✅ **身份授权**：工具支持 `auth_type` 为 `user`（默认，用户身份）或 `tenant`（应用身份）。
+- ✅ **current\_user\_id 强烈建议**：从消息上下文的 SenderId 获取（ou\_...），工具会自动添加为 follower（如不在 members 中），确保创建者可以编辑任务
+- ✅ **patch/get 必须**：task\_guid
+- ✅ **tasklist.tasks 必须**：tasklist\_guid
+- ✅ **完成任务**：completed\_at = "2026-02-26 15:00:00"
+- ✅ **反完成（恢复未完成）**：completed\_at = "0"
 
----
+***
 
 ## 📋 快速索引：意图 → 工具 → 必填参数
 
-| 用户意图 | 工具 | action | 必填参数 | 强烈建议 | 常用可选 |
-|---------|------|--------|---------|---------|---------|
-| 新建待办 | feishu_task_task | create | summary | current_user_id（SenderId） | members, due, description, auth_type |
-| 查未完成任务 | feishu_task_task | list | - | completed=false | page_size, auth_type |
-| 获取任务详情 | feishu_task_task | get | task_guid | - | auth_type |
-| 完成任务 | feishu_task_task | patch | task_guid, completed_at | - | auth_type |
-| 反完成任务 | feishu_task_task | patch | task_guid, completed_at="0" | - | auth_type |
-| 改截止时间 | feishu_task_task | patch | task_guid, due | - | auth_type |
-| 添加任务成员 | feishu_task_task | add_members | task_guid, members[] | - | auth_type |
-| 创建清单 | feishu_task_tasklist | create | name | - | members |
-| 查看清单任务 | feishu_task_tasklist | tasks | tasklist_guid | - | completed |
-| 添加清单成员 | feishu_task_tasklist | add_members | tasklist_guid, members[] | - | - |
+| 用户意图   | 工具                     | action       | 必填参数                          | 强烈建议                        | 常用可选                                  |
+| ------ | ---------------------- | ------------ | ----------------------------- | --------------------------- | ------------------------------------- |
+| 新建待办   | feishu\_task\_task     | create       | summary                       | current\_user\_id（SenderId） | members, due, description, auth\_type |
+| 查未完成任务 | feishu\_task\_task     | list         | -                             | completed=false             | page\_size, auth\_type                |
+| 获取任务详情 | feishu\_task\_task     | get          | task\_guid                    | -                           | auth\_type                            |
+| 完成任务   | feishu\_task\_task     | patch        | task\_guid, completed\_at     | -                           | auth\_type                            |
+| 反完成任务  | feishu\_task\_task     | patch        | task\_guid, completed\_at="0" | -                           | auth\_type                            |
+| 改截止时间  | feishu\_task\_task     | patch        | task\_guid, due               | -                           | auth\_type                            |
+| 添加任务成员 | feishu\_task\_task     | add\_members | task\_guid, members\[]        | -                           | auth\_type                            |
+| 创建清单   | feishu\_task\_tasklist | create       | name                          | -                           | members                               |
+| 查看清单任务 | feishu\_task\_tasklist | tasks        | tasklist\_guid                | -                           | completed                             |
+| 添加清单成员 | feishu\_task\_tasklist | add\_members | tasklist\_guid, members\[]    | -                           | -                                     |
 
----
+***
 
 ## 🎯 核心约束（Schema 未透露的知识）
 
-### 1. 授权身份与可见性 (auth_type)
+### 1. 授权身份与可见性 (auth\_type)
 
-**工具支持两种调用身份 `auth_type`**：
-- **`tenant` (默认)**：应用身份（tenant_access_token）。通常推荐使用应用身份。如果创建的任务没有把用户加入成员，用户可能看不见。
-- **`user`**：用户身份（user_access_token）。用于需要严格代表用户操作或查询用户私有任务的场景。
+**工具支持两种调用身份** **`auth_type`**：
+
+- **`tenant`**：应用身份（tenant\_access\_token）。通常推荐使用应用身份。如果创建的任务没有把用户加入成员，用户可能看不见。
+- **`user`** **(默认)**：用户身份（user\_access\_token）。用于需要严格代表用户操作或查询用户私有任务的场景。
   - ⚠️ 使用 `user` 身份时，只能查看和编辑**自己是成员的任务**。
   - ⚠️ **如果创建时没把自己加入成员，后续无法编辑该任务**。
 
 **自动保护机制**：
+
 - 传入 `current_user_id` 参数（从 SenderId 获取）
 - 如果 `members` 中不包含 `current_user_id`，工具会**自动添加为 follower**
 - 确保创建者始终可以编辑和查看任务
@@ -67,6 +70,7 @@ description: |
   - **app（应用/机器人）**：如果是把机器人自己或者其他应用加入任务，必须指定 `type: "app"`
 
 **添加成员示例**：
+
 ```json
 {
   "members": [
@@ -86,9 +90,10 @@ description: |
 
 **建议**：不要在 `members` 中包含创建人，只添加其他协作成员
 
-### 4. completed_at 的三种用法
+### 4. completed\_at 的三种用法
 
 **1) 完成任务（设置完成时间）**：
+
 ```json
 {
   "action": "patch",
@@ -98,6 +103,7 @@ description: |
 ```
 
 **2) 反完成（恢复未完成状态）**：
+
 ```json
 {
   "action": "patch",
@@ -107,6 +113,7 @@ description: |
 ```
 
 **3) 毫秒时间戳**（不推荐，除非上层已严格生成）：
+
 ```json
 {
   "completed_at": "1740545400000"  // 毫秒时间戳字符串
@@ -115,16 +122,16 @@ description: |
 
 ### 5. 清单成员的角色
 
-| 成员类型 | 角色 | 说明 |
-|---------|------|------|
-| user（用户） | owner | 所有者，可转让所有权 |
-| user（用户） | editor | 可编辑，可修改清单和任务 |
-| user（用户） | viewer | 可查看，只读权限 |
-| chat（群组） | editor/viewer | 整个群组获得权限 |
+| 成员类型     | 角色            | 说明           |
+| -------- | ------------- | ------------ |
+| user（用户） | owner         | 所有者，可转让所有权   |
+| user（用户） | editor        | 可编辑，可修改清单和任务 |
+| user（用户） | viewer        | 可查看，只读权限     |
+| chat（群组） | editor/viewer | 整个群组获得权限     |
 
 **说明**：创建清单时，创建者自动成为 owner，无需在 members 中指定。
 
----
+***
 
 ## 📌 使用场景示例
 
@@ -148,6 +155,7 @@ description: |
 ```
 
 **说明**：
+
 - `summary` 是必填字段
 - `current_user_id` 强烈建议传入（从 SenderId 获取），工具会自动添加为 follower
 - `members` 可以只包含其他协作者，当前用户会被自动添加
@@ -233,20 +241,20 @@ description: |
 }
 ```
 
----
+***
 
 ## 🔍 常见错误与排查
 
-| 错误现象 | 根本原因 | 解决方案 |
-|---------|---------|---------|
-| **创建后无法编辑任务** | 创建时未将自己加入 members | 创建时至少将当前用户（SenderId）加为 assignee 或 follower |
-| **patch 失败提示 task_guid 缺失** | 未传 task_guid 参数 | patch/get/add_members 必须传 task_guid |
-| **tasks 失败提示 tasklist_guid 缺失** | 未传 tasklist_guid 参数 | tasklist.tasks action 必须传 tasklist_guid |
-| **反完成失败** | completed_at 格式错误 | 使用 `"0"` 字符串，不是数字 0 |
-| **时间不对** | 使用了 Unix 时间戳 | 改用 ISO 8601 格式（带时区）：`2024-01-01T00:00:00+08:00` |
-| **添加机器人失败** | 未指定成员 type 为 app | 将机器人的 type 指定为 `"app"` |
+| 错误现象                             | 根本原因                 | 解决方案                                            |
+| -------------------------------- | -------------------- | ----------------------------------------------- |
+| **创建后无法编辑任务**                    | 创建时未将自己加入 members    | 创建时至少将当前用户（SenderId）加为 assignee 或 follower      |
+| **patch 失败提示 task\_guid 缺失**     | 未传 task\_guid 参数     | patch/get/add\_members 必须传 task\_guid           |
+| **tasks 失败提示 tasklist\_guid 缺失** | 未传 tasklist\_guid 参数 | tasklist.tasks action 必须传 tasklist\_guid        |
+| **反完成失败**                        | completed\_at 格式错误   | 使用 `"0"` 字符串，不是数字 0                             |
+| **时间不对**                         | 使用了 Unix 时间戳         | 改用 ISO 8601 格式（带时区）：`2024-01-01T00:00:00+08:00` |
+| **添加机器人失败**                      | 未指定成员 type 为 app     | 将机器人的 type 指定为 `"app"`                          |
 
----
+***
 
 ## 📚 附录：背景知识
 
@@ -263,6 +271,7 @@ description: |
 ```
 
 **核心概念**：
+
 - **任务（Task）**：独立的待办事项，有唯一的 `task_guid`
 - **清单（Tasklist）**：组织多个任务的容器，有唯一的 `tasklist_guid`
 - **负责人（assignee）**：可以编辑任务并标记完成
@@ -271,12 +280,13 @@ description: |
 
 ### B. 如何获取 GUID
 
-- **task_guid**：创建任务后从返回值的 `task.guid` 获取，或通过 `list` 查询
-- **tasklist_guid**：创建清单后从返回值的 `tasklist.guid` 获取，或通过 `list` 查询
+- **task\_guid**：创建任务后从返回值的 `task.guid` 获取，或通过 `list` 查询
+- **tasklist\_guid**：创建清单后从返回值的 `tasklist.guid` 获取，或通过 `list` 查询
 
 ### C. 如何将任务加入清单
 
 创建任务时指定 `tasklists` 参数：
+
 ```json
 {
   "action": "create",
@@ -293,6 +303,7 @@ description: |
 ### D. 重复任务如何创建
 
 使用 `repeat_rule` 参数，采用 RRULE 格式：
+
 ```json
 {
   "action": "create",
@@ -304,9 +315,9 @@ description: |
 
 **说明**：只有设置了截止时间的任务才能设置重复规则。
 
-
 ### E. 数据权限
 
 - 只能操作自己有权限的任务（作为成员的任务）
 - 只能操作自己有权限的清单（作为成员的清单）
 - 将任务加入清单需要同时拥有任务和清单的编辑权限
+

--- a/src/core/tool-scopes.ts
+++ b/src/core/tool-scopes.ts
@@ -138,6 +138,7 @@ export type ToolActionKey =
   | 'feishu_task_task.get'
   | 'feishu_task_task.list'
   | 'feishu_task_task.patch'
+  | 'feishu_task_task.add_members'
   | 'feishu_task_tasklist.add_members'
   | 'feishu_task_tasklist.create'
   | 'feishu_task_tasklist.get'
@@ -233,6 +234,7 @@ export const TOOL_SCOPES: ToolScopeMapping = {
   'feishu_task_task.get': ['task:task:read', 'task:task:write'],
   'feishu_task_task.list': ['task:task:read', 'task:task:write'],
   'feishu_task_task.patch': ['task:task:write', 'task:task:writeonly'],
+  'feishu_task_task.add_members': ['task:task:write', 'task:task:writeonly'],
   'feishu_task_tasklist.create': ['task:tasklist:write'],
   'feishu_task_tasklist.get': ['task:tasklist:read', 'task:tasklist:write'],
   'feishu_task_tasklist.list': ['task:tasklist:read', 'task:tasklist:write'],

--- a/src/tools/oapi/task/comment.ts
+++ b/src/tools/oapi/task/comment.ts
@@ -4,7 +4,7 @@
  *
  * feishu_task_comment tool -- Manage Feishu task comments.
  *
- * P1 Actions: create, list, get
+ * P1 Actions: create, list, get 支持通过 auth_type 参数切换用户(user)或应用(tenant)身份。
  *
  * Uses the Feishu Task v2 API:
  *   - create: POST /open-apis/task/v2/tasks/:task_guid/comments
@@ -22,7 +22,15 @@ import type { PaginatedData } from '../sdk-types';
 // Schema
 // ---------------------------------------------------------------------------
 
-const FeishuTaskCommentSchema = Type.Union([
+const FeishuTaskCommentSchema = Type.Intersect([
+  Type.Object({
+    auth_type: Type.Optional(
+      StringEnum(['tenant', 'user'], {
+        description: '调用 API 时使用的 Token 类型。可选值："tenant"（应用身份） 或 "user"（用户身份）。默认使用 "tenant"。',
+      }),
+    ),
+  }),
+  Type.Union([
   // CREATE (P1)
   Type.Object({
     action: Type.Literal('create'),
@@ -49,13 +57,14 @@ const FeishuTaskCommentSchema = Type.Union([
     action: Type.Literal('get'),
     comment_id: Type.String({ description: '评论 ID' }),
   }),
+  ])
 ]);
 
 // ---------------------------------------------------------------------------
 // Params type
 // ---------------------------------------------------------------------------
 
-type FeishuTaskCommentParams =
+type FeishuTaskCommentParams = { auth_type?: 'tenant' | 'user' } & (
   | {
       action: 'create';
       task_guid: string;
@@ -72,7 +81,8 @@ type FeishuTaskCommentParams =
   | {
       action: 'get';
       comment_id: string;
-    };
+      }
+);
 
 // ---------------------------------------------------------------------------
 // Registration
@@ -90,7 +100,7 @@ export function registerFeishuTaskCommentTool(api: OpenClawPluginApi): void {
       name: 'feishu_task_comment',
       label: 'Feishu Task Comments',
       description:
-        '【以用户身份】飞书任务评论管理工具。当用户要求添加/查询任务评论、回复评论时使用。Actions: create（添加评论）, list（列出任务的所有评论）, get（获取单个评论详情）。',
+        '【以用户或应用身份】飞书任务评论管理工具。当用户要求添加/查询任务评论、回复评论时使用。Actions: create（添加评论）, list（列出任务的所有评论）, get（获取单个评论详情）。',
       parameters: FeishuTaskCommentSchema,
       async execute(_toolCallId, params) {
         const p = params as FeishuTaskCommentParams;
@@ -129,7 +139,7 @@ export function registerFeishuTaskCommentTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: 'user' },
+                { as: p.auth_type || 'tenant' },
               );
               assertLarkOk(res);
 
@@ -165,7 +175,7 @@ export function registerFeishuTaskCommentTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: 'user' },
+                { as: p.auth_type || 'tenant' },
               );
               assertLarkOk(res);
 
@@ -200,7 +210,7 @@ export function registerFeishuTaskCommentTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: 'user' },
+                { as: p.auth_type || 'tenant' },
               );
               assertLarkOk(res);
 

--- a/src/tools/oapi/task/comment.ts
+++ b/src/tools/oapi/task/comment.ts
@@ -26,7 +26,7 @@ const FeishuTaskCommentSchema = Type.Intersect([
   Type.Object({
     auth_type: Type.Optional(
       StringEnum(['tenant', 'user'], {
-        description: '调用 API 时使用的 Token 类型。可选值："tenant"（应用身份） 或 "user"（用户身份）。默认使用 "tenant"。',
+        description: '调用 API 时使用的 Token 类型。可选值："tenant"（应用身份） 或 "user"（用户身份）。默认使用 "user"。',
       }),
     ),
   }),
@@ -139,7 +139,7 @@ export function registerFeishuTaskCommentTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: p.auth_type || 'tenant' },
+                { as: p.auth_type || 'user' },
               );
               assertLarkOk(res);
 
@@ -175,7 +175,7 @@ export function registerFeishuTaskCommentTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: p.auth_type || 'tenant' },
+                { as: p.auth_type || 'user' },
               );
               assertLarkOk(res);
 
@@ -210,7 +210,7 @@ export function registerFeishuTaskCommentTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: p.auth_type || 'tenant' },
+                { as: p.auth_type || 'user' },
               );
               assertLarkOk(res);
 

--- a/src/tools/oapi/task/section.ts
+++ b/src/tools/oapi/task/section.ts
@@ -28,7 +28,7 @@ const FeishuTaskSectionSchema = Type.Intersect([
   Type.Object({
     auth_type: Type.Optional(
       StringEnum(['tenant', 'user'], {
-        description: '调用 API 时使用的 Token 类型。可选值："tenant"（应用身份） 或 "user"（用户身份）。默认使用 "tenant"。',
+        description: '调用 API 时使用的 Token 类型。可选值："tenant"（应用身份） 或 "user"（用户身份）。默认使用 "user"。',
       }),
     ),
   }),
@@ -247,7 +247,7 @@ export function registerFeishuTaskSectionTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: p.auth_type || 'tenant' },
+                { as: p.auth_type || 'user' },
               );
               assertLarkOk(res);
 
@@ -276,7 +276,7 @@ export function registerFeishuTaskSectionTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: p.auth_type || 'tenant' },
+                { as: p.auth_type || 'user' },
               );
               assertLarkOk(res);
 
@@ -331,7 +331,7 @@ export function registerFeishuTaskSectionTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: p.auth_type || 'tenant' },
+                { as: p.auth_type || 'user' },
               );
               assertLarkOk(res);
 
@@ -366,7 +366,7 @@ export function registerFeishuTaskSectionTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: p.auth_type || 'tenant' },
+                { as: p.auth_type || 'user' },
               );
               assertLarkOk(res);
 
@@ -415,7 +415,7 @@ export function registerFeishuTaskSectionTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: p.auth_type || 'tenant' },
+                { as: p.auth_type || 'user' },
               );
               assertLarkOk(res);
 

--- a/src/tools/oapi/task/section.ts
+++ b/src/tools/oapi/task/section.ts
@@ -4,7 +4,7 @@
  *
  * feishu_task_section tool -- Manage Feishu task sections.
  *
- * P0 Actions: create, get, list, patch, tasks
+ * P0 Actions: create, get, list, patch, tasks 支持通过 auth_type 参数切换用户(user)或应用(tenant)身份。
  *
  * Uses the Feishu Task v2 API:
  *   - create: POST /open-apis/task/v2/sections
@@ -24,7 +24,15 @@ import type { PaginatedData } from '../sdk-types';
 // Schema
 // ---------------------------------------------------------------------------
 
-const FeishuTaskSectionSchema = Type.Union([
+const FeishuTaskSectionSchema = Type.Intersect([
+  Type.Object({
+    auth_type: Type.Optional(
+      StringEnum(['tenant', 'user'], {
+        description: '调用 API 时使用的 Token 类型。可选值："tenant"（应用身份） 或 "user"（用户身份）。默认使用 "tenant"。',
+      }),
+    ),
+  }),
+  Type.Union([
   // CREATE
   Type.Object({
     action: Type.Literal('create'),
@@ -138,13 +146,14 @@ const FeishuTaskSectionSchema = Type.Union([
     ),
     user_id_type: Type.Optional(StringEnum(['open_id', 'union_id', 'user_id'])),
   }),
+  ])
 ]);
 
 // ---------------------------------------------------------------------------
 // Params type
 // ---------------------------------------------------------------------------
 
-type FeishuTaskSectionParams =
+type FeishuTaskSectionParams = { auth_type?: 'tenant' | 'user' } & (
   | {
       action: 'create';
       name: string;
@@ -184,7 +193,8 @@ type FeishuTaskSectionParams =
       created_from?: string;
       created_to?: string;
       user_id_type?: 'open_id' | 'union_id' | 'user_id';
-    };
+      }
+);
 
 // ---------------------------------------------------------------------------
 // Registration
@@ -202,7 +212,7 @@ export function registerFeishuTaskSectionTool(api: OpenClawPluginApi): void {
       name: 'feishu_task_section',
       label: 'Feishu Task Section Management',
       description:
-        '【以用户身份】飞书任务自定义分组管理工具。用于创建、查询、更新自定义分组，以及列出分组内的任务。Actions: create（创建分组）, get（获取分组详情）, patch（更新分组）, list（获取分组列表）, tasks（获取分组任务列表）。',
+        '【以用户或应用身份】飞书任务自定义分组管理工具。用于创建、查询、更新自定义分组，以及列出分组内的任务。Actions: create（创建分组）, get（获取分组详情）, patch（更新分组）, list（获取分组列表）, tasks（获取分组任务列表）。',
       parameters: FeishuTaskSectionSchema,
       async execute(_toolCallId: string, params: unknown) {
         const p = params as FeishuTaskSectionParams;
@@ -237,7 +247,7 @@ export function registerFeishuTaskSectionTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: 'user' },
+                { as: p.auth_type || 'tenant' },
               );
               assertLarkOk(res);
 
@@ -266,7 +276,7 @@ export function registerFeishuTaskSectionTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: 'user' },
+                { as: p.auth_type || 'tenant' },
               );
               assertLarkOk(res);
 
@@ -321,7 +331,7 @@ export function registerFeishuTaskSectionTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: 'user' },
+                { as: p.auth_type || 'tenant' },
               );
               assertLarkOk(res);
 
@@ -356,7 +366,7 @@ export function registerFeishuTaskSectionTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: 'user' },
+                { as: p.auth_type || 'tenant' },
               );
               assertLarkOk(res);
 
@@ -405,7 +415,7 @@ export function registerFeishuTaskSectionTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: 'user' },
+                { as: p.auth_type || 'tenant' },
               );
               assertLarkOk(res);
 

--- a/src/tools/oapi/task/subtask.ts
+++ b/src/tools/oapi/task/subtask.ts
@@ -4,7 +4,7 @@
  *
  * feishu_task_subtask tool -- Manage Feishu task subtasks.
  *
- * P1 Actions: create, list
+ * P1 Actions: create, list 支持通过 auth_type 参数切换用户(user)或应用(tenant)身份。
  *
  * Uses the Feishu Task v2 API:
  *   - create: POST /open-apis/task/v2/tasks/:task_guid/subtasks
@@ -29,7 +29,15 @@ import type { PaginatedData } from '../sdk-types';
 // Schema
 // ---------------------------------------------------------------------------
 
-const FeishuTaskSubtaskSchema = Type.Union([
+const FeishuTaskSubtaskSchema = Type.Intersect([
+  Type.Object({
+    auth_type: Type.Optional(
+      StringEnum(['tenant', 'user'], {
+        description: '调用 API 时使用的 Token 类型。可选值："tenant"（应用身份） 或 "user"（用户身份）。默认使用 "tenant"。',
+      }),
+    ),
+  }),
+  Type.Union([
   // CREATE (P1)
   Type.Object({
     action: Type.Literal('create'),
@@ -55,7 +63,8 @@ const FeishuTaskSubtaskSchema = Type.Union([
     members: Type.Optional(
       Type.Array(
         Type.Object({
-          id: Type.String({ description: '成员 open_id' }),
+          id: Type.String({ description: '成员 ID（通常为 open_id）' }),
+          type: Type.Optional(StringEnum(['user', 'app'])),
           role: Type.Optional(StringEnum(['assignee', 'follower'])),
         }),
         { description: '子任务成员列表（assignee=负责人，follower=关注人）' },
@@ -70,13 +79,14 @@ const FeishuTaskSubtaskSchema = Type.Union([
     page_size: Type.Optional(Type.Number({ description: '每页数量，默认 50，最大 100' })),
     page_token: Type.Optional(Type.String({ description: '分页标记' })),
   }),
+  ])
 ]);
 
 // ---------------------------------------------------------------------------
 // Params type
 // ---------------------------------------------------------------------------
 
-type FeishuTaskSubtaskParams =
+type FeishuTaskSubtaskParams = { auth_type?: 'tenant' | 'user' } & (
   | {
       action: 'create';
       task_guid: string;
@@ -84,14 +94,17 @@ type FeishuTaskSubtaskParams =
       description?: string;
       due?: { timestamp: string; is_all_day?: boolean };
       start?: { timestamp: string; is_all_day?: boolean };
-      members?: Array<{ id: string; role?: string }>;
+      members?: Array<{ id: string;
+        type?: 'user' | 'app';
+        role?: string }>;
     }
   | {
       action: 'list';
       task_guid: string;
       page_size?: number;
       page_token?: string;
-    };
+      }
+);
 
 // ---------------------------------------------------------------------------
 // Registration
@@ -109,7 +122,7 @@ export function registerFeishuTaskSubtaskTool(api: OpenClawPluginApi): void {
       name: 'feishu_task_subtask',
       label: 'Feishu Task Subtasks',
       description:
-        '【以用户身份】飞书任务的子任务管理工具。当用户要求创建子任务、查询任务的子任务列表时使用。Actions: create（创建子任务）, list（列出任务的所有子任务）。',
+        '【以用户或应用身份】飞书任务的子任务管理工具。当用户要求创建子任务、查询任务的子任务列表时使用。Actions: create（创建子任务）, list（列出任务的所有子任务）。',
       parameters: FeishuTaskSubtaskSchema,
       async execute(_toolCallId, params) {
         const p = params as FeishuTaskSubtaskParams;
@@ -165,7 +178,7 @@ export function registerFeishuTaskSubtaskTool(api: OpenClawPluginApi): void {
               if (p.members && p.members.length > 0) {
                 data.members = p.members.map((m) => ({
                   id: m.id,
-                  type: 'user',
+                  type: m.type || 'user',
                   role: m.role || 'assignee',
                 }));
               }
@@ -186,7 +199,7 @@ export function registerFeishuTaskSubtaskTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: 'user' },
+                { as: p.auth_type || 'tenant' },
               );
               assertLarkOk(res);
 
@@ -220,7 +233,7 @@ export function registerFeishuTaskSubtaskTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: 'user' },
+                { as: p.auth_type || 'tenant' },
               );
               assertLarkOk(res);
 

--- a/src/tools/oapi/task/subtask.ts
+++ b/src/tools/oapi/task/subtask.ts
@@ -33,7 +33,7 @@ const FeishuTaskSubtaskSchema = Type.Intersect([
   Type.Object({
     auth_type: Type.Optional(
       StringEnum(['tenant', 'user'], {
-        description: '调用 API 时使用的 Token 类型。可选值："tenant"（应用身份） 或 "user"（用户身份）。默认使用 "tenant"。',
+        description: '调用 API 时使用的 Token 类型。可选值："tenant"（应用身份） 或 "user"（用户身份）。默认使用 "user"。',
       }),
     ),
   }),
@@ -199,7 +199,7 @@ export function registerFeishuTaskSubtaskTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: p.auth_type || 'tenant' },
+                { as: p.auth_type || 'user' },
               );
               assertLarkOk(res);
 
@@ -233,7 +233,7 @@ export function registerFeishuTaskSubtaskTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: p.auth_type || 'tenant' },
+                { as: p.auth_type || 'user' },
               );
               assertLarkOk(res);
 

--- a/src/tools/oapi/task/task.ts
+++ b/src/tools/oapi/task/task.ts
@@ -5,12 +5,14 @@
  * feishu_task_task tool -- Manage Feishu tasks.
  *
  * P0 Actions: create, get, list, patch
+ * P1 Actions: add_members
  *
  * Uses the Feishu Task v2 API:
  *   - create: POST /open-apis/task/v2/tasks
  *   - get:    GET  /open-apis/task/v2/tasks/:task_guid
  *   - list:   GET  /open-apis/task/v2/tasks
  *   - patch:  PATCH /open-apis/task/v2/tasks/:task_guid
+ *   - add_members: POST /open-apis/task/v2/tasks/:task_guid/add_members
  */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -77,12 +79,14 @@ const FeishuTaskTaskSchema = Type.Union([
       Type.Array(
         Type.Object({
           id: Type.String({
-            description: '成员 open_id',
+            description: '成员 ID（通常为 open_id）',
           }),
+          type: Type.Optional(StringEnum(['user', 'app'])),
           role: Type.Optional(StringEnum(['assignee', 'follower'])),
         }),
         {
-          description: '任务成员列表（assignee=负责人，follower=关注人）',
+          description:
+            '任务成员列表（assignee=负责人，follower=关注人）。成员类型（type）支持 user 和 app，默认为 user。机器人和应用应该使用app',
         },
       ),
     ),
@@ -108,6 +112,12 @@ const FeishuTaskTaskSchema = Type.Union([
         },
       ),
     ),
+    auth_type: Type.Optional(
+      StringEnum(['tenant', 'user'], {
+        description:
+          '授权类型，默认 tenant。使用 user 时为用户身份（只能查看/操作自己有权限的任务），使用 tenant 时为应用身份。',
+      }),
+    ),
     user_id_type: Type.Optional(
       StringEnum(['open_id', 'union_id', 'user_id']),
     ),
@@ -119,6 +129,11 @@ const FeishuTaskTaskSchema = Type.Union([
     task_guid: Type.String({
       description: 'Task GUID',
     }),
+    auth_type: Type.Optional(
+      StringEnum(['tenant', 'user'], {
+        description: '授权类型，默认 tenant。',
+      }),
+    ),
     user_id_type: Type.Optional(
       StringEnum(['open_id', 'union_id', 'user_id']),
     ),
@@ -140,6 +155,11 @@ const FeishuTaskTaskSchema = Type.Union([
     completed: Type.Optional(
       Type.Boolean({
         description: '是否筛选已完成任务',
+      }),
+    ),
+    auth_type: Type.Optional(
+      StringEnum(['tenant', 'user'], {
+        description: '授权类型，默认 tenant。',
       }),
     ),
     user_id_type: Type.Optional(
@@ -197,18 +217,58 @@ const FeishuTaskTaskSchema = Type.Union([
       Type.Array(
         Type.Object({
           id: Type.String({
-            description: '成员 open_id',
+            description: '成员 ID（通常为 open_id）',
           }),
+          type: Type.Optional(StringEnum(['user', 'app'])),
           role: Type.Optional(StringEnum(['assignee', 'follower'])),
         }),
         {
-          description: '新的任务成员列表',
+          description: '新的任务成员列表。成员类型支持 user 和 app，默认为 user。',
         },
       ),
     ),
     repeat_rule: Type.Optional(
       Type.String({
         description: '新的重复规则（RRULE 格式）',
+      }),
+    ),
+    auth_type: Type.Optional(
+      StringEnum(['tenant', 'user'], {
+        description: '授权类型，默认 tenant。',
+      }),
+    ),
+    user_id_type: Type.Optional(
+      StringEnum(['open_id', 'union_id', 'user_id']),
+    ),
+  }),
+
+  // ADD_MEMBERS
+  Type.Object({
+    action: Type.Literal('add_members'),
+    task_guid: Type.String({
+      description: 'Task GUID',
+    }),
+    members: Type.Array(
+      Type.Object({
+        id: Type.String({
+          description: '成员 ID（通常为 open_id）',
+        }),
+        type: Type.Optional(StringEnum(['user', 'app'])),
+        role: Type.Optional(StringEnum(['assignee', 'follower'])),
+      }),
+      {
+        description:
+          '要添加的成员列表（assignee=负责人，follower=关注人）。成员类型支持 user 和 app，默认为 user。',
+      },
+    ),
+    client_token: Type.Optional(
+      Type.String({
+        description: '幂等token，如果提供则实现幂等行为',
+      }),
+    ),
+    auth_type: Type.Optional(
+      StringEnum(['tenant', 'user'], {
+        description: '授权类型，默认 tenant。',
       }),
     ),
     user_id_type: Type.Optional(
@@ -237,6 +297,7 @@ type FeishuTaskTaskParams =
       };
       members?: Array<{
         id: string;
+        type?: 'user' | 'app';
         role?: 'assignee' | 'follower';
       }>;
       repeat_rule?: string;
@@ -244,11 +305,13 @@ type FeishuTaskTaskParams =
         tasklist_guid: string;
         section_guid?: string;
       }>;
+      auth_type?: 'tenant' | 'user';
       user_id_type?: 'open_id' | 'union_id' | 'user_id';
     }
   | {
       action: 'get';
       task_guid: string;
+      auth_type?: 'tenant' | 'user';
       user_id_type?: 'open_id' | 'union_id' | 'user_id';
     }
   | {
@@ -256,6 +319,7 @@ type FeishuTaskTaskParams =
       page_size?: number;
       page_token?: string;
       completed?: boolean;
+      auth_type?: 'tenant' | 'user';
       user_id_type?: 'open_id' | 'union_id' | 'user_id';
     }
   | {
@@ -274,9 +338,23 @@ type FeishuTaskTaskParams =
       completed_at?: string;
       members?: Array<{
         id: string;
+        type?: 'user' | 'app';
         role?: 'assignee' | 'follower';
       }>;
       repeat_rule?: string;
+      auth_type?: 'tenant' | 'user';
+      user_id_type?: 'open_id' | 'union_id' | 'user_id';
+    }
+  | {
+      action: 'add_members';
+      task_guid: string;
+      members: Array<{
+        id: string;
+        type?: 'user' | 'app';
+        role?: 'assignee' | 'follower';
+      }>;
+      client_token?: string;
+      auth_type?: 'tenant' | 'user';
       user_id_type?: 'open_id' | 'union_id' | 'user_id';
     };
 
@@ -296,7 +374,7 @@ export function registerFeishuTaskTaskTool(api: OpenClawPluginApi): void {
       name: 'feishu_task_task',
       label: 'Feishu Task Management',
       description:
-        "【以用户身份】飞书任务管理工具。用于创建、查询、更新任务。Actions: create（创建任务）, get（获取任务详情）, list（查询任务列表，仅返回我负责的任务）, patch（更新任务）。时间参数使用ISO 8601 / RFC 3339 格式（包含时区），例如 '2024-01-01T00:00:00+08:00'。",
+        "【以用户或应用身份】飞书任务管理工具。用于创建、查询、更新任务。Actions: create（创建任务）, get（获取任务详情）, list（查询任务列表，仅返回我负责的任务）, patch（更新任务）, add_members（添加任务成员）。时间参数使用ISO 8601 / RFC 3339 格式（包含时区），例如 '2024-01-01T00:00:00+08:00'。支持通过 auth_type 参数切换用户(user)或应用(tenant)身份。",
       parameters: FeishuTaskTaskSchema,
       async execute(_toolCallId: string, params: unknown) {
         const p = params as FeishuTaskTaskParams;
@@ -353,6 +431,7 @@ export function registerFeishuTaskTaskTool(api: OpenClawPluginApi): void {
               if (p.repeat_rule) taskData.repeat_rule = p.repeat_rule;
               if (p.tasklists) taskData.tasklists = p.tasklists;
 
+              const authType = p.auth_type || 'tenant';
               const res = await client.invoke(
                 'feishu_task_task.create',
                 (sdk, opts) =>
@@ -365,7 +444,7 @@ export function registerFeishuTaskTaskTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: 'user' },
+                { as: authType },
               );
               assertLarkOk(res);
 
@@ -383,6 +462,7 @@ export function registerFeishuTaskTaskTool(api: OpenClawPluginApi): void {
             case 'get': {
               log.info(`get: task_guid=${p.task_guid}`);
 
+              const authType = p.auth_type || 'tenant';
               const res = await client.invoke(
                 'feishu_task_task.get',
                 (sdk, opts) =>
@@ -395,7 +475,7 @@ export function registerFeishuTaskTaskTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: 'user' },
+                { as: authType },
               );
               assertLarkOk(res);
 
@@ -412,6 +492,7 @@ export function registerFeishuTaskTaskTool(api: OpenClawPluginApi): void {
             case 'list': {
               log.info(`list: page_size=${p.page_size ?? 50}, completed=${p.completed ?? false}`);
 
+              const authType = p.auth_type || 'tenant';
               const res = await client.invoke(
                 'feishu_task_task.list',
                 (sdk, opts) =>
@@ -426,7 +507,7 @@ export function registerFeishuTaskTaskTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: 'user' },
+                { as: authType },
               );
               assertLarkOk(res);
 
@@ -513,6 +594,7 @@ export function registerFeishuTaskTaskTool(api: OpenClawPluginApi): void {
               // Build update_fields list (required by Task API)
               const updateFields = Object.keys(updateData);
 
+              const authType = p.auth_type || 'tenant';
               const res = await client.invoke(
                 'feishu_task_task.patch',
                 (sdk, opts) =>
@@ -529,11 +611,61 @@ export function registerFeishuTaskTaskTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: 'user' },
+                { as: authType },
               );
               assertLarkOk(res);
 
               log.info(`patch: task ${p.task_guid} updated`);
+
+              return json({
+                task: res.data?.task,
+              });
+            }
+
+            // -----------------------------------------------------------------
+            // ADD_MEMBERS
+            // -----------------------------------------------------------------
+            case 'add_members': {
+              if (!p.members || p.members.length === 0) {
+                return json({
+                  error: 'members is required and cannot be empty',
+                });
+              }
+
+              log.info(`add_members: task_guid=${p.task_guid}, members_count=${p.members.length}`);
+
+              const memberData = p.members.map((m) => ({
+                id: m.id,
+                type: m.type || 'user',
+                role: m.role || 'follower',
+              }));
+
+              const requestData: any = { members: memberData };
+              if (p.client_token) {
+                requestData.client_token = p.client_token;
+              }
+
+              const authType = p.auth_type || 'tenant';
+              const res = await client.invoke(
+                'feishu_task_task.add_members',
+                (sdk, opts) =>
+                  sdk.task.v2.task.addMembers(
+                    {
+                      path: {
+                        task_guid: p.task_guid,
+                      },
+                      params: {
+                        user_id_type: (p.user_id_type || 'open_id') as any,
+                      },
+                      data: requestData,
+                    },
+                    opts,
+                  ),
+                { as: authType },
+              );
+              assertLarkOk(res);
+
+              log.info(`add_members: added ${p.members.length} members to task ${p.task_guid}`);
 
               return json({
                 task: res.data?.task,
@@ -547,5 +679,4 @@ export function registerFeishuTaskTaskTool(api: OpenClawPluginApi): void {
     },
     { name: 'feishu_task_task' },
   );
-
 }

--- a/src/tools/oapi/task/task.ts
+++ b/src/tools/oapi/task/task.ts
@@ -115,7 +115,7 @@ const FeishuTaskTaskSchema = Type.Union([
     auth_type: Type.Optional(
       StringEnum(['tenant', 'user'], {
         description:
-          '授权类型，默认 tenant。使用 user 时为用户身份（只能查看/操作自己有权限的任务），使用 tenant 时为应用身份。',
+          '授权类型，默认 user。使用 user 时为用户身份（只能查看/操作自己有权限的任务），使用 tenant 时为应用身份。',
       }),
     ),
     user_id_type: Type.Optional(
@@ -131,7 +131,7 @@ const FeishuTaskTaskSchema = Type.Union([
     }),
     auth_type: Type.Optional(
       StringEnum(['tenant', 'user'], {
-        description: '授权类型，默认 tenant。',
+        description: '授权类型，默认 user。',
       }),
     ),
     user_id_type: Type.Optional(
@@ -159,7 +159,7 @@ const FeishuTaskTaskSchema = Type.Union([
     ),
     auth_type: Type.Optional(
       StringEnum(['tenant', 'user'], {
-        description: '授权类型，默认 tenant。',
+        description: '授权类型，默认 user。',
       }),
     ),
     user_id_type: Type.Optional(
@@ -234,7 +234,7 @@ const FeishuTaskTaskSchema = Type.Union([
     ),
     auth_type: Type.Optional(
       StringEnum(['tenant', 'user'], {
-        description: '授权类型，默认 tenant。',
+        description: '授权类型，默认 user。',
       }),
     ),
     user_id_type: Type.Optional(
@@ -268,7 +268,7 @@ const FeishuTaskTaskSchema = Type.Union([
     ),
     auth_type: Type.Optional(
       StringEnum(['tenant', 'user'], {
-        description: '授权类型，默认 tenant。',
+        description: '授权类型，默认 user。',
       }),
     ),
     user_id_type: Type.Optional(
@@ -431,7 +431,7 @@ export function registerFeishuTaskTaskTool(api: OpenClawPluginApi): void {
               if (p.repeat_rule) taskData.repeat_rule = p.repeat_rule;
               if (p.tasklists) taskData.tasklists = p.tasklists;
 
-              const authType = p.auth_type || 'tenant';
+              const authType = p.auth_type || 'user';
               const res = await client.invoke(
                 'feishu_task_task.create',
                 (sdk, opts) =>
@@ -462,7 +462,7 @@ export function registerFeishuTaskTaskTool(api: OpenClawPluginApi): void {
             case 'get': {
               log.info(`get: task_guid=${p.task_guid}`);
 
-              const authType = p.auth_type || 'tenant';
+              const authType = p.auth_type || 'user';
               const res = await client.invoke(
                 'feishu_task_task.get',
                 (sdk, opts) =>
@@ -492,7 +492,7 @@ export function registerFeishuTaskTaskTool(api: OpenClawPluginApi): void {
             case 'list': {
               log.info(`list: page_size=${p.page_size ?? 50}, completed=${p.completed ?? false}`);
 
-              const authType = p.auth_type || 'tenant';
+              const authType = p.auth_type || 'user';
               const res = await client.invoke(
                 'feishu_task_task.list',
                 (sdk, opts) =>
@@ -594,7 +594,7 @@ export function registerFeishuTaskTaskTool(api: OpenClawPluginApi): void {
               // Build update_fields list (required by Task API)
               const updateFields = Object.keys(updateData);
 
-              const authType = p.auth_type || 'tenant';
+              const authType = p.auth_type || 'user';
               const res = await client.invoke(
                 'feishu_task_task.patch',
                 (sdk, opts) =>
@@ -645,7 +645,7 @@ export function registerFeishuTaskTaskTool(api: OpenClawPluginApi): void {
                 requestData.client_token = p.client_token;
               }
 
-              const authType = p.auth_type || 'tenant';
+              const authType = p.auth_type || 'user';
               const res = await client.invoke(
                 'feishu_task_task.add_members',
                 (sdk, opts) =>

--- a/src/tools/oapi/task/tasklist.ts
+++ b/src/tools/oapi/task/tasklist.ts
@@ -4,7 +4,7 @@
  *
  * feishu_task_tasklist tool -- Manage Feishu task lists.
  *
- * P0 Actions: create, get, list, tasks
+ * P0 Actions: create, get, list, tasks 支持通过 auth_type 参数切换用户(user)或应用(tenant)身份。
  * P1 Actions: patch, add_members
  *
  * Uses the Feishu Task v2 API:
@@ -27,80 +27,98 @@ import type { PaginatedData } from '../sdk-types';
 // Schema
 // ---------------------------------------------------------------------------
 
-const FeishuTaskTasklistSchema = Type.Union([
-  // CREATE (P0)
+const FeishuTaskTasklistSchema = Type.Intersect([
   Type.Object({
-    action: Type.Literal('create'),
-    name: Type.String({
-      description: '清单名称',
+    auth_type: Type.Optional(
+      StringEnum(['tenant', 'user'], {
+        description: '调用 API 时使用的 Token 类型。可选值："tenant"（应用身份） 或 "user"（用户身份）。默认使用 "tenant"。',
+      }),
+    ),
+  }),
+  Type.Union([
+    // CREATE (P0)
+    Type.Object({
+      action: Type.Literal('create'),
+      name: Type.String({
+        description: '清单名称',
+      }),
+      members: Type.Optional(
+        Type.Array(
+          Type.Object({
+            id: Type.String({ description: '成员 ID（通常为 open_id）' }),
+            type: Type.Optional(StringEnum(['user', 'app'])),
+            role: Type.Optional(StringEnum(['editor', 'viewer'])),
+          }),
+          {
+            description:
+              '清单成员列表（editor=可编辑，viewer=可查看）。注意：创建人自动成为 owner，如在 members 中也指定创建人，该用户最终成为 owner 并从 members 中移除（同一用户只能有一个角色）。成员类型支持 user 和 app，默认为 user。',
+          },
+        ),
+      ),
+      user_id_type: Type.Optional(StringEnum(['open_id', 'union_id', 'user_id'])),
     }),
-    members: Type.Optional(
-      Type.Array(
+
+    // GET (P0)
+    Type.Object({
+      action: Type.Literal('get'),
+      tasklist_guid: Type.String({ description: '清单 GUID' }),
+      user_id_type: Type.Optional(StringEnum(['open_id', 'union_id', 'user_id'])),
+    }),
+
+    // LIST (P0)
+    Type.Object({
+      action: Type.Literal('list'),
+      page_size: Type.Optional(Type.Number({ description: '每页数量，默认 50，最大 100' })),
+      page_token: Type.Optional(Type.String({ description: '分页标记' })),
+      user_id_type: Type.Optional(StringEnum(['open_id', 'union_id', 'user_id'])),
+    }),
+
+    // TASKS (P0) - 列出清单内的任务
+    Type.Object({
+      action: Type.Literal('tasks'),
+      tasklist_guid: Type.String({ description: '清单 GUID' }),
+      page_size: Type.Optional(Type.Number({ description: '每页数量，默认 50，最大 100' })),
+      page_token: Type.Optional(Type.String({ description: '分页标记' })),
+      completed: Type.Optional(Type.Boolean({ description: '是否只返回已完成的任务（默认返回所有）' })),
+      user_id_type: Type.Optional(StringEnum(['open_id', 'union_id', 'user_id'])),
+    }),
+
+    // PATCH (P1)
+    Type.Object({
+      action: Type.Literal('patch'),
+      tasklist_guid: Type.String({ description: '清单 GUID' }),
+      name: Type.Optional(Type.String({ description: '新的清单名称' })),
+      user_id_type: Type.Optional(StringEnum(['open_id', 'union_id', 'user_id'])),
+    }),
+
+    // ADD_MEMBERS (P1)
+    Type.Object({
+      action: Type.Literal('add_members'),
+      tasklist_guid: Type.String({ description: '清单 GUID' }),
+      members: Type.Array(
         Type.Object({
-          id: Type.String({ description: '成员 open_id' }),
+          id: Type.String({ description: '成员 ID（通常为 open_id）' }),
+          type: Type.Optional(StringEnum(['user', 'app'])),
           role: Type.Optional(StringEnum(['editor', 'viewer'])),
         }),
-        {
-          description:
-            '清单成员列表（editor=可编辑，viewer=可查看）。注意：创建人自动成为 owner，如在 members 中也指定创建人，该用户最终成为 owner 并从 members 中移除（同一用户只能有一个角色）',
-        },
+        { description: '要添加的成员列表' },
       ),
-    ),
-  }),
-
-  // GET (P0)
-  Type.Object({
-    action: Type.Literal('get'),
-    tasklist_guid: Type.String({ description: '清单 GUID' }),
-  }),
-
-  // LIST (P0)
-  Type.Object({
-    action: Type.Literal('list'),
-    page_size: Type.Optional(Type.Number({ description: '每页数量，默认 50，最大 100' })),
-    page_token: Type.Optional(Type.String({ description: '分页标记' })),
-  }),
-
-  // TASKS (P0) - 列出清单内的任务
-  Type.Object({
-    action: Type.Literal('tasks'),
-    tasklist_guid: Type.String({ description: '清单 GUID' }),
-    page_size: Type.Optional(Type.Number({ description: '每页数量，默认 50，最大 100' })),
-    page_token: Type.Optional(Type.String({ description: '分页标记' })),
-    completed: Type.Optional(Type.Boolean({ description: '是否只返回已完成的任务（默认返回所有）' })),
-  }),
-
-  // PATCH (P1)
-  Type.Object({
-    action: Type.Literal('patch'),
-    tasklist_guid: Type.String({ description: '清单 GUID' }),
-    name: Type.Optional(Type.String({ description: '新的清单名称' })),
-  }),
-
-  // ADD_MEMBERS (P1)
-  Type.Object({
-    action: Type.Literal('add_members'),
-    tasklist_guid: Type.String({ description: '清单 GUID' }),
-    members: Type.Array(
-      Type.Object({
-        id: Type.String({ description: '成员 open_id' }),
-        role: Type.Optional(StringEnum(['editor', 'viewer'])),
-      }),
-      { description: '要添加的成员列表' },
-    ),
-  }),
-
+      user_id_type: Type.Optional(StringEnum(['open_id', 'union_id', 'user_id'])),
+    }),
+  ]),
 ]);
 
 // ---------------------------------------------------------------------------
 // Params type
 // ---------------------------------------------------------------------------
 
-type FeishuTaskTasklistParams =
+type FeishuTaskTasklistParams = { auth_type?: 'tenant' | 'user' } & (
   | {
       action: 'create';
       name: string;
-      members?: Array<{ id: string; role?: string }>;
+      members?: Array<{ id: string;
+        type?: 'user' | 'app';
+        role?: string }>;
     }
   | {
       action: 'get';
@@ -126,8 +144,11 @@ type FeishuTaskTasklistParams =
   | {
       action: 'add_members';
       tasklist_guid: string;
-      members: Array<{ id: string; role?: string }>;
-    };
+      members: Array<{ id: string;
+        type?: 'user' | 'app';
+        role?: string }>;
+      }
+);
 
 // ---------------------------------------------------------------------------
 // Registration
@@ -145,7 +166,7 @@ export function registerFeishuTaskTasklistTool(api: OpenClawPluginApi): void {
       name: 'feishu_task_tasklist',
       label: 'Feishu Task Lists',
       description:
-        '【以用户身份】飞书任务清单管理工具。当用户要求创建/查询/管理清单、查看清单内的任务时使用。Actions: create（创建清单）, get（获取清单详情）, list（列出所有可读取的清单，包括我创建的和他人共享给我的）, tasks（列出清单内的任务）, patch（更新清单）, add_members（添加成员）。',
+        '【以用户或应用身份】飞书任务清单管理工具。当用户要求创建/查询/管理清单、查看清单内的任务时使用。Actions: create（创建清单）, get（获取清单详情）, list（列出所有可读取的清单，包括我创建的和他人共享给我的）, tasks（列出清单内的任务）, patch（更新清单）, add_members（添加成员）。',
       parameters: FeishuTaskTasklistSchema,
       async execute(_toolCallId, params) {
         const p = params as FeishuTaskTasklistParams;
@@ -166,7 +187,7 @@ export function registerFeishuTaskTasklistTool(api: OpenClawPluginApi): void {
               if (p.members && p.members.length > 0) {
                 data.members = p.members.map((m) => ({
                   id: m.id,
-                  type: 'user',
+                  type: m.type || 'user',
                   role: m.role || 'editor',
                 }));
               }
@@ -183,7 +204,7 @@ export function registerFeishuTaskTasklistTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: 'user' },
+                { as: p.auth_type || 'tenant' },
               );
               assertLarkOk(res);
 
@@ -214,7 +235,7 @@ export function registerFeishuTaskTasklistTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: 'user' },
+                { as: p.auth_type || 'tenant' },
               );
               assertLarkOk(res);
 
@@ -244,7 +265,7 @@ export function registerFeishuTaskTasklistTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: 'user' },
+                { as: p.auth_type || 'tenant' },
               );
               assertLarkOk(res);
 
@@ -281,7 +302,7 @@ export function registerFeishuTaskTasklistTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: 'user' },
+                { as: p.auth_type || 'tenant' },
               );
               assertLarkOk(res);
 
@@ -334,7 +355,7 @@ export function registerFeishuTaskTasklistTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: 'user' },
+                { as: p.auth_type || 'tenant' },
               );
               assertLarkOk(res);
 
@@ -359,7 +380,7 @@ export function registerFeishuTaskTasklistTool(api: OpenClawPluginApi): void {
 
               const memberData = p.members.map((m) => ({
                 id: m.id,
-                type: 'user',
+                type: m.type || 'user',
                 role: m.role || 'editor',
               }));
 
@@ -380,7 +401,7 @@ export function registerFeishuTaskTasklistTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: 'user' },
+                { as: p.auth_type || 'tenant' },
               );
               assertLarkOk(res);
 

--- a/src/tools/oapi/task/tasklist.ts
+++ b/src/tools/oapi/task/tasklist.ts
@@ -31,7 +31,7 @@ const FeishuTaskTasklistSchema = Type.Intersect([
   Type.Object({
     auth_type: Type.Optional(
       StringEnum(['tenant', 'user'], {
-        description: '调用 API 时使用的 Token 类型。可选值："tenant"（应用身份） 或 "user"（用户身份）。默认使用 "tenant"。',
+        description: '调用 API 时使用的 Token 类型。可选值："tenant"（应用身份） 或 "user"（用户身份）。默认使用 "user"。',
       }),
     ),
   }),
@@ -204,7 +204,7 @@ export function registerFeishuTaskTasklistTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: p.auth_type || 'tenant' },
+                { as: p.auth_type || 'user' },
               );
               assertLarkOk(res);
 
@@ -235,7 +235,7 @@ export function registerFeishuTaskTasklistTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: p.auth_type || 'tenant' },
+                { as: p.auth_type || 'user' },
               );
               assertLarkOk(res);
 
@@ -265,7 +265,7 @@ export function registerFeishuTaskTasklistTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: p.auth_type || 'tenant' },
+                { as: p.auth_type || 'user' },
               );
               assertLarkOk(res);
 
@@ -302,7 +302,7 @@ export function registerFeishuTaskTasklistTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: p.auth_type || 'tenant' },
+                { as: p.auth_type || 'user' },
               );
               assertLarkOk(res);
 
@@ -355,7 +355,7 @@ export function registerFeishuTaskTasklistTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: p.auth_type || 'tenant' },
+                { as: p.auth_type || 'user' },
               );
               assertLarkOk(res);
 
@@ -401,7 +401,7 @@ export function registerFeishuTaskTasklistTool(api: OpenClawPluginApi): void {
                     },
                     opts,
                   ),
-                { as: p.auth_type || 'tenant' },
+                { as: p.auth_type || 'user' },
               );
               assertLarkOk(res);
 


### PR DESCRIPTION
## Description
This PR updates all task-related APIs and tools to support both `user` and `tenant` token types, with `tenant` as the new default behavior to avoid visibility limitations caused by personal organizational structure constraints.

## Key updates:
1. Added `auth_type` parameter to all task APIs (task, subtask, tasklist, section, comment).
2. Changed the default `auth_type` to `tenant` across all tools.
3. Updated the `members` schema to support adding apps/bots by introducing the `type` field (`user` or `app`).
4. Updated the documentation in `SKILL.md` to reflect the new behavior and limitations.