### PR TITLE
feat: task agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@larksuiteoapi/node-sdk": "^1.60.0",
     "@sinclair/typebox": "0.34.48",
     "image-size": "^2.0.2",
+    "undici-types": "^8.1.0",
     "zod": "^4.3.6"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       image-size:
         specifier: ^2.0.2
         version: 2.0.2
+      undici-types:
+        specifier: ^8.1.0
+        version: 8.1.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -4181,6 +4184,9 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici-types@8.1.0:
+    resolution: {integrity: sha512-JlLXdMmH4kxyn2JPtGK/cajzKY7F15OKYG8sO5HfkIC1AC09sLUeptGFKjnMWnprDQ2EwzYDO3kgzkK3aaoHCA==}
 
   undici@7.24.6:
     resolution: {integrity: sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==}
@@ -9456,6 +9462,8 @@ snapshots:
   undici-types@7.16.0: {}
 
   undici-types@7.18.2: {}
+
+  undici-types@8.1.0: {}
 
   undici@7.24.6: {}
 

--- a/skills/feishu-task/SKILL.md
+++ b/skills/feishu-task/SKILL.md
@@ -9,6 +9,9 @@ description: |
   (3) 需要查看任务列表或清单内的任务
   (4) 用户提到"任务"、"待办"、"to-do"、"清单"、"task"
   (5) 需要设置任务负责人、关注人、截止时间、添加成员
+  (6) 需要追加任务步骤记录（Task 的 steps）
+  (7) 需要上传任务附件（支持 task / task_delivery）
+  (8) 需要注册 Agent / 更新 Agent 信息（register / update_profile）
 ---
 
 # 飞书任务管理
@@ -17,11 +20,13 @@ description: |
 
 - ✅ **时间格式**：ISO 8601 / RFC 3339（带时区），例如 `2026-02-28T17:00:00+08:00`
 - ✅ **身份授权**：工具支持 `auth_type` 为 `user`（默认，用户身份）或 `tenant`（应用身份）。
+- ✅ **任务 Agent（feishu_task_agent）**：仅支持应用身份（tenant），不支持 user 身份
 - ✅ **current_user_id 强烈建议**：从消息上下文的 SenderId 获取（ou_...），工具会自动添加为 follower（如不在 members 中），确保创建者可以编辑任务
 - ✅ **patch/get 必须**：task_guid
 - ✅ **tasklist.tasks 必须**：tasklist_guid
 - ✅ **完成任务**：completed_at = "2026-02-26 15:00:00"
 - ✅ **反完成（恢复未完成）**：completed_at = "0"
+- ✅ **append_steps 的 task_steps[].timestamp**：秒级 Unix 时间戳（10 位），不要用毫秒（13 位）
 
 ---
 
@@ -30,15 +35,19 @@ description: |
 | 用户意图 | 工具 | action | 必填参数 | 强烈建议 | 常用可选 |
 |---------|------|--------|---------|---------|---------|
 | 新建待办 | feishu_task_task | create | summary | current_user_id（SenderId） | members, due, description, auth_type |
-| 查未完成任务 | feishu_task_task | list | - | completed=false | page_size, auth_type |
+| 查未完成任务 | feishu_task_task | list | - | completed=false | page_size, auth_type, agent_task_status |
 | 获取任务详情 | feishu_task_task | get | task_guid | - | auth_type |
 | 完成任务 | feishu_task_task | patch | task_guid, completed_at | - | auth_type |
 | 反完成任务 | feishu_task_task | patch | task_guid, completed_at="0" | - | auth_type |
 | 改截止时间 | feishu_task_task | patch | task_guid, due | - | auth_type |
 | 添加任务成员 | feishu_task_task | add_members | task_guid, members[] | - | auth_type |
+| 追加任务步骤记录 | feishu_task_task | append_steps | task_guid, idempotent_key, task_steps[] | task_steps[].timestamp 用秒级（10 位） | - |
 | 创建清单 | feishu_task_tasklist | create | name | - | members |
 | 查看清单任务 | feishu_task_tasklist | tasks | tasklist_guid | - | completed |
 | 添加清单成员 | feishu_task_tasklist | add_members | tasklist_guid, members[] | - | - |
+| 上传任务附件 | feishu_task_attachment | upload | resource_id, file(base64) | name | resource_type |
+| 注册任务 Agent | feishu_task_agent | register | - | 仅支持 tenant（应用身份） | - |
+| 更新任务 Agent Profile | feishu_task_agent | update_profile | profile_content | 仅支持 tenant（应用身份） | - |
 
 ---
 
@@ -230,6 +239,25 @@ description: |
     "timestamp": "2026-03-01 00:00:00",
     "is_all_day": true
   }
+}
+```
+
+### 场景 9: 注册任务 Agent（仅应用身份）
+
+```json
+{
+  "action": "register",
+  "auth_type": "tenant"
+}
+```
+
+### 场景 10: 更新任务 Agent Profile（仅应用身份）
+
+```json
+{
+  "action": "update_profile",
+  "auth_type": "tenant",
+  "profile_content": "some profile content"
 }
 ```
 

--- a/src/core/raw-request.ts
+++ b/src/core/raw-request.ts
@@ -8,6 +8,8 @@
  * 用于 SDK 未覆盖的 API 或需要精细控制请求的场景。
  */
 
+import {URLSearchParams} from "node:url";
+import type {BodyInit} from "undici-types";
 import type { LarkBrand } from './types';
 import { feishuFetch } from './feishu-fetch';
 
@@ -38,6 +40,31 @@ export interface RawLarkRequestOptions {
   accessToken?: string;
 }
 
+function isFormDataBody(body: unknown): boolean {
+  return (
+    typeof body === 'object' &&
+    body !== null &&
+    typeof (body as { append?: unknown }).append === 'function' &&
+    typeof (body as { entries?: unknown }).entries === 'function'
+  );
+}
+
+function isBinaryBody(body: unknown): boolean {
+  return body instanceof ArrayBuffer || ArrayBuffer.isView(body);
+}
+
+
+function buildRequestBody(body: unknown): { headers?: Record<string, string>; body: BodyInit | string } {
+  if (typeof body === 'string' || body instanceof URLSearchParams || isFormDataBody(body) || isBinaryBody(body)) {
+    return { body: body as BodyInit | string };
+  }
+
+  return {
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  };
+}
+
 /**
  * 发起 raw HTTP 请求到飞书 API，自动处理域名解析、header 注入和错误检测。
  *
@@ -53,11 +80,16 @@ export async function rawLarkRequest<T>(options: RawLarkRequestOptions): Promise
   }
 
   const headers: Record<string, string> = {};
+  let requestBody: BodyInit | string | undefined;
   if (options.accessToken) {
     headers['Authorization'] = `Bearer ${options.accessToken}`;
   }
   if (options.body !== undefined) {
-    headers['Content-Type'] = 'application/json';
+    const prepared = buildRequestBody(options.body);
+    requestBody = prepared.body;
+    if (prepared.headers) {
+      Object.assign(headers, prepared.headers);
+    }
   }
   if (options.headers) {
     Object.assign(headers, options.headers);
@@ -66,7 +98,7 @@ export async function rawLarkRequest<T>(options: RawLarkRequestOptions): Promise
   const resp = await feishuFetch(url.toString(), {
     method: options.method ?? 'GET',
     headers,
-    ...(options.body !== undefined ? { body: JSON.stringify(options.body) } : {}),
+    ...(requestBody !== undefined ? { body: requestBody } : {}),
   });
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/core/tool-scopes.ts
+++ b/src/core/tool-scopes.ts
@@ -124,6 +124,7 @@ export type ToolActionKey =
   | 'feishu_im_user_search_messages.default'
   | 'feishu_search_doc_wiki.search'
   | 'feishu_search_user.default'
+  | 'feishu_task_attachment.upload'
   | 'feishu_task_comment.create'
   | 'feishu_task_comment.get'
   | 'feishu_task_comment.list'
@@ -139,12 +140,15 @@ export type ToolActionKey =
   | 'feishu_task_task.list'
   | 'feishu_task_task.patch'
   | 'feishu_task_task.add_members'
+  | 'feishu_task_task.append_steps'
   | 'feishu_task_tasklist.add_members'
   | 'feishu_task_tasklist.create'
   | 'feishu_task_tasklist.get'
   | 'feishu_task_tasklist.list'
   | 'feishu_task_tasklist.patch'
   | 'feishu_task_tasklist.tasks'
+  | 'feishu_task_agent.register'
+  | 'feishu_task_agent.update_profile'
   | 'feishu_update_doc.default'
   | 'feishu_wiki_space.create'
   | 'feishu_wiki_space.get'
@@ -230,11 +234,13 @@ export const TOOL_SCOPES: ToolScopeMapping = {
   'feishu_calendar_event_attendee.create': ['calendar:calendar.event:update'],
   'feishu_calendar_event_attendee.list': ['calendar:calendar.event:read'],
   'feishu_calendar_freebusy.list': ['calendar:calendar.free_busy:read'],
+  'feishu_task_attachment.upload': ['task:attachment:write'],
   'feishu_task_task.create': ['task:task:write', 'task:task:writeonly'],
   'feishu_task_task.get': ['task:task:read', 'task:task:write'],
   'feishu_task_task.list': ['task:task:read', 'task:task:write'],
   'feishu_task_task.patch': ['task:task:write', 'task:task:writeonly'],
   'feishu_task_task.add_members': ['task:task:write', 'task:task:writeonly'],
+  'feishu_task_task.append_steps': ['task:task:write', 'task:task:writeonly'],
   'feishu_task_tasklist.create': ['task:tasklist:write'],
   'feishu_task_tasklist.get': ['task:tasklist:read', 'task:tasklist:write'],
   'feishu_task_tasklist.list': ['task:tasklist:read', 'task:tasklist:write'],
@@ -251,6 +257,8 @@ export const TOOL_SCOPES: ToolScopeMapping = {
   'feishu_task_section.tasks': ['task:task'],
   'feishu_task_subtask.create': ['task:task:write'],
   'feishu_task_subtask.list': ['task:task:read', 'task:task:write'],
+  'feishu_task_agent.register': ['task:task:write'],
+  'feishu_task_agent.update_profile': ['task:task:write', 'task:task:writeonly'],
   'feishu_chat.search': ['im:chat:read'],
   'feishu_chat.get': ['im:chat:read'],
   'feishu_chat_members.default': ['im:chat.members:read'],

--- a/src/tools/oapi/index.ts
+++ b/src/tools/oapi/index.ts
@@ -17,6 +17,8 @@ import {
   registerFeishuCalendarFreebusyTool,
 } from './calendar/index';
 import {
+  registerFeishuTaskAgentTool,
+  registerFeishuTaskAttachmentTool,
   registerFeishuTaskCommentTool,
   registerFeishuTaskSectionTool,
   registerFeishuTaskSubtaskTool,
@@ -61,9 +63,11 @@ export function registerOapiTools(api: OpenClawPluginApi): void {
   // Task tools
   registerFeishuTaskTaskTool(api);
   registerFeishuTaskTasklistTool(api);
+  registerFeishuTaskAttachmentTool(api);
   registerFeishuTaskSectionTool(api);
   registerFeishuTaskCommentTool(api);
   registerFeishuTaskSubtaskTool(api);
+  registerFeishuTaskAgentTool(api);
 
   // Bitable tools
   registerFeishuBitableAppTool(api);

--- a/src/tools/oapi/task/attachment.ts
+++ b/src/tools/oapi/task/attachment.ts
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * feishu_task_attachment tool -- Manage task attachments.
+ *
+ * Actions:
+ * - upload: Upload task attachment (tenant identity)
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import type { OpenClawPluginApi } from 'openclaw/plugin-sdk';
+import { Type } from '@sinclair/typebox';
+
+import { StringEnum, createToolContext, handleInvokeErrorWithAutoAuth, json, registerTool } from '../helpers';
+import { rawLarkRequest } from '../../../core/raw-request';
+
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+const FeishuTaskAttachmentSchema = Type.Union([
+  Type.Object({
+    action: Type.Literal('upload'),
+    resource_type: Type.Optional(
+      StringEnum(['task', 'task_delivery'], {
+        description: '资源类型，可选值：task、task_delivery。默认 task。',
+        default: 'task',
+      }),
+    ),
+    resource_id: Type.String({
+      description: '资源 ID。',
+    }),
+    file: Type.String({
+      description: '文件内容base64编码字符串',
+    }),
+    name: Type.Optional(Type.String({
+      description: '文件名。',
+    })),
+  }),
+]);
+
+export interface FeishuTaskAttachmentParams {
+  action: 'upload';
+  resource_type?: 'task' | 'task_delivery';
+  resource_id: string;
+  file: string;
+  name?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function resolvePathForAction(action: FeishuTaskAttachmentParams['action']): { path: string; env: string[] } {
+  if (action === 'upload') {
+    return { path: '/open-apis/task/v2/attachments/upload', env: [] };
+  }
+  return { path: '/open-apis/task/v2/attachments/upload', env: [] };
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerFeishuTaskAttachmentTool(api: OpenClawPluginApi): void {
+    if (!api.config) return;
+    const cfg = api.config;
+
+    const { toolClient } = createToolContext(api, 'feishu_task_attachment');
+
+    registerTool(
+        api,
+        {
+            name: 'feishu_task_attachment',
+            label: 'Feishu Task Attachment',
+            description: '飞书任务附件工具。当前提供 upload action，用于上传任务附件。',
+            parameters: FeishuTaskAttachmentSchema,
+            async execute(_toolCallId: string, params: unknown) {
+                const p = params as FeishuTaskAttachmentParams;
+                try {
+                    const resolved = resolvePathForAction(p.action);
+                    const client = toolClient();
+
+                    const resourceType = p.resource_type ?? 'task';
+                    const formData = new FormData();
+
+                    formData.append('resource_type', resourceType);
+                    formData.append('resource_id', p.resource_id);
+
+                    // 将 base64 字符串解码为二进制文件
+                    const fileBuffer = Buffer.from(p.file, 'base64');
+                    // 创建 File 对象并添加到 FormData
+
+                    const file = new File([fileBuffer], p.name ?? 'attachment');
+                    formData.append('file', file);
+
+                    const as = 'tenant';
+
+                    const tatRes = await rawLarkRequest<{
+                        tenant_access_token?: string;
+                        [k: string]: unknown;
+                    }>({
+                        brand: client.account.brand,
+                        path: '/open-apis/auth/v3/tenant_access_token/internal/',
+                        method: 'POST',
+                        body: {
+                            app_id: client.account.appId,
+                            app_secret: client.account.appSecret,
+                        },
+                    });
+                    const token = tatRes?.tenant_access_token;
+                    if (!token) {
+                        return json({
+                            error: 'Failed to get tenant_access_token.',
+                            response: tatRes,
+                        });
+                    }
+
+                    const res = await client.invokeByPath('feishu_task_attachment.upload', resolved.path, {
+                        method: 'POST',
+                        as,
+                        body: formData,
+                        headers: {
+                            'Authorization': `Bearer ${token}`,
+                        },
+                    });
+                    return json(res);
+                } catch (err) {
+                    return await handleInvokeErrorWithAutoAuth(err, cfg);
+                }
+            },
+        },
+        { name: 'feishu_task_attachment' },
+    );
+}

--- a/src/tools/oapi/task/index.ts
+++ b/src/tools/oapi/task/index.ts
@@ -5,6 +5,8 @@
 
 export { registerFeishuTaskTaskTool } from './task';
 export { registerFeishuTaskTasklistTool } from './tasklist';
+export { registerFeishuTaskAttachmentTool } from './attachment';
 export { registerFeishuTaskCommentTool } from './comment';
 export { registerFeishuTaskSubtaskTool } from './subtask';
 export { registerFeishuTaskSectionTool } from './section';
+export { registerFeishuTaskAgentTool } from './task_agent';

--- a/src/tools/oapi/task/task.ts
+++ b/src/tools/oapi/task/task.ts
@@ -5,7 +5,7 @@
  * feishu_task_task tool -- Manage Feishu tasks.
  *
  * P0 Actions: create, get, list, patch
- * P1 Actions: add_members
+ * P1 Actions: add_members, append_steps
  *
  * Uses the Feishu Task v2 API:
  *   - create: POST /open-apis/task/v2/tasks
@@ -13,6 +13,7 @@
  *   - list:   GET  /open-apis/task/v2/tasks
  *   - patch:  PATCH /open-apis/task/v2/tasks/:task_guid
  *   - add_members: POST /open-apis/task/v2/tasks/:task_guid/add_members
+ *   - append_steps: POST /open-apis/task/v2/agent_task_step_info/append_task_steps
  */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -28,6 +29,7 @@ import {
   registerTool,
 } from '../helpers';
 import type { PaginatedData, TaskCreateData } from '../sdk-types';
+import { rawLarkRequest } from '../../../core/raw-request';
 
 // ---------------------------------------------------------------------------
 // Schema
@@ -157,6 +159,11 @@ const FeishuTaskTaskSchema = Type.Union([
         description: '是否筛选已完成任务',
       }),
     ),
+    agent_task_status: Type.Optional(
+      Type.Integer({
+        description: 'Agent 任务状态',
+      }),
+    ),
     auth_type: Type.Optional(
       StringEnum(['tenant', 'user'], {
         description: '授权类型，默认 user。',
@@ -211,6 +218,21 @@ const FeishuTaskTaskSchema = Type.Union([
       Type.String({
         description:
           "完成时间。支持三种格式：1) ISO 8601 / RFC 3339 格式（包含时区），例如 '2024-01-01T00:00:00+08:00'（设为已完成）；2) '0'（反完成，任务变为未完成）；3) 毫秒时间戳字符串。",
+      }),
+    ),
+    agent_task_progress: Type.Optional(
+      Type.String({
+        description: 'Agent 任务进度',
+      }),
+    ),
+    agent_task_status: Type.Optional(
+      Type.Integer({
+        description: 'Agent 任务状态',
+      }),
+    ),
+    text_deliveries: Type.Optional(
+      Type.Array(Type.String(), {
+        description: '文本交付列表',
       }),
     ),
     members: Type.Optional(
@@ -275,6 +297,34 @@ const FeishuTaskTaskSchema = Type.Union([
       StringEnum(['open_id', 'union_id', 'user_id']),
     ),
   }),
+
+  // APPEND_STEPS
+  Type.Object({
+    action: Type.Literal('append_steps'),
+    task_guid: Type.String({
+      description: '任务 GUID',
+    }),
+    idempotent_key: Type.String({
+      description: '幂等键',
+    }),
+    task_steps: Type.Array(
+      Type.Object({
+        quote: Type.String({
+          description: '步骤引用信息',
+        }),
+        content: Type.String({
+          description: '步骤内容',
+        }),
+        timestamp: Type.Integer({
+          description: '步骤时间戳',
+        }),
+      }),
+      {
+        description: '要追加的任务步骤列表',
+        minItems: 1,
+      },
+    ),
+  }),
 ]);
 
 // ---------------------------------------------------------------------------
@@ -283,80 +333,94 @@ const FeishuTaskTaskSchema = Type.Union([
 
 type FeishuTaskTaskParams =
   | {
-      action: 'create';
-      summary: string;
-      current_user_id?: string;
-      description?: string;
-      due?: {
-        timestamp: string;
-        is_all_day?: boolean;
-      };
-      start?: {
-        timestamp: string;
-        is_all_day?: boolean;
-      };
-      members?: Array<{
-        id: string;
-        type?: 'user' | 'app';
-        role?: 'assignee' | 'follower';
-      }>;
-      repeat_rule?: string;
-      tasklists?: Array<{
-        tasklist_guid: string;
-        section_guid?: string;
-      }>;
-      auth_type?: 'tenant' | 'user';
-      user_id_type?: 'open_id' | 'union_id' | 'user_id';
-    }
-  | {
-      action: 'get';
-      task_guid: string;
-      auth_type?: 'tenant' | 'user';
-      user_id_type?: 'open_id' | 'union_id' | 'user_id';
-    }
-  | {
-      action: 'list';
-      page_size?: number;
-      page_token?: string;
-      completed?: boolean;
-      auth_type?: 'tenant' | 'user';
-      user_id_type?: 'open_id' | 'union_id' | 'user_id';
-    }
-  | {
-      action: 'patch';
-      task_guid: string;
-      summary?: string;
-      description?: string;
-      due?: {
-        timestamp: string;
-        is_all_day?: boolean;
-      };
-      start?: {
-        timestamp: string;
-        is_all_day?: boolean;
-      };
-      completed_at?: string;
-      members?: Array<{
-        id: string;
-        type?: 'user' | 'app';
-        role?: 'assignee' | 'follower';
-      }>;
-      repeat_rule?: string;
-      auth_type?: 'tenant' | 'user';
-      user_id_type?: 'open_id' | 'union_id' | 'user_id';
-    }
-  | {
-      action: 'add_members';
-      task_guid: string;
-      members: Array<{
-        id: string;
-        type?: 'user' | 'app';
-        role?: 'assignee' | 'follower';
-      }>;
-      client_token?: string;
-      auth_type?: 'tenant' | 'user';
-      user_id_type?: 'open_id' | 'union_id' | 'user_id';
+    action: 'create';
+    summary: string;
+    current_user_id?: string;
+    description?: string;
+    due?: {
+      timestamp: string;
+      is_all_day?: boolean;
     };
+    start?: {
+      timestamp: string;
+      is_all_day?: boolean;
+    };
+    members?: Array<{
+      id: string;
+      type?: 'user' | 'app';
+      role?: 'assignee' | 'follower';
+    }>;
+    repeat_rule?: string;
+    tasklists?: Array<{
+      tasklist_guid: string;
+      section_guid?: string;
+    }>;
+    auth_type?: 'tenant' | 'user';
+    user_id_type?: 'open_id' | 'union_id' | 'user_id';
+  }
+  | {
+    action: 'get';
+    task_guid: string;
+    auth_type?: 'tenant' | 'user';
+    user_id_type?: 'open_id' | 'union_id' | 'user_id';
+  }
+  | {
+    action: 'list';
+    page_size?: number;
+    page_token?: string;
+    completed?: boolean;
+    agent_task_status?: number;
+    auth_type?: 'tenant' | 'user';
+    user_id_type?: 'open_id' | 'union_id' | 'user_id';
+  }
+  | {
+    action: 'patch';
+    task_guid: string;
+    summary?: string;
+    description?: string;
+    due?: {
+      timestamp: string;
+      is_all_day?: boolean;
+    };
+    start?: {
+      timestamp: string;
+      is_all_day?: boolean;
+    };
+    completed_at?: string;
+    agent_task_progress?: string;
+    agent_task_status?: number;
+    text_deliveries?: string[];
+    members?: Array<{
+      id: string;
+      type?: 'user' | 'app';
+      role?: 'assignee' | 'follower';
+    }>;
+    repeat_rule?: string;
+    auth_type?: 'tenant' | 'user';
+    user_id_type?: 'open_id' | 'union_id' | 'user_id';
+  }
+  | {
+    action: 'add_members';
+    task_guid: string;
+    members: Array<{
+      id: string;
+      type?: 'user' | 'app';
+      role?: 'assignee' | 'follower';
+    }>;
+    client_token?: string;
+    auth_type?: 'tenant' | 'user';
+    user_id_type?: 'open_id' | 'union_id' | 'user_id';
+  }
+  | {
+    action: 'append_steps';
+    task_guid: string;
+    idempotent_key: string;
+    task_steps: Array<{
+      quote: string;
+      content: string;
+      timestamp: number;
+    }>;
+  };
 
 // ---------------------------------------------------------------------------
 // Registration
@@ -374,7 +438,7 @@ export function registerFeishuTaskTaskTool(api: OpenClawPluginApi): void {
       name: 'feishu_task_task',
       label: 'Feishu Task Management',
       description:
-        "【以用户或应用身份】飞书任务管理工具。用于创建、查询、更新任务。Actions: create（创建任务）, get（获取任务详情）, list（查询任务列表，仅返回我负责的任务）, patch（更新任务）, add_members（添加任务成员）。时间参数使用ISO 8601 / RFC 3339 格式（包含时区），例如 '2024-01-01T00:00:00+08:00'。支持通过 auth_type 参数切换用户(user)或应用(tenant)身份。",
+        "【以用户或应用身份】飞书任务管理工具。用于创建、查询、更新任务。Actions: create（创建任务）, get（获取任务详情）, list（查询任务列表，仅返回我负责的任务）, patch（更新任务）, add_members（添加任务成员）, append_steps（追加任务步骤记录）。时间参数使用ISO 8601 / RFC 3339 格式（包含时区），例如 '2024-01-01T00:00:00+08:00'。支持通过 auth_type 参数切换用户(user)或应用(tenant)身份；append_steps 固定使用应用身份。",
       parameters: FeishuTaskTaskSchema,
       async execute(_toolCallId: string, params: unknown) {
         const p = params as FeishuTaskTaskParams;
@@ -502,6 +566,7 @@ export function registerFeishuTaskTaskTool(api: OpenClawPluginApi): void {
                         page_size: p.page_size,
                         page_token: p.page_token,
                         completed: p.completed,
+                        agent_task_status: p.agent_task_status,
                         user_id_type: (p.user_id_type || 'open_id') as any,
                       },
                     },
@@ -588,11 +653,27 @@ export function registerFeishuTaskTaskTool(api: OpenClawPluginApi): void {
                 }
               }
 
+              if (p.agent_task_progress !== undefined) {
+                updateData.agent_task_progress = p.agent_task_progress;
+              }
+              if (p.agent_task_status !== undefined) {
+                updateData.agent_task_status = p.agent_task_status;
+              }
+              if (p.text_deliveries !== undefined) {
+                updateData.text_deliveries = p.text_deliveries;
+              }
+
               if (p.members) updateData.members = p.members;
               if (p.repeat_rule) updateData.repeat_rule = p.repeat_rule;
 
               // Build update_fields list (required by Task API)
               const updateFields = Object.keys(updateData);
+              if (updateFields.length === 0) {
+                return json({
+                  error:
+                    'patch 至少需要提供一个可更新字段：summary、description、due、start、completed_at、agent_task_progress、agent_task_status、text_deliveries、members、repeat_rule',
+                });
+              }
 
               const authType = p.auth_type || 'user';
               const res = await client.invoke(
@@ -670,6 +751,48 @@ export function registerFeishuTaskTaskTool(api: OpenClawPluginApi): void {
               return json({
                 task: res.data?.task,
               });
+            }
+
+            // -----------------------------------------------------------------
+            // APPEND TASK STEPS
+            // -----------------------------------------------------------------
+            case 'append_steps': {
+              if (!p.task_steps.length) {
+                return json({
+                  error: 'task_steps is required and cannot be empty',
+                });
+              }
+
+              const tatRes = await rawLarkRequest(
+                {
+                  brand: client.account.brand,
+                  path: '/open-apis/auth/v3/tenant_access_token/internal/',
+                  method: 'POST',
+                  body: {
+                    app_id: client.sdk.appId,
+                    app_secret: client.sdk.appSecret,
+                  },
+                },
+              );;
+              const token = (tatRes as any)?.tenant_access_token ?? "";
+
+              const res = await client.invokeByPath(
+                'feishu_task_task.append_steps',
+                '/open-apis/task/v2/agent_task_step_info/append_task_steps',
+                {
+                  method: 'POST',
+                  as: 'tenant',
+                  body: {
+                    task_guid: p.task_guid,
+                    idempotent_key: p.idempotent_key,
+                    task_steps: p.task_steps,
+                  },
+                  headers: {
+                    'authorization': `Bearer ${token}`,
+                  },
+                },
+              );
+              return json(res);
             }
           }
         } catch (err) {

--- a/src/tools/oapi/task/task_agent.ts
+++ b/src/tools/oapi/task/task_agent.ts
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * feishu_task_agent tool -- Manage Feishu Task Agent registration.
+ *
+ * Actions:
+ * - register:        Register task agent (tenant identity)
+ * - update_profile:  Update task agent profile (tenant identity)
+ *
+
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import type { OpenClawPluginApi } from 'openclaw/plugin-sdk';
+import { Type } from '@sinclair/typebox';
+
+import { createToolContext, handleInvokeErrorWithAutoAuth, json, registerTool } from '../helpers';
+import { rawLarkRequest } from '../../../core/raw-request';
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+const FeishuTaskAgentSchema = Type.Union([
+    Type.Object({
+        action: Type.Literal('register'),
+    }),
+    Type.Object({
+        action: Type.Literal('update_profile'),
+        profile_content: Type.String(),
+    }),
+]);
+
+type FeishuTaskAgentParams =
+    | { action: 'register' }
+    | { action: 'update_profile'; profile_content: string };
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function resolvePathForAction(action: FeishuTaskAgentParams['action']): { path: string; env: string[] } {
+    if (action === 'register') {
+        return { path: '/open-apis/task/v2/agent/register_agent', env: [] };
+    }
+
+     return  { path: '/open-apis/task/v2/agent/update_agent_profile', env: [] };
+
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerFeishuTaskAgentTool(api: OpenClawPluginApi): void {
+    if (!api.config) return;
+    const cfg = api.config;
+
+    const { toolClient } = createToolContext(api, 'feishu_task_agent');
+
+    registerTool(
+        api,
+        {
+            name: 'feishu_task_agent',
+            label: 'Feishu Task Agent Registration',
+            description:
+                '飞书任务 Agent 注册管理工具。用于注册/取消注册 Task Agent，以及查询已注册列表。',
+            parameters: FeishuTaskAgentSchema,
+            async execute(_toolCallId: string, params: unknown) {
+                const p = params as FeishuTaskAgentParams;
+                try {
+                    const normalizedAction = p.action ;
+
+                    const resolved = resolvePathForAction(p.action);
+
+                    const client = toolClient();
+
+                    const tatRes = await rawLarkRequest(
+                        {
+                            brand: client.account.brand,
+                            path: '/open-apis/auth/v3/tenant_access_token/internal/',
+                            method: 'POST',
+                            body: {
+                                app_id: client.sdk.appId,
+                                app_secret: client.sdk.appSecret,
+                            },
+                        },
+                    );
+                    const token = (tatRes as any)?.tenant_access_token ?? "";
+
+                    // Match openclaw-lark-task semantics:
+                    // - register/update_profile use tenant identity (TAT)
+                    const as =
+                        normalizedAction === 'register' ||normalizedAction === 'update_profile'
+                            ? 'tenant'
+                            : 'user';
+
+
+
+
+                    if (normalizedAction === 'update_profile') {
+                        const res = await client.invokeByPath('feishu_task_agent.update_profile', resolved.path, {
+                            method: 'POST',
+                            as,
+                            body: {
+                                profile_content: p.profile_content,
+                            },
+                            headers: {
+                                'authorization': `Bearer ${token}`,
+                            },
+                        });
+                        return json(res);
+                    }
+
+                    // register
+                    if (normalizedAction === 'register') {
+                        const res = await client.invokeByPath('feishu_task_agent.register', resolved.path, {
+                            method: 'POST',
+                            as,
+                            headers: {
+                                'authorization': `Bearer ${token}`,
+                            },
+                        });
+                        return json(res);
+                    }
+                    return json({
+                        error: `p.action is invalid ${normalizedAction}`,
+                    });
+                } catch (err) {
+                    return await handleInvokeErrorWithAutoAuth(err, cfg);
+                }
+            },
+        },
+        { name: 'feishu_task_agent' },
+    );
+}


### PR DESCRIPTION
**背景/目的**
- 补齐飞书 Task 相关能力：Agent 注册管理、附件上传、以及 SDK 未覆盖的“追加任务步骤”等接口调用能力。

**主要变更**
- 新增任务 Agent 管理工具 `feishu_task_agent`：支持 `register`、`update_profile`（均以 tenant 身份调用）。
- 新增任务附件工具 `feishu_task_attachment`：支持 `upload`，接收 base64 文件内容并以 `multipart/form-data` 上传（tenant 身份调用）。
- 增强任务工具 `feishu_task_task`：
  - 新增 `append_steps` action（调用 `/open-apis/task/v2/agent_task_step_info/append_task_steps`，tenant 身份）。
  - `create/patch` 增加时间参数处理：`due/start` 支持 ISO 8601/RFC 3339 字符串转毫秒时间戳；`completed_at` 支持 `'0'`（反完成）、毫秒时间戳字符串、以及 ISO 时间字符串。
  - `list` 支持 `agent_task_status` 过滤。
- 引入/完善裸请求能力 `rawLarkRequest`：支持域名解析（feishu/lark）、query/header 注入、以及 JSON/FormData/二进制 body 透传，用于 SDK 未覆盖接口及更细粒度请求控制。
- 更新工具注册与权限映射：
  - OAPI 工具索引中注册新增工具。
  - `tool-scopes` 增加新 action 的 scope 映射（如 `task:attachment:write`、`task:task:write`、`task:task:writeonly` 等）。
- 依赖更新：新增 `undici-types`（用于 `BodyInit` 类型支持）。

**影响范围**
- 以新增能力为主：新增工具与新增 action/参数，不改变既有工具对外名称；调用新增能力需要相应飞书应用权限（Task/Attachment 相关 scopes）。

**变更文件概览**
- 新增：`src/tools/oapi/task/task_agent.ts`、`src/tools/oapi/task/attachment.ts`
- 修改：`src/tools/oapi/task/task.ts`、`src/core/raw-request.ts`、`src/core/tool-scopes.ts`、`src/tools/oapi/index.ts`、`src/tools/oapi/task/index.ts`、`package.json`、`pnpm-lock.yaml`