### PR TITLE
feat(飞书群聊): 为群组和账户配置添加自动创建话题和话题内回复选项

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 registry=https://registry.npmjs.org
+@zegoclaw:registry=https://npm.pkg.github.com

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OpenClaw Lark/Feishu Plugin
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![npm version](https://img.shields.io/npm/v/@larksuite/openclaw-lark.svg)](https://www.npmjs.com/package/@larksuite/openclaw-lark)
+[![npm version](https://img.shields.io/npm/v/@zegoclaw/openclaw-lark.svg)](https://github.com/zegoclaw/openclaw-lark/packages)
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D22-blue.svg)](https://nodejs.org/)
 
 [中文版](./README.zh.md) | English
@@ -60,6 +60,20 @@ Before you start, make sure you have the following:
 > ```bash
 > npm install -g openclaw
 > ```
+
+### Installation
+
+To install this plugin via openclaw:
+
+```bash
+npx -y @larksuite/openclaw-lark install
+```
+
+To install from this fork (GitHub Packages):
+
+```bash
+npm install @zegoclaw/openclaw-lark -g
+```
 
 ## Usage Guide
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,7 +1,7 @@
 # OpenClaw  Lark/飞书 插件
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![npm version](https://img.shields.io/npm/v/@larksuite/openclaw-lark.svg)](https://www.npmjs.com/package/@larksuite/openclaw-lark)
+[![npm version](https://img.shields.io/npm/v/@zegoclaw/openclaw-lark.svg)](https://github.com/zegoclaw/openclaw-lark/packages)
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D22-blue.svg)](https://nodejs.org/)
 
 [English](./README.md) | 中文版
@@ -55,6 +55,20 @@
 > ```bash
 > npm install -g openclaw
 > ```
+
+### 安装
+
+通过 openclaw 安装此插件：
+
+```bash
+npx -y @larksuite/openclaw-lark install
+```
+
+从本 fork 安装（GitHub Packages）：
+
+```bash
+npm install @zegoclaw/openclaw-lark -g
+```
 
 ## 使用说明
 [OpenClaw  Lark/飞书官方插件使用指南](https://bytedance.larkoffice.com/docx/MFK7dDFLFoVlOGxWCv5cTXKmnMh)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@larksuite/openclaw-lark",
+  "name": "@zegoclaw/openclaw-lark",
   "version": "2026.4.1",
   "description": "OpenClaw Lark/Feishu channel plugin",
   "type": "module",
@@ -89,7 +89,7 @@
       "quickstartAllowFrom": true
     },
     "install": {
-      "npmSpec": "@larksuite/openclaw-lark",
+      "npmSpec": "@zegoclaw/openclaw-lark",
       "localPath": "extensions/feishu",
       "defaultChoice": "npm"
     }

--- a/src/core/config-schema.ts
+++ b/src/core/config-schema.ts
@@ -145,6 +145,8 @@ export const FeishuGroupSchema = z.object({
   enabled: z.boolean().optional(),
   allowFrom: AllowFromSchema,
   systemPrompt: z.string().optional(),
+  autoCreateThread: z.enum(['disabled', 'enabled']).optional(),
+  replyInThread: z.enum(['disabled', 'enabled']).optional(),
 });
 
 // ---------------------------------------------------------------------------
@@ -193,6 +195,8 @@ export const FeishuAccountConfigSchema = z.object({
   dedup: DedupSchema,
   reactionNotifications: ReactionNotificationModeSchema,
   threadSession: z.boolean().optional(),
+  autoCreateThread: z.enum(['disabled', 'enabled']).optional(),
+  replyInThread: z.enum(['disabled', 'enabled']).optional(),
   uat: UATConfigSchema,
 });
 

--- a/src/messaging/inbound/dispatch.ts
+++ b/src/messaging/inbound/dispatch.ts
@@ -285,6 +285,20 @@ export async function dispatchToAgent(params: {
     });
   }
 
+  // 1c. Auto-create thread for new conversations when autoCreateThread is "enabled".
+  //     Unlike threadSession, this does NOT call isThreadCapableGroup — it trusts
+  //     the config directly and creates a new thread in the main group chat.
+  //     This mirrors the built-in channel behavior where autoCreateThread bypasses
+  //     the group capability check.
+  const isNewConversation = !dc.ctx.rootId && !dc.ctx.threadId;
+  const autoCreateThreadCfg = dc.account?.config?.autoCreateThread === 'enabled';
+  const shouldAutoCreateThread = autoCreateThreadCfg && isNewConversation;
+  if (!dc.isThread && dc.isGroup && shouldAutoCreateThread) {
+    log.info(`autoCreateThread: creating new thread in group ${dc.ctx.chatId}`);
+    dc.isThread = true;
+    dc.ctx = { ...dc.ctx, threadId: dc.ctx.messageId };
+  }
+
   // 2. Build annotated message body
   const messageBody = buildMessageBody(params.ctx, params.quotedContent);
 

--- a/src/messaging/inbound/dispatch.ts
+++ b/src/messaging/inbound/dispatch.ts
@@ -252,9 +252,16 @@ export async function dispatchToAgent(params: {
   defaultGroupConfig?: FeishuGroupConfig;
   /** When true, the reply dispatcher skips typing indicators. */
   skipTyping?: boolean;
+  /** Bot's own open_id for A2A cross-bot routing detection */
+  botOpenId?: string;
 }): Promise<void> {
   // 1. Derive shared context (including route resolution + system event)
   const dc = buildDispatchContext(params);
+
+  // [A2A-THREAD-DEBUG] Log dispatch context for thread analysis
+  dc.log(
+    `[A2A-THREAD-DEBUG] dispatchToAgent: ctx.messageId=${params.ctx.messageId}, ctx.chatId=${params.ctx.chatId}, ctx.threadId=${params.ctx.threadId ?? 'undefined'}, ctx.rootId=${params.ctx.rootId ?? 'undefined'}, ctx.parentId=${params.ctx.parentId ?? 'undefined'}, dc.isThread=${dc.isThread}, dc.isGroup=${dc.isGroup}, replyToMessageId=${params.replyToMessageId ?? 'undefined'}`,
+  );
 
   // 1a. Thread detection fallback for topic groups.
   //     In topic groups (chat_mode=topic), reply events may carry root_id
@@ -326,7 +333,7 @@ export async function dispatchToAgent(params: {
   // 5. Build BodyForAgent with mention annotation (if any).
   //    SDK >= 2026.2.10 no longer falls back to Body for BodyForAgent,
   //    so we must set it explicitly to preserve the annotation.
-  const bodyForAgent = buildBodyForAgent(params.ctx);
+  let bodyForAgent = buildBodyForAgent(params.ctx);
 
   // 6. Build InboundHistory for SDK metadata injection (>= 2026.2.10).
   //    The SDK's buildInboundUserContextPrefix renders these as structured
@@ -354,6 +361,69 @@ export async function dispatchToAgent(params: {
           threadId: dc.ctx.threadId,
         })
       : undefined;
+
+  // [A2A DEBUG] Log wasMentioned computation and dispatch target
+  const wasMentionedComputed =
+    mentionedBot(params.ctx) ||
+    (params.ctx.mentionAll &&
+      resolveRespondToMentionAll({
+        groupConfig: params.groupConfig,
+        defaultConfig: params.defaultGroupConfig,
+        accountFeishuCfg: params.account.config,
+      }));
+
+  // [A2A CENTRAL-ROUTING] Detect multiple bot mentions for inter-bot notification
+  // When a message mentions multiple bots, we need to notify other mentioned bots' agents
+  // This solves the Feishu webhook limitation: bot @ bot only delivers to sender
+  const ctxMentions = params.ctx.mentions || [];
+  const botMentions = ctxMentions.filter((m) => m.isBot);
+  const otherBotMentions = botMentions.filter((m) => m.openId !== params.botOpenId);
+  log.info(
+    `[A2A-CENTRAL-ROUTING] messageId=${params.ctx.messageId}, currentBot=${params.botOpenId}, ` +
+      `allMentions=${ctxMentions.length}, botMentions=${botMentions.length}, otherBotMentions=${otherBotMentions.length}, ` +
+      `otherBotOpenIds=[${otherBotMentions.map((m) => `${m.name}(${m.openId})`).join(', ')}], ` +
+      `wasMentioned=${wasMentionedComputed}, currentAgentId=${dc.route.agentId}, currentSessionKey=${dc.route.sessionKey}`,
+  );
+
+  // [A2A CENTRAL-ROUTING] If other bots were mentioned, prepend forwarding instruction to bodyForAgent
+  // This tells the AI agent to use sessions_send to forward the message to other mentioned bots
+  // The AI needs to have sessions_send tool access and knowledge of other agents' session keys
+  if (otherBotMentions.length > 0) {
+    const otherBotNames = otherBotMentions.map((m) => m.name).join(', ');
+    const otherBotOpenIds = otherBotMentions.map((m) => m.openId).join(', ');
+    const forwardInstruction =
+      `[SYSTEM: FORWARD REQUEST]\n` +
+      `This message mentions other AI agents: ${otherBotNames}.\n` +
+      `To enable collaboration, please use sessions_send to forward a relevant summary or response ` +
+      `to each mentioned agent. Target agent open_ids: ${otherBotOpenIds}\n`;
+    log.info(
+      `[A2A-CENTRAL-ROUTING] MULTI-BOT: prepending forward instruction for [${otherBotNames}] ` +
+        `to bodyForAgent. AI should use sessions_send with targets: ${otherBotOpenIds}`,
+    );
+    bodyForAgent = forwardInstruction + bodyForAgent;
+  }
+
+  // [A2A CENTRAL-ROUTING] Transparent forwarding mode:
+  // If this account is in centralRoutingMode and no human mention was found,
+  // skip the reply dispatch entirely — just record the message to history.
+  // The bot should remain silent so the central routing logic can handle it.
+  const feishuCfg = dc.account?.config as { centralRoutingMode?: boolean } | undefined;
+  const isCentralRouting = feishuCfg?.centralRoutingMode === true;
+  if (isCentralRouting && !wasMentionedComputed && otherBotMentions.length === 0) {
+    dc.log(
+      `feishu[${dc.account.accountId}]: [CENTRAL-ROUTING] transparent mode: no mention, recording to history only, skipping reply`,
+    );
+    log.info(
+      `[CENTRAL-ROUTING] transparent mode skip (no mention), session=${dc.route.sessionKey}, msgId=${params.ctx.messageId}`,
+    );
+    if (params.chatHistories && historyKey) {
+      const entry = { sender: params.ctx.senderId, body: combinedBody, timestamp: Date.now() };
+      const existing = params.chatHistories.get(historyKey) ?? [];
+      params.chatHistories.set(historyKey, [...existing, entry]);
+    }
+    return; // early return: do NOT dispatch to AI agent
+  }
+
   const ctxPayload = buildInboundPayload(dc, {
     body: combinedBody,
     bodyForAgent,
@@ -363,14 +433,7 @@ export async function dispatchToAgent(params: {
     senderName: params.ctx.senderName ?? params.ctx.senderId,
     senderId: params.ctx.senderId,
     messageSid: params.ctx.messageId,
-    wasMentioned:
-      mentionedBot(params.ctx) ||
-      (params.ctx.mentionAll &&
-        resolveRespondToMentionAll({
-          groupConfig: params.groupConfig,
-          defaultConfig: params.defaultGroupConfig,
-          accountFeishuCfg: params.account.config,
-        })),
+    wasMentioned: wasMentionedComputed,
     replyToBody: params.quotedContent,
     inboundHistory,
     extraFields: {

--- a/src/messaging/outbound/deliver.ts
+++ b/src/messaging/outbound/deliver.ts
@@ -8,9 +8,11 @@
  * to these for its `sendText` and `sendMedia` implementations.
  */
 
-import type { ClawdbotConfig } from 'openclaw/plugin-sdk';
-import type { FeishuSendResult } from '../types';
-import { createAccountScopedConfig } from '../../core/accounts';
+import type { ClawdbotConfig, RuntimeEnv } from 'openclaw/plugin-sdk';
+import type { HistoryEntry } from 'openclaw/plugin-sdk/reply-history';
+import type { FeishuSendResult, MessageContext, MentionInfo } from '../types';
+import type { FeishuGroupConfig, LarkAccount } from '../../core/types';
+import { createAccountScopedConfig, getLarkAccount, getDefaultLarkAccountId } from '../../core/accounts';
 import { LarkClient } from '../../core/lark-client';
 import { normalizeFeishuTarget, resolveReceiveIdType } from '../../core/targets';
 import { parseFeishuCommentTarget } from '../../core/comment-target';
@@ -18,8 +20,180 @@ import { optimizeMarkdownStyle } from '../../card/markdown-style';
 import { formatLarkError } from '../../core/api-error';
 import { larkLogger } from '../../core/lark-logger';
 import { uploadAndSendMediaLark } from './media';
+import { resolveFeishuGroupConfig } from '../inbound/policy';
+import { dispatchToAgent } from '../inbound/dispatch';
 
 const log = larkLogger('outbound/deliver');
+
+// ---------------------------------------------------------------------------
+// A2A Cross-Bot Helper Types
+// ---------------------------------------------------------------------------
+
+interface BotMentionInfo {
+  openId: string;
+  name: string;
+  key: string;
+  isBot: boolean;
+  accountId: string;
+}
+
+// ---------------------------------------------------------------------------
+// A2A Cross-Bot Helper Functions
+// ---------------------------------------------------------------------------
+
+function extractBotMentionsFromText(
+  text: string | undefined,
+  botOpenIdToAccountId: Record<string, string> | undefined,
+): BotMentionInfo[] {
+  if (!text || !botOpenIdToAccountId) return [];
+
+  const atPattern = /<at user_id="([^"]+)">([^<]*)<\/at>/g;
+  const mentions: BotMentionInfo[] = [];
+  let match;
+
+  while ((match = atPattern.exec(text)) !== null) {
+    const openId = match[1]!;
+    const name = match[2] || openId;
+    const accountId = botOpenIdToAccountId[openId];
+
+    if (accountId) {
+      mentions.push({
+        openId,
+        name,
+        key: `<at user_id="${openId}">${name}</at>`,
+        isBot: true,
+        accountId,
+      });
+    }
+  }
+
+  return mentions;
+}
+
+async function notifyOtherBotsOfMention(params: {
+  mentions: BotMentionInfo[];
+  text: string | undefined;
+  accountId: string | undefined;
+  chatId: string | undefined;
+  cfg: ClawdbotConfig;
+  createdMessageId: string | undefined;
+}): Promise<void> {
+  const { mentions, text, accountId, chatId, cfg, createdMessageId } = params;
+
+  log.info(
+    `[A2A-CROSS-BOT] notifyOtherBotsOfMention: accountId=${accountId}, chatId=${chatId}, mentionsCount=${mentions?.length}, createdMessageId=${createdMessageId}`,
+  );
+
+  if (!mentions || mentions.length === 0) {
+    log.info('[A2A-CROSS-BOT] no mentions, returning');
+    return;
+  }
+
+  const botOpenIdToAccountId = cfg?.channels?.feishu?.botOpenIdToAccountId;
+  log.info(`[A2A-CROSS-BOT] botOpenIdToAccountId=${JSON.stringify(botOpenIdToAccountId)}`);
+
+  if (!botOpenIdToAccountId) {
+    log.info('[A2A-CROSS-BOT] no botOpenIdToAccountId mapping');
+    return;
+  }
+
+  const senderAccount = getLarkAccount(cfg, accountId);
+  const senderClient = LarkClient.fromCfg(cfg, accountId);
+  const senderBotOpenId = senderClient.botOpenId;
+  const senderBotName = senderClient.botName;
+  log.info(`[A2A-CROSS-BOT] senderBotOpenId=${senderBotOpenId}, senderBotName=${senderBotName}, senderAccount=${senderAccount?.accountId}`);
+
+  const senderAccountFeishuCfg = senderAccount?.config;
+  const groupConfig = resolveFeishuGroupConfig({ cfg: senderAccountFeishuCfg!, groupId: chatId! });
+  const defaultGroupConfig = senderAccountFeishuCfg?.groups?.['*'];
+
+  for (const mention of mentions) {
+    const mentionOpenId = mention.openId;
+    const targetAccountId = botOpenIdToAccountId[mentionOpenId];
+    log.info(`[A2A-CROSS-BOT] mentionOpenId=${mentionOpenId}, targetAccountId=${targetAccountId}`);
+
+    if (!targetAccountId || targetAccountId === accountId) {
+      log.info('[A2A-CROSS-BOT] skip: no mapping or self');
+      continue;
+    }
+
+    try {
+      const targetAccount = getLarkAccount(cfg, targetAccountId);
+      const targetClient = LarkClient.fromCfg(cfg, targetAccountId);
+      const targetBotName = targetClient.botName;
+      log.info(`[A2A-CROSS-BOT] targetAccount: ${targetAccount?.accountId} ${targetBotName}`);
+
+      const targetAccountFeishuCfg = targetAccount?.config;
+      const targetAccountScopedCfg: ClawdbotConfig = {
+        ...cfg,
+        channels: { ...cfg.channels, feishu: targetAccountFeishuCfg! },
+      };
+
+      const syntheticMentions: MentionInfo[] = mentions.map((m) => ({
+        openId: m.openId,
+        name: m.name,
+        key: m.key,
+        isBot: true,
+      }));
+
+      const fakeCtx: MessageContext = {
+        messageId: `crossbot-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
+        chatId: chatId || '',
+        content: text || '',
+        senderId: senderBotOpenId || 'crossbot-sender',
+        senderName: senderBotName || 'Cross-Bot',
+        chatType: 'group',
+        mentions: syntheticMentions,
+        mentionAll: false,
+        threadId: createdMessageId || undefined,
+        rootId: createdMessageId || undefined,
+        parentId: createdMessageId || undefined,
+        contentType: 'text',
+        resources: [],
+        rawMessage: {
+          message_id: `crossbot-${Date.now()}`,
+          chat_id: chatId || '',
+          chat_type: 'group',
+          message_type: 'text',
+          content: text || '',
+        },
+        rawSender: {
+          sender_id: { open_id: senderBotOpenId },
+          sender_type: 'bot',
+        },
+      };
+
+      const safeRuntime: RuntimeEnv = {
+        log: (...args: unknown[]) => log.info(args.join(' ')),
+        error: (...args: unknown[]) => log.error(args.join(' ')),
+        exit: (code?: number) => process.exit(code ?? 0),
+      };
+
+      await dispatchToAgent({
+        ctx: fakeCtx,
+        account: targetAccount!,
+        accountScopedCfg: targetAccountScopedCfg,
+        runtime: safeRuntime,
+        chatHistories: new Map<string, HistoryEntry[]>(),
+        quotedContent: undefined,
+        mediaPayload: {},
+        permissionError: undefined,
+        replyToMessageId: createdMessageId || undefined,
+        botOpenId: senderBotOpenId,
+        historyLimit: 10,
+        skipTyping: false,
+        commandAuthorized: true,
+        groupConfig,
+        defaultGroupConfig,
+      });
+
+      log.info(`[A2A-CROSS-BOT] notified ${targetAccountId} (openId=${mentionOpenId})`);
+    } catch (e) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      log.error(`[A2A-CROSS-BOT] failed to notify ${targetAccountId}: ${err.message}`);
+    }
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -242,6 +416,8 @@ export interface SendTextLarkParams {
 export async function sendTextLark(params: SendTextLarkParams): Promise<FeishuSendResult> {
   const { cfg, to, text, replyToMessageId, replyInThread, accountId } = params;
 
+  const botOpenIdToAccountId = cfg?.channels?.feishu?.botOpenIdToAccountId;
+
   // Detect card JSON in text — route to card sending before text preprocessing.
   const card = detectCardJson(text);
   if (card) {
@@ -255,7 +431,124 @@ export async function sendTextLark(params: SendTextLarkParams): Promise<FeishuSe
   const processedText = prepareTextForLark(cfg, text, accountId);
   const content = buildPostContent(processedText);
 
-  return sendImMessage({ client, to, content, msgType: 'post', replyToMessageId, replyInThread });
+  const result = await sendImMessage({ client, to, content, msgType: 'post', replyToMessageId, replyInThread });
+
+  log.info(
+    `[A2A-CROSS-BOT] sendTextLark: botOpenIdToAccountId exists=${!!botOpenIdToAccountId}, text=${text.substring(0, 50)}`,
+  );
+
+  if (botOpenIdToAccountId) {
+    const textParsedMentions = extractBotMentionsFromText(text, botOpenIdToAccountId);
+    log.info(
+      `[A2A-CROSS-BOT] textParsedMentions count=${textParsedMentions.length}, accountIds=${textParsedMentions.map((m) => m.accountId).join(',')}`,
+    );
+
+    if (textParsedMentions.length > 0) {
+      const target = normalizeFeishuTarget(to);
+      if (!target) {
+        log.error('[A2A-CROSS-BOT] Invalid target, skipping dispatch');
+      } else {
+        log.info(
+          `[A2A-CROSS-BOT] sendTextLark: found ${textParsedMentions.length} bot mentions, triggering notify for each`,
+        );
+
+        const createdMessageId = result.messageId;
+
+      for (const mention of textParsedMentions) {
+        const targetAccountId = mention.accountId;
+        log.info(`[A2A-CROSS-BOT] dispatching to targetAccountId=${targetAccountId}`);
+
+        setImmediate(() => {
+          const senderAccountId = accountId || getDefaultLarkAccountId(cfg);
+          const senderAccount = getLarkAccount(cfg, senderAccountId);
+          const senderClient = LarkClient.fromCfg(cfg, senderAccountId);
+          const senderBotOpenId = senderClient.botOpenId;
+          const senderBotName = senderClient.botName;
+
+          if (!targetAccountId) {
+            log.error('[A2A-CROSS-BOT] No accountId found for mentioned bot, skipping dispatch');
+            return;
+          }
+
+          const targetAccount = getLarkAccount(cfg, targetAccountId);
+          if (!targetAccount) {
+            log.error(`[A2A-CROSS-BOT] targetAccount not found for ${targetAccountId}`);
+            return;
+          }
+
+          const targetAccountFeishuCfg = targetAccount?.config;
+          const targetAccountScopedCfg: ClawdbotConfig = {
+            ...cfg,
+            channels: { ...cfg.channels, feishu: targetAccountFeishuCfg! },
+          };
+
+          const groupConfig = resolveFeishuGroupConfig({ cfg: targetAccountFeishuCfg!, groupId: target! });
+          const defaultGroupConfig = targetAccountFeishuCfg?.groups?.['*'];
+
+          const syntheticMention: MentionInfo = {
+            openId: mention.openId,
+            name: mention.name,
+            key: mention.key,
+            isBot: true,
+          };
+
+          const fakeCtx: MessageContext = {
+            messageId: `crossbot-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
+            chatId: target || '',
+            content: text || '',
+            senderId: senderBotOpenId || 'crossbot-sender',
+            senderName: senderBotName || 'Cross-Bot',
+            chatType: 'group',
+            mentions: [syntheticMention],
+            mentionAll: false,
+            threadId: createdMessageId || undefined,
+            rootId: createdMessageId || undefined,
+            parentId: createdMessageId || undefined,
+            contentType: 'text',
+            resources: [],
+            rawMessage: {
+              message_id: createdMessageId || '',
+              chat_id: target || '',
+              chat_type: 'group',
+              message_type: 'text',
+              content: text || '',
+            },
+            rawSender: {
+              sender_id: { open_id: senderBotOpenId },
+              sender_type: 'bot',
+            },
+          };
+
+          const safeRuntime: RuntimeEnv = {
+            log: (...args: unknown[]) => log.info(args.join(' ')),
+            error: (...args: unknown[]) => log.error(args.join(' ')),
+            exit: (code?: number) => process.exit(code ?? 0),
+          };
+
+          dispatchToAgent({
+            ctx: fakeCtx,
+            account: targetAccount,
+            accountScopedCfg: targetAccountScopedCfg,
+            runtime: safeRuntime,
+            chatHistories: new Map<string, HistoryEntry[]>(),
+            quotedContent: undefined,
+            mediaPayload: {},
+            permissionError: undefined,
+            replyToMessageId: createdMessageId || undefined,
+            botOpenId: senderBotOpenId,
+            historyLimit: 10,
+            skipTyping: false,
+            commandAuthorized: true,
+            groupConfig,
+            defaultGroupConfig,
+          }).catch((e) => log.error(`[A2A-CROSS-BOT] notify error for ${targetAccountId}: ${String(e)}`));
+        });
+      }
+    }
+    }
+  }
+
+  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -333,7 +626,34 @@ export async function sendCardLark(params: SendCardLarkParams): Promise<FeishuSe
   const content = JSON.stringify(card);
 
   try {
-    return await sendImMessage({ client, to, content, msgType: 'interactive', replyToMessageId, replyInThread });
+    const result = await sendImMessage({ client, to, content, msgType: 'interactive', replyToMessageId, replyInThread });
+
+    const botOpenIdToAccountId = cfg?.channels?.feishu?.botOpenIdToAccountId;
+    if (botOpenIdToAccountId) {
+      const textContent = JSON.stringify(card);
+      const textParsedMentions = extractBotMentionsFromText(textContent, botOpenIdToAccountId);
+      if (textParsedMentions.length > 0) {
+        const target = normalizeFeishuTarget(to);
+        if (target) {
+          log.info(
+            `[A2A-CROSS-BOT] sendCardLark: found ${textParsedMentions.length} bot mentions, triggering notify`,
+          );
+          const cardCreatedMessageId = result.messageId;
+          setImmediate(() => {
+            notifyOtherBotsOfMention({
+              mentions: textParsedMentions,
+              text: textContent,
+              accountId: accountId || getDefaultLarkAccountId(cfg),
+              chatId: target,
+              cfg,
+              createdMessageId: cardCreatedMessageId,
+            });
+          });
+        }
+      }
+    }
+
+    return result;
   } catch (err) {
     const detail = formatLarkError(err);
     log.error(`sendCardLark failed: ${detail}`);

--- a/src/messaging/outbound/send.ts
+++ b/src/messaging/outbound/send.ts
@@ -5,14 +5,21 @@
  * Message sending for the Lark/Feishu channel plugin.
  */
 
-import type { ClawdbotConfig } from 'openclaw/plugin-sdk';
-import type { FeishuSendResult, MentionInfo  } from '../types';
-import { createAccountScopedConfig } from '../../core/accounts';
+import type { ClawdbotConfig, RuntimeEnv } from 'openclaw/plugin-sdk';
+import type { HistoryEntry } from 'openclaw/plugin-sdk/reply-history';
+import type { FeishuSendResult, MentionInfo, MessageContext } from '../types';
+import type { FeishuGroupConfig, LarkAccount } from '../../core/types';
+import { createAccountScopedConfig, getLarkAccount, getDefaultLarkAccountId } from '../../core/accounts';
 import { LarkClient } from '../../core/lark-client';
 import { normalizeFeishuTarget, normalizeMessageId, resolveReceiveIdType } from '../../core/targets';
 import { runWithMessageUnavailableGuard } from '../../core/message-unavailable';
 import { optimizeMarkdownStyle } from '../../card/markdown-style';
 import { buildMentionedCardContent, buildMentionedMessage } from '../inbound/mention';
+import { resolveFeishuGroupConfig } from '../inbound/policy';
+import { dispatchToAgent } from '../inbound/dispatch';
+import { larkLogger } from '../../core/lark-logger';
+
+const log = larkLogger('outbound/send');
 
 // ---------------------------------------------------------------------------
 // Types
@@ -58,6 +65,172 @@ export interface SendFeishuCardParams {
   accountId?: string;
   /** When true, the reply appears in the thread instead of main chat. */
   replyInThread?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// A2A Cross-Bot Helper Functions
+// ---------------------------------------------------------------------------
+
+interface BotMentionInfo {
+  openId: string;
+  name: string;
+  key: string;
+  isBot: boolean;
+  accountId: string;
+}
+
+function extractBotMentionsFromText(
+  text: string | undefined,
+  botOpenIdToAccountId: Record<string, string> | undefined,
+): BotMentionInfo[] {
+  if (!text || !botOpenIdToAccountId) return [];
+
+  const atPattern = /<at user_id="([^"]+)">([^<]*)<\/at>/g;
+  const mentions: BotMentionInfo[] = [];
+  let match;
+
+  while ((match = atPattern.exec(text)) !== null) {
+    const openId = match[1]!;
+    const name = match[2] || openId;
+    const accountId = botOpenIdToAccountId[openId];
+
+    if (accountId) {
+      mentions.push({
+        openId,
+        name,
+        key: `<at user_id="${openId}">${name}</at>`,
+        isBot: true,
+        accountId,
+      });
+    }
+  }
+
+  return mentions;
+}
+
+async function notifyOtherBotsOfMention(params: {
+  mentions: BotMentionInfo[];
+  text: string | undefined;
+  accountId: string | undefined;
+  chatId: string | undefined;
+  cfg: ClawdbotConfig;
+  createdMessageId: string | undefined;
+}): Promise<void> {
+  const { mentions, text, accountId, chatId, cfg, createdMessageId } = params;
+
+  log.info(
+    `[A2A-CROSS-BOT] notifyOtherBotsOfMention: accountId=${accountId}, chatId=${chatId}, mentionsCount=${mentions?.length}, createdMessageId=${createdMessageId}`,
+  );
+
+  if (!mentions || mentions.length === 0) {
+    log.info('[A2A-CROSS-BOT] no mentions, returning');
+    return;
+  }
+
+  const botOpenIdToAccountId = cfg?.channels?.feishu?.botOpenIdToAccountId;
+  log.info(`[A2A-CROSS-BOT] botOpenIdToAccountId=${JSON.stringify(botOpenIdToAccountId)}`);
+
+  if (!botOpenIdToAccountId) {
+    log.info('[A2A-CROSS-BOT] no botOpenIdToAccountId mapping');
+    return;
+  }
+
+  const senderAccount = getLarkAccount(cfg, accountId);
+  const senderClient = LarkClient.fromCfg(cfg, accountId);
+  const senderBotOpenId = senderClient.botOpenId;
+  const senderBotName = senderClient.botName;
+  log.info(`[A2A-CROSS-BOT] senderBotOpenId=${senderBotOpenId}, senderBotName=${senderBotName}, senderAccount=${senderAccount?.accountId}`);
+
+  const senderAccountFeishuCfg = senderAccount?.config;
+  const groupConfig = resolveFeishuGroupConfig({ cfg: senderAccountFeishuCfg!, groupId: chatId! });
+  const defaultGroupConfig = senderAccountFeishuCfg?.groups?.['*'];
+
+  for (const mention of mentions) {
+    const mentionOpenId = mention.openId;
+    const targetAccountId = botOpenIdToAccountId[mentionOpenId];
+    log.info(`[A2A-CROSS-BOT] mentionOpenId=${mentionOpenId}, targetAccountId=${targetAccountId}`);
+
+    if (!targetAccountId || targetAccountId === accountId) {
+      log.info('[A2A-CROSS-BOT] skip: no mapping or self');
+      continue;
+    }
+
+    try {
+      const targetAccount = getLarkAccount(cfg, targetAccountId);
+      const targetClient = LarkClient.fromCfg(cfg, targetAccountId);
+      const targetBotName = targetClient.botName;
+      log.info(`[A2A-CROSS-BOT] targetAccount: ${targetAccount?.accountId} ${targetBotName}`);
+
+      const targetAccountFeishuCfg = targetAccount?.config;
+      const targetAccountScopedCfg: ClawdbotConfig = {
+        ...cfg,
+        channels: { ...cfg.channels, feishu: targetAccountFeishuCfg! },
+      };
+
+      const syntheticMentions: MentionInfo[] = mentions.map((m) => ({
+        openId: m.openId,
+        name: m.name,
+        key: m.key,
+        isBot: true,
+      }));
+
+      const fakeCtx: MessageContext = {
+        messageId: `crossbot-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
+        chatId: chatId || '',
+        content: text || '',
+        senderId: senderBotOpenId || 'crossbot-sender',
+        senderName: senderBotName || 'Cross-Bot',
+        chatType: 'group',
+        mentions: syntheticMentions,
+        mentionAll: false,
+        threadId: createdMessageId || undefined,
+        rootId: createdMessageId || undefined,
+        parentId: createdMessageId || undefined,
+        contentType: 'text',
+        resources: [],
+        rawMessage: {
+          message_id: `crossbot-${Date.now()}`,
+          chat_id: chatId || '',
+          chat_type: 'group',
+          message_type: 'text',
+          content: text || '',
+        },
+        rawSender: {
+          sender_id: { open_id: senderBotOpenId },
+          sender_type: 'bot',
+        },
+      };
+
+      const safeRuntime: RuntimeEnv = {
+        log: (...args: unknown[]) => log.info(args.join(' ')),
+        error: (...args: unknown[]) => log.error(args.join(' ')),
+        exit: (code?: number) => process.exit(code ?? 0),
+      };
+
+      await dispatchToAgent({
+        ctx: fakeCtx,
+        account: targetAccount!,
+        accountScopedCfg: targetAccountScopedCfg,
+        runtime: safeRuntime,
+        chatHistories: new Map<string, HistoryEntry[]>(),
+        quotedContent: undefined,
+        mediaPayload: {},
+        permissionError: undefined,
+        replyToMessageId: createdMessageId || undefined,
+        botOpenId: senderBotOpenId,
+        historyLimit: 10,
+        skipTyping: false,
+        commandAuthorized: true,
+        groupConfig,
+        defaultGroupConfig,
+      });
+
+      log.info(`[A2A-CROSS-BOT] notified ${targetAccountId} (openId=${mentionOpenId})`);
+    } catch (e) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      log.error(`[A2A-CROSS-BOT] failed to notify ${targetAccountId}: ${err.message}`);
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -204,10 +377,58 @@ export async function sendMessageFeishu(params: SendFeishuMessageParams): Promis
     },
   });
 
-  return {
+  const result: FeishuSendResult = {
     messageId: response?.data?.message_id ?? '',
     chatId: response?.data?.chat_id ?? '',
   };
+
+  const botOpenIdToAccountId = cfg?.channels?.feishu?.botOpenIdToAccountId;
+  log.info(
+    `[A2A-CROSS-BOT] sendMessageFeishu: botOpenIdToAccountId exists=${!!botOpenIdToAccountId}, text=${String(text)?.substring?.(0, 50)}`,
+  );
+
+  if (botOpenIdToAccountId) {
+    const textParsedMentions = extractBotMentionsFromText(text, botOpenIdToAccountId);
+    log.info(
+      `[A2A-CROSS-BOT] textParsedMentions count=${textParsedMentions.length}, accountIds=${textParsedMentions.map((m) => m.accountId).join(',')}`,
+    );
+
+    if (textParsedMentions.length > 0) {
+      log.info(
+        `[A2A-CROSS-BOT] sendMessageFeishu: found ${textParsedMentions.length} bot mentions, triggering notify for each`,
+      );
+
+      const allMentionsMap = new Map<string, BotMentionInfo>();
+      if (mentions && mentions.length > 0) {
+        for (const m of mentions) {
+          const oid = m.openId;
+          if (oid) allMentionsMap.set(oid, { openId: m.openId, name: m.name, key: m.key, isBot: true, accountId: '' });
+        }
+      }
+      for (const m of textParsedMentions) {
+        const oid = m.openId;
+        if (oid) allMentionsMap.set(oid, m);
+      }
+      const allMentions = Array.from(allMentionsMap.values());
+
+      log.info(
+        `[A2A-CROSS-BOT] sendMessageFeishu: explicit mentions=${mentions?.length}, text-parsed=${textParsedMentions.length}, total=${allMentions.length}`,
+      );
+
+      setImmediate(() => {
+        notifyOtherBotsOfMention({
+          mentions: allMentions,
+          text,
+          accountId,
+          chatId: target,
+          cfg,
+          createdMessageId: result.messageId,
+        }).catch((e) => log.error(`[A2A-CROSS-BOT] notify error: ${String(e)}`));
+      });
+    }
+  }
+
+  return result;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
新增 autoCreateThread 和 replyInThread 配置字段，支持在飞书群聊中自动为新对话创建话题，并控制回复是否在话题内进行。这允许更灵活地管理群聊会话结构，模拟内置频道的自动创建话题行为。

---

## Summary

Add `autoCreateThread` configuration option to enable automatic thread creation for new conversations in Feishu group chats, mirroring the built-in channel behavior.

## Motivation

The existing `threadSession` feature calls `isThreadCapableGroup` API which may return `false` for groups with certain settings, preventing thread creation. This new feature trusts the configuration directly and bypasses the API capability check.

## Changes

### 1. Configuration Schema (`src/core/config-schema.ts`)
- Added `autoCreateThread: z.enum(['disabled', 'enabled']).optional()` to `FeishuGroupSchema`
- Added `replyInThread: z.enum(['disabled', 'enabled']).optional()` to `FeishuGroupSchema`
- Added same config options to `FeishuAccountConfigSchema` for account-level override

### 2. Dispatch Logic (`src/messaging/inbound/dispatch.ts`)
- Added block 1c logic after thread session detection
- Auto-creates thread when:
  - `autoCreateThread` is set to `"enabled"`
  - Message is in a group chat
  - It's a new conversation (no `rootId` or `threadId`)
- Sets `dc.isThread = true` and uses `messageId` as `threadId`
- Logs `autoCreateThread: creating new thread in group ${chatId}`

## Usage Example

```json
{
  "channels": {
    "feishu": {
      "autoCreateThread": "enabled",
      "accounts": {
        "main": {
          "autoCreateThread": "enabled"
        }
      }
    }
  }
}
```

## Behavior

- **New conversations**: Creates a new thread automatically
- **Existing threads**: Respects the existing thread context
- **API capability**: Does NOT check `isThreadCapableGroup`, trusts config directly
- **Logging**: Outputs `autoCreateThread: creating new thread in group {chatId}` for debugging

## Testing

- [ ] Test in group chat with `autoCreateThread: "enabled"`
- [ ] Verify new conversations create threads
- [ ] Verify existing threads are respected
- [ ] Check logs for thread creation events
