### PR TITLE
fix(contracts): supersede #470, add missing feishu_ask_user_question and feishu_task_section

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -13,6 +13,7 @@
   },
   "contracts": {
     "tools": [
+      "feishu_ask_user_question",
       "feishu_bitable_app",
       "feishu_bitable_app_table",
       "feishu_bitable_app_table_field",
@@ -46,6 +47,7 @@
       "feishu_task_task",
       "feishu_task_agent",
       "feishu_task_attachment",
+      "feishu_task_section",
       "feishu_task_tasklist",
       "feishu_update_doc",
       "feishu_wiki_space",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,11 +1,56 @@
 {
   "id": "openclaw-lark",
-  "channels": ["feishu"],
-  "skills": ["./skills"],
+  "channels": [
+    "feishu"
+  ],
+  "skills": [
+    "./skills"
+  ],
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
     "properties": {}
+  },
+  "contracts": {
+    "tools": [
+      "feishu_bitable_app",
+      "feishu_bitable_app_table",
+      "feishu_bitable_app_table_field",
+      "feishu_bitable_app_table_record",
+      "feishu_bitable_app_table_view",
+      "feishu_calendar_calendar",
+      "feishu_calendar_event",
+      "feishu_calendar_event_attendee",
+      "feishu_calendar_freebusy",
+      "feishu_chat",
+      "feishu_chat_members",
+      "feishu_create_doc",
+      "feishu_doc_comments",
+      "feishu_doc_media",
+      "feishu_drive_file",
+      "feishu_fetch_doc",
+      "feishu_get_user",
+      "feishu_im_bot_image",
+      "feishu_im_user_fetch_resource",
+      "feishu_im_user_get_messages",
+      "feishu_im_user_get_thread_messages",
+      "feishu_im_user_message",
+      "feishu_im_user_search_messages",
+      "feishu_oauth",
+      "feishu_oauth_batch_auth",
+      "feishu_search_doc_wiki",
+      "feishu_search_user",
+      "feishu_sheet",
+      "feishu_task_comment",
+      "feishu_task_subtask",
+      "feishu_task_task",
+      "feishu_task_agent",
+      "feishu_task_attachment",
+      "feishu_task_tasklist",
+      "feishu_update_doc",
+      "feishu_wiki_space",
+      "feishu_wiki_space_node"
+    ]
   },
   "channelConfigs": {
     "feishu": {


### PR DESCRIPTION
## Summary

Supersedes #470 by Casper-Mars (cherry-picked, original commit & authorship preserved) and patches two omissions in `contracts.tools`:

- `feishu_ask_user_question` — registered in `src/tools/ask-user-question.ts:937`
- `feishu_task_section` — registered in `src/tools/oapi/task/section.ts:214`

Without these, callers that gate capability discovery on the manifest will not see those tools even though they are registered at runtime.

A scan of `src/` for `name: 'feishu_*'` / `toolName = 'feishu_*'` registrations yields 39 tools; this PR's `contracts.tools` now matches that set 1:1. (`feishu_auth` / `feishu_diagnose` / `feishu_doctor` are commands, not tools, and `feishu_my_tool` is a jsdoc example — correctly excluded.)

## Commits

1. `feat: 添加 Feishu 工具合约配置` — original work by @Casper-Mars (cherry-picked from #470)
2. `fix(contracts): add missing feishu_ask_user_question and feishu_task_section`

## Test plan

- [ ] CI green
- [ ] `jq '.contracts.tools | length' openclaw.plugin.json` returns 39
- [ ] Diff vs. registered tool set is empty