### PR TITLE
feat: 添加 Feishu 工具合约配置

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -49,7 +49,9 @@
       "feishu_task_tasklist",
       "feishu_update_doc",
       "feishu_wiki_space",
-      "feishu_wiki_space_node"
+      "feishu_wiki_space_node",
+      "feishu_task_section",
+      "feishu_ask_user_question"
     ]
   },
   "channelConfigs": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,11 +1,56 @@
 {
   "id": "openclaw-lark",
-  "channels": ["feishu"],
-  "skills": ["./skills"],
+  "channels": [
+    "feishu"
+  ],
+  "skills": [
+    "./skills"
+  ],
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
     "properties": {}
+  },
+  "contracts": {
+    "tools": [
+      "feishu_bitable_app",
+      "feishu_bitable_app_table",
+      "feishu_bitable_app_table_field",
+      "feishu_bitable_app_table_record",
+      "feishu_bitable_app_table_view",
+      "feishu_calendar_calendar",
+      "feishu_calendar_event",
+      "feishu_calendar_event_attendee",
+      "feishu_calendar_freebusy",
+      "feishu_chat",
+      "feishu_chat_members",
+      "feishu_create_doc",
+      "feishu_doc_comments",
+      "feishu_doc_media",
+      "feishu_drive_file",
+      "feishu_fetch_doc",
+      "feishu_get_user",
+      "feishu_im_bot_image",
+      "feishu_im_user_fetch_resource",
+      "feishu_im_user_get_messages",
+      "feishu_im_user_get_thread_messages",
+      "feishu_im_user_message",
+      "feishu_im_user_search_messages",
+      "feishu_oauth",
+      "feishu_oauth_batch_auth",
+      "feishu_search_doc_wiki",
+      "feishu_search_user",
+      "feishu_sheet",
+      "feishu_task_comment",
+      "feishu_task_subtask",
+      "feishu_task_task",
+      "feishu_task_agent",
+      "feishu_task_attachment",
+      "feishu_task_tasklist",
+      "feishu_update_doc",
+      "feishu_wiki_space",
+      "feishu_wiki_space_node"
+    ]
   },
   "channelConfigs": {
     "feishu": {


### PR DESCRIPTION
扩展插件配置以支持 Feishu 平台的各种工具合约，包括表格、日历、聊天、文档、任务和知识库等功能模块。