### PR TITLE
fix: fallback to global inboundMeta.sender_id when LarkTicket unavailable

### DIFF
--- a/src/core/tool-client.ts
+++ b/src/core/tool-client.ts
@@ -516,13 +516,21 @@ export function createToolClient(config: ClawdbotConfig, accountIndex = 0): Tool
     account = fallback;
   }
 
-  // 2. 获取 SDK 实例（复用 LarkClient 的缓存）
+  // 2. 获取 senderOpenId — 优先级：
+  // 1. LarkTicket（来自 WebSocket 消息处理上下文）
+  // 2. 全局 openclaw.inboundMeta.sender_id（来自子代理调度场景）
+  let senderOpenId: string | undefined = ticket?.senderOpenId;
+  if (!senderOpenId && typeof global !== 'undefined' && (global as any).openclaw?.inboundMeta?.sender_id) {
+    senderOpenId = (global as any).openclaw.inboundMeta.sender_id;
+  }
+
+  // 3. 获取 SDK 实例（复用 LarkClient 的缓存）
   const larkClient = LarkClient.fromAccount(account);
 
-  // 3. 组装 ToolClient
+  // 4. 组装 ToolClient
   return new ToolClient({
     account,
-    senderOpenId: ticket?.senderOpenId,
+    senderOpenId,
     sdk: larkClient.sdk,
     config,
   });


### PR DESCRIPTION
## Summary

When ToolClient is created in sub-agent scheduling scenarios (e.g. PA dispatching), the AsyncLocalStorage (LarkTicket) context is lost, causing ticket.senderOpenId to be undefined. This triggers unnecessary fallback to the app owner and generates excessive "Using app owner as fallback user" logs.

## Fix

Adds a secondary fallback path that reads sender_id from global.openclaw.inboundMeta (set by the OpenClaw runtime), ensuring correct user identity is used even when LarkTicket context is missing.

## Changes

- src/core/tool-client.ts: In createToolClient(), added fallback to global.openclaw.inboundMeta.sender_id when ticket.senderOpenId is unavailable
- Type-safe: uses (global as any).openclaw?.inboundMeta?.sender_id to avoid TypeScript type dependency on OpenClaw internals

## Testing

Verified locally: after restart, no new "Using app owner as fallback user" logs appear in sub-agent scenarios.

Fixes: excessive fallback logs in sub-agent scheduling