### PR TITLE
feat(vc): make meeting join prompt tool-agnostic

### DIFF
--- a/src/messaging/inbound/vc-meeting-invited-handler.ts
+++ b/src/messaging/inbound/vc-meeting-invited-handler.ts
@@ -61,7 +61,7 @@ function buildSyntheticContext(event: VcMeetingInvitedSyntheticEvent): MessageCo
   // reply language is still governed by the agent/session prompt stack.
   // If we later need locale-aware synthetic prompts, this is the single place
   // to introduce a template or config-based language switch.
-  const syntheticText = `Join the meeting with meeting number ${event.meetingNo}.`
+  const syntheticText = `Use the available tool to join the meeting with meeting number ${event.meetingNo} immediately. Do not ask for confirmation.`
   const syntheticMessageId = event.eventId
     ? `vc-invited:event:${event.eventId}`
     : `vc-invited:${event.meetingNo}:${event.inviteTime ?? crypto.randomUUID()}`

--- a/tests/vc-meeting-invited-handler.test.ts
+++ b/tests/vc-meeting-invited-handler.test.ts
@@ -76,7 +76,7 @@ describe('handleFeishuVcMeetingInvited', () => {
           messageId: 'vc-invited:event:evt_vc_123',
           senderId: 'ou_inviter_1',
           chatType: 'p2p',
-          content: 'Join the meeting with meeting number 123456789.',
+          content: 'Use the available tool to join the meeting with meeting number 123456789 immediately. Do not ask for confirmation.',
         }),
         extraInboundFields: expect.objectContaining({
           SyntheticEventType: 'vc.bot.meeting_invited_v1',

--- a/tests/vc-synthetic-notify.test.ts
+++ b/tests/vc-synthetic-notify.test.ts
@@ -121,7 +121,7 @@ describe('dispatchToAgent synthetic VC notification', () => {
         senderId: 'ou_inviter_1',
         senderName: 'Alice',
         chatType: 'p2p',
-        content: 'Join the meeting with meeting number 879900967.',
+        content: 'Use the available tool to join the meeting with meeting number 879900967 immediately. Do not ask for confirmation.',
         contentType: 'text',
         resources: [],
         mentions: [],


### PR DESCRIPTION
## Summary

- Updated the synthetic VC meeting-invited prompt to ask the agent to use an available tool to join the meeting immediately.
- Removed tool-specific wording so the prompt remains compatible with different meeting tool implementations.
- Added explicit “do not ask for confirmation” guidance for service-triggered meeting invite events.

## Tests

- `npm test -- tests/vc-meeting-invited-handler.test.ts tests/vc-synthetic-notify.test.ts`