### PR TITLE
feat: make FEISHU_CARD_TABLE_LIMIT configurable via cardTableLimit

### DIFF
--- a/src/card/card-error.ts
+++ b/src/card/card-error.ts
@@ -29,8 +29,31 @@ export const CARD_CONTENT_SUB_ERROR = {
   ELEMENT_LIMIT: 11310,
 } as const;
 
-// 经验性的飞书卡片表格上限 -- 4+ 张触发 230099/11310（2026-03 实测）。
+/** 飞书卡片表格上限缺省值（可通过 channels.feishu.cardTableLimit 覆盖）。 */
 export const FEISHU_CARD_TABLE_LIMIT = 3;
+
+/**
+ * 解析实际生效的卡片表格数量上限。
+ *
+ * 配置优先级：channels.feishu.cardTableLimit > FEISHU_CARD_TABLE_LIMIT（缺省 3）。
+ * - 不设置 / 缺省 → 3
+ * - 0 或 false → 关闭限制（不 sanitize，不 fallback 到纯文本）
+ * - 正整数（如 50）→ 自定义上限
+ */
+export function resolveTableLimit(feishuCfgOrRootCfg: Record<string, unknown> | undefined): number {
+  // 支持直接传入 feishuCfg 或传入根 config（自动提取 channels.feishu）
+  const feishuCfg = feishuCfgOrRootCfg?.cardTableLimit !== undefined
+    ? feishuCfgOrRootCfg
+    : (feishuCfgOrRootCfg as Record<string, unknown>)?.channels as Record<string, unknown>?.feishu as Record<string, unknown> | undefined;
+  if (feishuCfg?.cardTableLimit === 0 || feishuCfg?.cardTableLimit === false) {
+    return Infinity; // 关闭限制
+  }
+  const configured = Number(feishuCfg?.cardTableLimit);
+  if (Number.isFinite(configured) && configured > 0 && Number.isInteger(configured)) {
+    return configured;
+  }
+  return FEISHU_CARD_TABLE_LIMIT; // 缺省 3
+}
 
 export interface MarkdownTableMatch {
   index: number;

--- a/src/card/reply-dispatcher.ts
+++ b/src/card/reply-dispatcher.ts
@@ -247,7 +247,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
 
       // ---- Static text delivery ----
       if (text.trim()) {
-        if (shouldUseCard(text)) {
+        if (shouldUseCard(text, feishuCfg)) {
           const chunks = core.channel.text.chunkTextWithMode(text, textChunkLimit, chunkMode);
           log.info('deliver: sending card chunks', {
             count: chunks.length,

--- a/src/card/reply-mode.ts
+++ b/src/card/reply-mode.ts
@@ -9,7 +9,7 @@
  */
 
 import type { FeishuConfig } from '../core/types';
-import { FEISHU_CARD_TABLE_LIMIT, findMarkdownTablesOutsideCodeBlocks } from './card-error';
+import { FEISHU_CARD_TABLE_LIMIT, findMarkdownTablesOutsideCodeBlocks, resolveTableLimit } from './card-error';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -75,10 +75,11 @@ export function expandAutoMode(params: {
  * being rendered inside a Feishu interactive card (fenced code blocks or
  * markdown tables).
  */
-export function shouldUseCard(text: string): boolean {
+export function shouldUseCard(text: string, feishuCfg?: Record<string, unknown>): boolean {
   // Table limit takes priority -- even with code blocks, too many tables will fail
+  const tableLimit = resolveTableLimit(feishuCfg);
   const tableMatches = findMarkdownTablesOutsideCodeBlocks(text);
-  if (tableMatches.length > FEISHU_CARD_TABLE_LIMIT) {
+  if (tableMatches.length > tableLimit && tableLimit !== Infinity) {
     return false;
   }
   // Fenced code blocks

--- a/src/card/streaming-card-controller.ts
+++ b/src/card/streaming-card-controller.ts
@@ -619,6 +619,8 @@ export class StreamingCardController {
             reasoningText: this.reasoning.accumulatedReasoningText || undefined,
           },
           this.imageResolver,
+          undefined,
+          this.deps.cfg,
         );
         const errorCard = buildCardContent('complete', {
           text: terminalContent.text,
@@ -705,6 +707,8 @@ export class StreamingCardController {
             reasoningText: this.reasoning.accumulatedReasoningText || undefined,
           },
           this.imageResolver,
+          undefined,
+          this.deps.cfg,
         );
         const footerMetrics = this.needsFooterMetrics() ? await this.getFooterSessionMetrics() : undefined;
 
@@ -787,6 +791,8 @@ export class StreamingCardController {
           reasoningText: this.reasoning.accumulatedReasoningText || undefined,
         },
         this.imageResolver,
+        undefined,
+        this.deps.cfg,
       );
       const footerMetrics = this.needsFooterMetrics() ? await this.getFooterSessionMetrics() : undefined;
       if (effectiveCardId) {
@@ -1164,12 +1170,14 @@ export function prepareTerminalCardContent(
   content: TerminalCardContentInput,
   imageResolver: TerminalCardTextImageResolver,
   tableLimit: number = FEISHU_CARD_TABLE_LIMIT,
+  feishuCfg?: Record<string, unknown>,
 ): TerminalCardContentInput {
+  const resolvedLimit = feishuCfg ? resolveTableLimit(feishuCfg) : tableLimit;
   const resolvedReasoningText = content.reasoningText ? imageResolver.resolveImages(content.reasoningText) : undefined;
   const resolvedText = imageResolver.resolveImages(content.text);
   const sanitizedSegments = sanitizeTextSegmentsForCard(
     resolvedReasoningText ? [resolvedReasoningText, resolvedText] : [resolvedText],
-    tableLimit,
+    resolvedLimit,
   );
 
   if (resolvedReasoningText) {


### PR DESCRIPTION
## Summary

Fixes #435

将 FEISHU_CARD_TABLE_LIMIT 从硬编码常量改为可配置项 channels.feishu.cardTableLimit。

## Problem

Streaming Card 模式下，第 4 个 Markdown 表格起被 sanitizeTextForCard() 强制降级为代码块，而 Static 模式下同样内容正常渲染。原因是 FEISHU_CARD_LIMIT = 3 硬编码且无法通过配置调整。

## Changes

- src/card/card-error.ts：新增 resolveTableLimit(feishuCfg) 函数
- src/card/reply-mode.ts：shouldUseCard() 新增可选 feishuCfg 参数
- src/card/streaming-card-controller.ts：prepareTerminalCardContent() 新增可选 feishuCfg 参数
- src/card/reply-dispatcher.ts：向 shouldUseCard() 传入 feishuCfg

## Configuration

| 值 | 行为 |
|---|------|
| 不设置 | 3（缺省） |
| 0 / false | 关闭限制 |
| 正整数 | 自定义上限 |