### PR TITLE
fix: task schema

### DIFF
--- a/src/tools/oapi/task/comment.ts
+++ b/src/tools/oapi/task/comment.ts
@@ -22,18 +22,17 @@ import type { PaginatedData } from '../sdk-types';
 // Schema
 // ---------------------------------------------------------------------------
 
-const FeishuTaskCommentSchema = Type.Intersect([
-  Type.Object({
-    auth_type: Type.Optional(
-      StringEnum(['tenant', 'user'], {
-        description: '调用 API 时使用的 Token 类型。可选值："tenant"（应用身份） 或 "user"（用户身份）。默认使用 "user"。',
-      }),
-    ),
+const FeishuTaskCommentAuthType = Type.Optional(
+  StringEnum(['tenant', 'user'], {
+    description: '调用 API 时使用的 Token 类型。可选值："tenant"（应用身份） 或 "user"（用户身份）。默认使用 "user"。',
   }),
-  Type.Union([
+);
+
+const FeishuTaskCommentSchema = Type.Union([
   // CREATE (P1)
   Type.Object({
     action: Type.Literal('create'),
+    auth_type: FeishuTaskCommentAuthType,
     task_guid: Type.String({ description: '任务 GUID' }),
     content: Type.String({ description: '评论内容（纯文本，最长 3000 字符）' }),
     reply_to_comment_id: Type.Optional(Type.String({ description: '要回复的评论 ID（用于回复评论）' })),
@@ -42,6 +41,7 @@ const FeishuTaskCommentSchema = Type.Intersect([
   // LIST (P1)
   Type.Object({
     action: Type.Literal('list'),
+    auth_type: FeishuTaskCommentAuthType,
     resource_id: Type.String({ description: '要获取评论的资源 ID（任务 GUID）' }),
     direction: Type.Optional(
       StringEnum(['asc', 'desc'], {
@@ -55,9 +55,9 @@ const FeishuTaskCommentSchema = Type.Intersect([
   // GET (P1)
   Type.Object({
     action: Type.Literal('get'),
+    auth_type: FeishuTaskCommentAuthType,
     comment_id: Type.String({ description: '评论 ID' }),
   }),
-  ])
 ]);
 
 // ---------------------------------------------------------------------------

--- a/src/tools/oapi/task/section.ts
+++ b/src/tools/oapi/task/section.ts
@@ -24,18 +24,17 @@ import type { PaginatedData } from '../sdk-types';
 // Schema
 // ---------------------------------------------------------------------------
 
-const FeishuTaskSectionSchema = Type.Intersect([
-  Type.Object({
-    auth_type: Type.Optional(
-      StringEnum(['tenant', 'user'], {
-        description: '调用 API 时使用的 Token 类型。可选值："tenant"（应用身份） 或 "user"（用户身份）。默认使用 "user"。',
-      }),
-    ),
+const FeishuTaskSectionAuthType = Type.Optional(
+  StringEnum(['tenant', 'user'], {
+    description: '调用 API 时使用的 Token 类型。可选值："tenant"（应用身份） 或 "user"（用户身份）。默认使用 "user"。',
   }),
-  Type.Union([
+);
+
+const FeishuTaskSectionSchema = Type.Union([
   // CREATE
   Type.Object({
     action: Type.Literal('create'),
+    auth_type: FeishuTaskSectionAuthType,
     name: Type.String({
       description: '自定义分组名。不允许为空，最大100个utf8字符。',
     }),
@@ -61,6 +60,7 @@ const FeishuTaskSectionSchema = Type.Intersect([
   // GET
   Type.Object({
     action: Type.Literal('get'),
+    auth_type: FeishuTaskSectionAuthType,
     section_guid: Type.String({
       description: '要获取的自定义分组GUID',
     }),
@@ -70,6 +70,7 @@ const FeishuTaskSectionSchema = Type.Intersect([
   // PATCH
   Type.Object({
     action: Type.Literal('patch'),
+    auth_type: FeishuTaskSectionAuthType,
     section_guid: Type.String({
       description: '要更新的自定义分组GUID',
     }),
@@ -94,6 +95,7 @@ const FeishuTaskSectionSchema = Type.Intersect([
   // LIST
   Type.Object({
     action: Type.Literal('list'),
+    auth_type: FeishuTaskSectionAuthType,
     resource_type: StringEnum(['tasklist', 'my_tasks']),
     resource_id: Type.Optional(
       Type.String({
@@ -116,6 +118,7 @@ const FeishuTaskSectionSchema = Type.Intersect([
   // TASKS
   Type.Object({
     action: Type.Literal('tasks'),
+    auth_type: FeishuTaskSectionAuthType,
     section_guid: Type.String({
       description: '要获取任务的自定义分组全局唯一ID',
     }),
@@ -146,7 +149,6 @@ const FeishuTaskSectionSchema = Type.Intersect([
     ),
     user_id_type: Type.Optional(StringEnum(['open_id', 'union_id', 'user_id'])),
   }),
-  ])
 ]);
 
 // ---------------------------------------------------------------------------

--- a/src/tools/oapi/task/subtask.ts
+++ b/src/tools/oapi/task/subtask.ts
@@ -29,18 +29,17 @@ import type { PaginatedData } from '../sdk-types';
 // Schema
 // ---------------------------------------------------------------------------
 
-const FeishuTaskSubtaskSchema = Type.Intersect([
-  Type.Object({
-    auth_type: Type.Optional(
-      StringEnum(['tenant', 'user'], {
-        description: '调用 API 时使用的 Token 类型。可选值："tenant"（应用身份） 或 "user"（用户身份）。默认使用 "user"。',
-      }),
-    ),
+const FeishuTaskSubtaskAuthType = Type.Optional(
+  StringEnum(['tenant', 'user'], {
+    description: '调用 API 时使用的 Token 类型。可选值："tenant"（应用身份） 或 "user"（用户身份）。默认使用 "user"。',
   }),
-  Type.Union([
+);
+
+const FeishuTaskSubtaskSchema = Type.Union([
   // CREATE (P1)
   Type.Object({
     action: Type.Literal('create'),
+    auth_type: FeishuTaskSubtaskAuthType,
     task_guid: Type.String({ description: '父任务 GUID' }),
     summary: Type.String({ description: '子任务标题' }),
     description: Type.Optional(Type.String({ description: '子任务描述' })),
@@ -75,11 +74,11 @@ const FeishuTaskSubtaskSchema = Type.Intersect([
   // LIST (P1)
   Type.Object({
     action: Type.Literal('list'),
+    auth_type: FeishuTaskSubtaskAuthType,
     task_guid: Type.String({ description: '父任务 GUID' }),
     page_size: Type.Optional(Type.Number({ description: '每页数量，默认 50，最大 100' })),
     page_token: Type.Optional(Type.String({ description: '分页标记' })),
   }),
-  ])
 ]);
 
 // ---------------------------------------------------------------------------

--- a/src/tools/oapi/task/tasklist.ts
+++ b/src/tools/oapi/task/tasklist.ts
@@ -27,18 +27,17 @@ import type { PaginatedData } from '../sdk-types';
 // Schema
 // ---------------------------------------------------------------------------
 
-const FeishuTaskTasklistSchema = Type.Intersect([
-  Type.Object({
-    auth_type: Type.Optional(
-      StringEnum(['tenant', 'user'], {
-        description: '调用 API 时使用的 Token 类型。可选值："tenant"（应用身份） 或 "user"（用户身份）。默认使用 "user"。',
-      }),
-    ),
+const FeishuTaskTasklistAuthType = Type.Optional(
+  StringEnum(['tenant', 'user'], {
+    description: '调用 API 时使用的 Token 类型。可选值："tenant"（应用身份） 或 "user"（用户身份）。默认使用 "user"。',
   }),
-  Type.Union([
+);
+
+const FeishuTaskTasklistSchema = Type.Union([
     // CREATE (P0)
     Type.Object({
       action: Type.Literal('create'),
+      auth_type: FeishuTaskTasklistAuthType,
       name: Type.String({
         description: '清单名称',
       }),
@@ -61,6 +60,7 @@ const FeishuTaskTasklistSchema = Type.Intersect([
     // GET (P0)
     Type.Object({
       action: Type.Literal('get'),
+      auth_type: FeishuTaskTasklistAuthType,
       tasklist_guid: Type.String({ description: '清单 GUID' }),
       user_id_type: Type.Optional(StringEnum(['open_id', 'union_id', 'user_id'])),
     }),
@@ -68,6 +68,7 @@ const FeishuTaskTasklistSchema = Type.Intersect([
     // LIST (P0)
     Type.Object({
       action: Type.Literal('list'),
+      auth_type: FeishuTaskTasklistAuthType,
       page_size: Type.Optional(Type.Number({ description: '每页数量，默认 50，最大 100' })),
       page_token: Type.Optional(Type.String({ description: '分页标记' })),
       user_id_type: Type.Optional(StringEnum(['open_id', 'union_id', 'user_id'])),
@@ -76,6 +77,7 @@ const FeishuTaskTasklistSchema = Type.Intersect([
     // TASKS (P0) - 列出清单内的任务
     Type.Object({
       action: Type.Literal('tasks'),
+      auth_type: FeishuTaskTasklistAuthType,
       tasklist_guid: Type.String({ description: '清单 GUID' }),
       page_size: Type.Optional(Type.Number({ description: '每页数量，默认 50，最大 100' })),
       page_token: Type.Optional(Type.String({ description: '分页标记' })),
@@ -86,6 +88,7 @@ const FeishuTaskTasklistSchema = Type.Intersect([
     // PATCH (P1)
     Type.Object({
       action: Type.Literal('patch'),
+      auth_type: FeishuTaskTasklistAuthType,
       tasklist_guid: Type.String({ description: '清单 GUID' }),
       name: Type.Optional(Type.String({ description: '新的清单名称' })),
       user_id_type: Type.Optional(StringEnum(['open_id', 'union_id', 'user_id'])),
@@ -94,6 +97,7 @@ const FeishuTaskTasklistSchema = Type.Intersect([
     // ADD_MEMBERS (P1)
     Type.Object({
       action: Type.Literal('add_members'),
+      auth_type: FeishuTaskTasklistAuthType,
       tasklist_guid: Type.String({ description: '清单 GUID' }),
       members: Type.Array(
         Type.Object({
@@ -105,7 +109,6 @@ const FeishuTaskTasklistSchema = Type.Intersect([
       ),
       user_id_type: Type.Optional(StringEnum(['open_id', 'union_id', 'user_id'])),
     }),
-  ]),
 ]);
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- replace top-level `Type.Intersect([... , Type.Union(...)])` schemas with top-level `Type.Union(...)`
- inline `auth_type` into each action branch for compatibility with openclaw schema constraints

## Files
- `src/tools/oapi/task/tasklist.ts`
- `src/tools/oapi/task/comment.ts`
- `src/tools/oapi/task/subtask.ts`
- `src/tools/oapi/task/section.ts`

## Reason
Openclaw requires the top-level schema to be `Type.Union`, and does not support `Type.Intersect` at the top level for these tool parameter schemas.