### PR TITLE
[codex] Fix Feishu SecretRef runtime resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "bin/",
     "dist/",
     "skills/",
+    "secret-contract-api.js",
     "openclaw.plugin.json",
     "README.md",
     "LICENSE"

--- a/secret-contract-api.js
+++ b/secret-contract-api.js
@@ -1,0 +1,1 @@
+export { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from './dist/secret-contract-api.mjs';

--- a/secret-contract-api.ts
+++ b/secret-contract-api.ts
@@ -1,0 +1,71 @@
+import type { OpenClawConfig } from 'openclaw/plugin-sdk';
+import {
+  collectSimpleChannelFieldAssignments,
+  getChannelSurface,
+} from 'openclaw/plugin-sdk/channel-secret-basic-runtime';
+
+type SimpleChannelFieldAssignmentParams = Parameters<typeof collectSimpleChannelFieldAssignments>[0];
+
+interface RuntimeConfigAssignmentParams {
+  config: OpenClawConfig;
+  defaults: SimpleChannelFieldAssignmentParams['defaults'];
+  context: SimpleChannelFieldAssignmentParams['context'];
+}
+
+interface SecretTargetRegistryEntry {
+  id: string;
+  targetType: string;
+  configFile: 'openclaw.json';
+  pathPattern: string;
+  secretShape: 'secret_input';
+  expectedResolvedValue: 'string';
+  includeInPlan: boolean;
+  includeInConfigure: boolean;
+  includeInAudit: boolean;
+}
+
+const SECRET_FIELDS = ['appSecret', 'encryptKey', 'verificationToken'] as const;
+
+export const secretTargetRegistryEntries: readonly SecretTargetRegistryEntry[] = SECRET_FIELDS.flatMap((field) => [
+  {
+    id: `channels.feishu.accounts.*.${field}`,
+    targetType: `channels.feishu.accounts.*.${field}`,
+    configFile: 'openclaw.json',
+    pathPattern: `channels.feishu.accounts.*.${field}`,
+    secretShape: 'secret_input',
+    expectedResolvedValue: 'string',
+    includeInPlan: true,
+    includeInConfigure: true,
+    includeInAudit: true,
+  },
+  {
+    id: `channels.feishu.${field}`,
+    targetType: `channels.feishu.${field}`,
+    configFile: 'openclaw.json',
+    pathPattern: `channels.feishu.${field}`,
+    secretShape: 'secret_input',
+    expectedResolvedValue: 'string',
+    includeInPlan: true,
+    includeInConfigure: true,
+    includeInAudit: true,
+  },
+]);
+
+export function collectRuntimeConfigAssignments(params: RuntimeConfigAssignmentParams): void {
+  const resolved = getChannelSurface(params.config, 'feishu');
+  if (!resolved) return;
+
+  const { channel, surface } = resolved;
+  for (const field of SECRET_FIELDS) {
+    collectSimpleChannelFieldAssignments({
+      channelKey: 'feishu',
+      field,
+      channel,
+      surface,
+      defaults: params.defaults,
+      context: params.context,
+      topInactiveReason: `no enabled Feishu account inherits this top-level ${field}.`,
+      accountInactiveReason: 'Feishu account is disabled.',
+    });
+  }
+}

--- a/src/commands/diagnose.ts
+++ b/src/commands/diagnose.ts
@@ -15,6 +15,7 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 
 import type { OpenClawConfig } from 'openclaw/plugin-sdk';
+import { resolveCommandSecretRefsViaGateway } from 'openclaw/plugin-sdk/runtime';
 
 interface DiagLogger {
   info: (message: string) => void;
@@ -26,6 +27,7 @@ import type * as Lark from '@larksuiteoapi/node-sdk';
 import { probeFeishu } from '../channel/probe';
 import { getEnabledLarkAccounts, getLarkAccount, getLarkAccountIds } from '../core/accounts';
 import { LarkClient } from '../core/lark-client';
+import { getPluginVersion } from '../core/version';
 
 /**
  * Resolve the global config for cross-account operations.
@@ -80,9 +82,16 @@ interface DiagReport {
 // Constants
 // ---------------------------------------------------------------------------
 
-const PLUGIN_VERSION = '2026.2.10';
 const LOG_READ_BYTES = 256 * 1024; // read last 256KB of log
 const MAX_ERROR_LINES = 20;
+const FEISHU_SECRET_TARGET_IDS = new Set([
+  'channels.feishu.appSecret',
+  'channels.feishu.accounts.*.appSecret',
+  'channels.feishu.encryptKey',
+  'channels.feishu.accounts.*.encryptKey',
+  'channels.feishu.verificationToken',
+  'channels.feishu.accounts.*.verificationToken',
+]);
 /** Matches a timestamped log line: 2026-02-13T09:23:35.038Z [level]: ... */
 const TIMESTAMPED_LINE_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
 const ERROR_LEVEL_RE = /\[error\]|\[warn\]/i;
@@ -91,10 +100,30 @@ const ERROR_LEVEL_RE = /\[error\]|\[warn\]/i;
 // Helpers
 // ---------------------------------------------------------------------------
 
-function maskSecret(secret?: string): string {
+function maskSecret(secret?: unknown): string {
   if (!secret) return '(未设置)';
-  if (secret.length <= 4) return '****';
-  return secret.slice(0, 4) + '****';
+  return '****';
+}
+
+async function resolveFeishuCommandConfig(
+  config: OpenClawConfig,
+  commandName: string,
+): Promise<{ config: OpenClawConfig; diagnostics: string[] }> {
+  try {
+    const result = await resolveCommandSecretRefsViaGateway({
+      config,
+      commandName,
+      targetIds: FEISHU_SECRET_TARGET_IDS,
+    });
+    return { config: result.resolvedConfig, diagnostics: result.diagnostics };
+  } catch (err) {
+    return {
+      config,
+      diagnostics: [
+        `${commandName}: failed to resolve SecretRefs: ${err instanceof Error ? err.message : String(err)}`,
+      ],
+    };
+  }
 }
 
 async function extractRecentErrors(logPath: string): Promise<string[]> {
@@ -272,8 +301,16 @@ export async function runDiagnosis(params: { config: OpenClawConfig; logger?: Di
   const { config } = params;
   // Use the global config to enumerate all accounts — the passed-in
   // config may be account-scoped (accounts map stripped).
-  const globalCfg = resolveGlobalConfig(config);
+  const resolved = await resolveFeishuCommandConfig(resolveGlobalConfig(config), 'feishu-diagnose');
+  const globalCfg = resolved.config;
   const globalChecks: DiagCheckResult[] = [];
+
+  globalChecks.push({
+    name: 'SecretRef 解析',
+    status: resolved.diagnostics.length > 0 ? 'warn' : 'pass',
+    message: resolved.diagnostics.length > 0 ? `${resolved.diagnostics.length} 条诊断` : '已解析',
+    details: resolved.diagnostics.length > 0 ? resolved.diagnostics.join('\n') : undefined,
+  });
 
   // -- Environment --
   const nodeVer = parseInt(process.version.slice(1), 10);
@@ -337,7 +374,7 @@ export async function runDiagnosis(params: { config: OpenClawConfig; logger?: Di
       nodeVersion: process.version,
       platform: process.platform,
       arch: process.arch,
-      pluginVersion: PLUGIN_VERSION,
+      pluginVersion: getPluginVersion(),
     },
     accounts: accountResults,
     toolsRegistered: tools,

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -9,6 +9,7 @@
  */
 
 import type { OpenClawConfig } from 'openclaw/plugin-sdk';
+import { resolveCommandSecretRefsViaGateway } from 'openclaw/plugin-sdk/runtime';
 import type * as Lark from '@larksuiteoapi/node-sdk';
 
 import { getEnabledLarkAccounts } from '../core/accounts';
@@ -120,6 +121,7 @@ const T: Record<
     appPermFail: string;
     userPermPass: string;
     userPermFail: string;
+    secretRefDiagTitle: string;
   }
 > = {
   zh_cn: {
@@ -188,6 +190,7 @@ const T: Record<
     appPermFail: '#### ❌ 应用身份权限检查未通过',
     userPermPass: '#### ✅ 用户身份权限检查通过',
     userPermFail: '#### ❌ 用户身份权限检查未通过',
+    secretRefDiagTitle: '#### ⚠️ SecretRef 解析诊断',
   },
   en_us: {
     notSet: '(not set)',
@@ -258,8 +261,18 @@ const T: Record<
     appPermFail: '#### ❌ App Permission Check Failed',
     userPermPass: '#### ✅ User Permission Check Passed',
     userPermFail: '#### ❌ User Permission Check Failed',
+    secretRefDiagTitle: '#### ⚠️ SecretRef Resolution Diagnostics',
   },
 };
+
+const FEISHU_SECRET_TARGET_IDS = new Set([
+  'channels.feishu.appSecret',
+  'channels.feishu.accounts.*.appSecret',
+  'channels.feishu.encryptKey',
+  'channels.feishu.accounts.*.encryptKey',
+  'channels.feishu.verificationToken',
+  'channels.feishu.accounts.*.verificationToken',
+]);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -292,10 +305,30 @@ function getAllToolScopes(): string[] {
 /**
  * 掩码敏感信息（appSecret）
  */
-function maskSecret(secret: string | undefined, locale: DoctorLocale): string {
+function maskSecret(secret: unknown, locale: DoctorLocale): string {
   if (!secret) return T[locale].notSet;
-  if (secret.length <= 4) return '****';
-  return secret.slice(0, 4) + '****';
+  return '****';
+}
+
+async function resolveFeishuCommandConfig(
+  config: OpenClawConfig,
+  commandName: string,
+): Promise<{ config: OpenClawConfig; diagnostics: string[] }> {
+  try {
+    const result = await resolveCommandSecretRefsViaGateway({
+      config,
+      commandName,
+      targetIds: FEISHU_SECRET_TARGET_IDS,
+    });
+    return { config: result.resolvedConfig, diagnostics: result.diagnostics };
+  } catch (err) {
+    return {
+      config,
+      diagnostics: [
+        `${commandName}: failed to resolve SecretRefs: ${err instanceof Error ? err.message : String(err)}`,
+      ],
+    };
+  }
 }
 
 /**
@@ -676,7 +709,8 @@ export async function runFeishuDoctor(
   // 1. 获取目标账户
   //    Use the global config to enumerate all accounts — the passed-in
   //    config may be account-scoped (accounts map stripped).
-  const globalCfg = resolveGlobalConfig(config);
+  const resolved = await resolveFeishuCommandConfig(resolveGlobalConfig(config), 'feishu-doctor');
+  const globalCfg = resolved.config;
   const allAccounts = getEnabledLarkAccounts(globalCfg);
   if (allAccounts.length === 0) {
     return t.noAccounts;
@@ -694,11 +728,17 @@ export async function runFeishuDoctor(
   lines.push('');
   lines.push(`${t.pluginVersionLabel}: ${getPluginVersion()}  |  ${t.diagTimeLabel}: ${formatTimestamp(new Date())}`);
   lines.push('');
+  if (resolved.diagnostics.length > 0) {
+    lines.push(t.secretRefDiagTitle);
+    lines.push('');
+    lines.push(resolved.diagnostics.join('\n'));
+    lines.push('');
+  }
   lines.push('---');
   lines.push('');
 
   // 3. 工具配置（全局，不区分账户）
-  const toolsResult = checkToolsProfile(config, locale);
+  const toolsResult = checkToolsProfile(globalCfg, locale);
   const toolsTitle = toolsResult.status === 'pass' ? t.toolsCheckPass : t.toolsCheckWarn;
   lines.push(toolsTitle);
   lines.push('');
@@ -730,7 +770,7 @@ export async function runFeishuDoctor(
     }
 
     // 4a. 环境信息
-    const basicInfoResult = await checkBasicInfo(account, config, locale);
+    const basicInfoResult = await checkBasicInfo(account, globalCfg, locale);
     const basicTitle = basicInfoResult.status === 'pass' ? t.envCheckPass : t.envCheckFail;
     lines.push(basicTitle);
     lines.push('');

--- a/src/core/token-store.ts
+++ b/src/core/token-store.ts
@@ -29,8 +29,8 @@ import { larkLogger } from './lark-logger';
 const log = larkLogger('core/token-store');
 
 // Dynamic require to avoid security scanner false positive (child-process).
-// CJS (tsc output) has __filename; ESM (tsdown output) has import.meta.url.
-const _require = createRequire(typeof __filename !== 'undefined' ? __filename : import.meta.url);
+// The base path only needs to be absolute for built-in module resolution.
+const _require = createRequire(join(process.cwd(), 'openclaw-lark-runtime.cjs'));
 const _cpMod = ['child', 'process'].join('_');
 const _cp = _require(`node:${_cpMod}`) as typeof import('node:child_process');
 const execFile = promisify(_cp.execFile);

--- a/tests/secret-contract-api.test.ts
+++ b/tests/secret-contract-api.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import type { OpenClawConfig } from 'openclaw/plugin-sdk';
+
+import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from '../secret-contract-api.ts';
+
+function secretRef(id: string) {
+  return { source: 'file', provider: 'lark-secrets', id };
+}
+
+function makeResolverContext(sourceConfig: OpenClawConfig) {
+  return {
+    sourceConfig,
+    env: {},
+    cache: {},
+    warnings: [],
+    warningKeys: new Set<string>(),
+    assignments: [],
+  };
+}
+
+describe('Feishu secret contract API', () => {
+  it('registers top-level and account-scoped Feishu secret targets', () => {
+    expect(secretTargetRegistryEntries.map((entry) => entry.id)).toEqual([
+      'channels.feishu.accounts.*.appSecret',
+      'channels.feishu.appSecret',
+      'channels.feishu.accounts.*.encryptKey',
+      'channels.feishu.encryptKey',
+      'channels.feishu.accounts.*.verificationToken',
+      'channels.feishu.verificationToken',
+    ]);
+  });
+
+  it('collects active SecretRef assignments for Feishu account credentials', () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          enabled: true,
+          appId: 'cli_default',
+          appSecret: secretRef('/lark/defaultSecret'),
+          accounts: {
+            default: {
+              enabled: true,
+            },
+            mediaops: {
+              enabled: true,
+              appId: 'cli_mediaops',
+              appSecret: secretRef('/lark/mediaopsSecret'),
+            },
+            disabled: {
+              enabled: false,
+              appId: 'cli_disabled',
+              appSecret: secretRef('/lark/disabledSecret'),
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const context = makeResolverContext(cfg);
+
+    collectRuntimeConfigAssignments({
+      config: cfg,
+      defaults: undefined,
+      context,
+    });
+
+    expect(context.assignments.map((assignment: { path: string }) => assignment.path)).toEqual([
+      'channels.feishu.appSecret',
+      'channels.feishu.accounts.mediaops.appSecret',
+    ]);
+    expect(context.warnings).toHaveLength(1);
+
+    const [topLevel, account] = context.assignments as Array<{ apply(value: string): void }>;
+    topLevel.apply('resolved-default');
+    account.apply('resolved-mediaops');
+
+    const feishu = cfg.channels?.feishu as {
+      appSecret: unknown;
+      accounts: Record<string, { appSecret: unknown }>;
+    };
+    expect(feishu.appSecret).toBe('resolved-default');
+    expect(feishu.accounts.mediaops.appSecret).toBe('resolved-mediaops');
+    expect(feishu.accounts.disabled.appSecret).toEqual(secretRef('/lark/disabledSecret'));
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,6 @@
 
     "outDir": "dist"
   },
-  "include": ["index.ts", "src/**/*.ts", "tests/**/*.ts", "*.config.ts"],
+  "include": ["index.ts", "secret-contract-api.ts", "src/**/*.ts", "tests/**/*.ts", "*.config.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-  entry: { index: 'index.ts' },
+  entry: { index: 'index.ts', 'secret-contract-api': 'secret-contract-api.ts' },
   format: 'esm',
   target: 'node22',
   platform: 'node',
@@ -9,13 +9,6 @@ export default defineConfig({
   outDir: 'dist',
   dts: true,
   deps: {
-    neverBundle: [
-      /^openclaw(\/.*)?$/,
-      /^@larksuiteoapi\//,
-      /^@sinclair\//,
-      'image-size',
-      'zod',
-      /^node:/,
-    ],
+    neverBundle: [/^openclaw(\/.*)?$/, /^@larksuiteoapi\//, /^@sinclair\//, 'image-size', 'zod', /^node:/],
   },
 });


### PR DESCRIPTION
## Summary

- add a Feishu secret contract API so OpenClaw can resolve `channels.feishu` SecretRefs for `appSecret`, `encryptKey`, and `verificationToken` at runtime
- publish a root `secret-contract-api.js` shim and build a `dist/secret-contract-api.mjs` entry so the OpenClaw plugin loader can discover the contract from the package root
- resolve Feishu command SecretRefs before `feishu-diagnose` and `feishu-doctor` inspect accounts, and report the actual package version in diagnostics
- avoid an `import.meta.url`-dependent `createRequire` path in the token store so CommonJS-style runtime copies do not fail while loading `node:child_process`

## Root Cause

OpenClaw 2026.5 resolves channel SecretRefs through per-channel secret contract APIs. The external Feishu package did not expose a contract, so runtime config could pass unresolved SecretRef objects through to the Lark SDK as `appSecret`, causing tenant token acquisition and WebSocket startup to fail. The diagnostic commands also read raw config and could crash when attempting to mask a SecretRef object as a string.

## Validation

- `pnpm test`
- `pnpm test tests/secret-contract-api.test.ts`
- `pnpm build`
- `pnpm exec eslint secret-contract-api.ts tests/secret-contract-api.test.ts src/commands/diagnose.ts src/commands/doctor.ts src/core/token-store.ts`
- `node -e "import('./secret-contract-api.js').then((m)=>console.log(typeof m.collectRuntimeConfigAssignments, m.secretTargetRegistryEntries.length))"`
- `pnpm pack --dry-run`

Known existing issue: `pnpm typecheck` still fails on `src/tools/oapi/task/task.ts(569,25)` because `agent_task_status` is not in the current SDK request type. That error is unrelated to this SecretRef fix and was present outside the changed files.
