### PR TITLE
fix: extract <at> tags as standalone post elements for real mentions

### DIFF
--- a/src/messaging/outbound/deliver.ts
+++ b/src/messaging/outbound/deliver.ts
@@ -38,7 +38,12 @@ const log = larkLogger('outbound/deliver');
  * `<at>` tags embedded inside an `{tag: "md"}` element are rendered
  * visually but do NOT produce mention metadata or trigger events.
  */
-function buildPostContent(text: string): string {
+/**
+ * Parse text containing `<at>` tags into an array of post elements.
+ * `<at user_id="...">Name</at>` → `{tag: "at", user_id: "..."}`,
+ * everything else → `{tag: "md", text: "..."}`.
+ */
+export function buildPostElements(text: string): Array<Record<string, string>> {
   const cleaned = text.replace(/\\"/g, '"');
   const atRegex = /(<at\s+user_id="[^"]+">.*?<\/at>)/gi;
   const parts = cleaned.split(atRegex);
@@ -54,9 +59,13 @@ function buildPostContent(text: string): string {
   if (elements.length === 0) {
     elements.push({ tag: 'md', text });
   }
+  return elements;
+}
+
+export function buildPostContent(text: string): string {
   return JSON.stringify({
     zh_cn: {
-      content: [elements],
+      content: [buildPostElements(text)],
     },
   });
 }

--- a/src/messaging/outbound/deliver.ts
+++ b/src/messaging/outbound/deliver.ts
@@ -30,11 +30,33 @@ const log = larkLogger('outbound/deliver');
 
 /**
  * Build a Feishu post-format content envelope from processed text.
+ *
+ * Extracts `<at user_id="...">Name</at>` tags from the text and emits them
+ * as standalone `{tag: "at"}` post elements so that Feishu recognises them
+ * as real mentions (populates the `mentions` array and triggers
+ * `im.message.receive_v1` for the mentioned user/bot).  Without this,
+ * `<at>` tags embedded inside an `{tag: "md"}` element are rendered
+ * visually but do NOT produce mention metadata or trigger events.
  */
 function buildPostContent(text: string): string {
+  const cleaned = text.replace(/\\"/g, '"');
+  const atRegex = /(<at\s+user_id="[^"]+">.*?<\/at>)/gi;
+  const parts = cleaned.split(atRegex);
+  const elements: Array<Record<string, string>> = [];
+  for (const part of parts) {
+    const m = part.match(/<at\s+user_id="([^"]+)">(.*?)<\/at>/i);
+    if (m) {
+      elements.push({ tag: 'at', user_id: m[1] });
+    } else if (part) {
+      elements.push({ tag: 'md', text: part });
+    }
+  }
+  if (elements.length === 0) {
+    elements.push({ tag: 'md', text });
+  }
   return JSON.stringify({
     zh_cn: {
-      content: [[{ tag: 'md', text }]],
+      content: [elements],
     },
   });
 }

--- a/src/messaging/outbound/send.ts
+++ b/src/messaging/outbound/send.ts
@@ -17,15 +17,10 @@ import { optimizeMarkdownStyle } from '../../card/markdown-style';
 import { buildMentionedCardContent, buildMentionedMessage } from '../inbound/mention';
 import { getSentinelStore } from '../inbound/sentinel-store';
 import { type NormalizeContext, type SentinelEntry, normalizeOutboundMentions } from './normalize-mentions';
+import { buildPostElements } from './deliver';
 
 const sendLog = larkLogger('outbound/send');
 
-/**
- * Runs the outbound text through mention normalization. Returns the
- * input unchanged on any failure so a parser bug never blocks send.
- * Sentinels collected during normalization are returned for the caller
- * to record after a successful send.
- */
 async function normalizeFeishuOutboundText(
   cfg: ClawdbotConfig,
   to: string,
@@ -176,7 +171,7 @@ export async function sendMessageFeishu(params: SendFeishuMessageParams): Promis
 
   if (i18nTexts && Object.keys(i18nTexts).length > 0) {
     // Multi-locale post: build each locale's content independently.
-    const postBody: Record<string, { content: Array<Array<{ tag: string; text: string }>> }> = {};
+    const postBody: Record<string, { content: Array<Array<Record<string, string>>> }> = {};
     for (const [locale, localeText] of Object.entries(i18nTexts)) {
       let processed = localeText;
 
@@ -192,7 +187,7 @@ export async function sendMessageFeishu(params: SendFeishuMessageParams): Promis
       processed = optimizeMarkdownStyle(processed, 1);
 
       postBody[locale] = {
-        content: [[{ tag: 'md', text: processed }]],
+        content: [buildPostElements(processed)],
       };
     }
     contentPayload = JSON.stringify(postBody);
@@ -213,7 +208,7 @@ export async function sendMessageFeishu(params: SendFeishuMessageParams): Promis
 
     contentPayload = JSON.stringify({
       zh_cn: {
-        content: [[{ tag: 'md', text: messageText }]],
+        content: [buildPostElements(messageText)],
       },
     });
   }
@@ -530,7 +525,7 @@ export async function editMessageFeishu(params: {
 
   const contentPayload = JSON.stringify({
     zh_cn: {
-      content: [[{ tag: 'md', text: optimizedText }]],
+      content: [buildPostElements(optimizedText)],
     },
   });
 


### PR DESCRIPTION
## Problem

When an LLM response contains `<at user_id="ou_xxx">Name</at>` tags, the current `buildPostContent()` function wraps the entire text — including `<at>` tags — inside a single `{tag: "md", text: "..."}` element. Lark's post message API treats `<at>` tags embedded in markdown text as **visual rendering only** — it does NOT populate the `mentions` array or trigger `im.message.receive_v1` events.

This blocks multi-bot collaboration scenarios where Bot A needs to @mention Bot B in group chats.

## Verified behavior

| Payload format | `mentions` array | Event triggered |
|---|---|---|
| `{tag: "md", text: "...<at>..."}` (current) | empty | No |
| `{tag: "at", user_id: "..."}` as standalone element | populated | Yes |

Tested with Lark API `POST /open-apis/im/v1/messages` and verified via `im.message.receive_v1` WebSocket events.

## Change

`buildPostContent()` in `src/messaging/outbound/deliver.ts` now:

1. Unescapes `\"` → `"` (LLM output may contain escaped quotes)
2. Splits text on `<at user_id="...">...</at>` boundaries
3. Emits `<at>` matches as `{tag: "at", user_id: "..."}` elements
4. Emits surrounding text as `{tag: "md", text: "..."}` elements
5. Falls back to original behavior when no `<at>` tags are present

## Impact

- **Non-breaking**: Messages without `<at>` tags behave identically to before
- **Additive**: Messages with `<at>` tags now produce real mentions
- Works with `normalizeAtMentions()` which already fixes common AI-generated `<at>` format errors

## Use case

Multi-bot group chats where agents @mention each other to create discussion chains. Without this fix, the mention is rendered visually but the target bot never receives the event.