### PR TITLE
fix: use command-auth for sender authorization

### DIFF
--- a/src/messaging/inbound/handler.ts
+++ b/src/messaging/inbound/handler.ts
@@ -20,7 +20,7 @@ import {
   DEFAULT_GROUP_HISTORY_LIMIT,
   recordPendingHistoryEntryIfEnabled,
 } from 'openclaw/plugin-sdk/reply-history';
-import { resolveSenderCommandAuthorization } from 'openclaw/plugin-sdk/zalouser';
+import { resolveSenderCommandAuthorization } from 'openclaw/plugin-sdk/command-auth';
 import { isNormalizedSenderAllowed } from 'openclaw/plugin-sdk/allow-from';
 import type { FeishuMessageEvent } from '../types';
 import { getLarkAccount } from '../../core/accounts';


### PR DESCRIPTION
## Summary

- Replace the stale `openclaw/plugin-sdk/zalouser` import with `openclaw/plugin-sdk/command-auth` for `resolveSenderCommandAuthorization`.
- This aligns the Feishu inbound handler with the current OpenClaw SDK export surface and avoids handler load failures when `zalouser` is not exported.

Fixes #457.

## Why

On OpenClaw `2026.4.27`, a live Feishu install showed outbound messages working while inbound messages were not dispatched. Logs showed the inbound handler failing to load because `openclaw/plugin-sdk/zalouser` was not defined by OpenClaw's package exports / root alias map.

`resolveSenderCommandAuthorization` is available from `openclaw/plugin-sdk/command-auth`, and the call site/signature remains compatible.

## Verification

- `pnpm exec eslint src/messaging/inbound/handler.ts` ✅
- `pnpm typecheck` currently fails on an unrelated existing error in `src/tools/oapi/task/task.ts` (`agent_task_status` is not in the SDK task list parameter type).
- A local patched install using this import change restored Feishu inbound dispatch after gateway restart; see #457 for the runtime logs and details.
