### PR TITLE
feat(channel): normalize outbound @mentions for feishu

### DIFF
--- a/src/card/reply-dispatcher-types.ts
+++ b/src/card/reply-dispatcher-types.ts
@@ -132,6 +132,8 @@ export interface CreateFeishuReplyDispatcherParams {
   skipTyping?: boolean;
   /** When true, replies are sent into the thread instead of main chat. */
   replyInThread?: boolean;
+  /** Thread root id when the reply lives inside a thread; used for sentinel keying. */
+  threadId?: string;
   toolUseDisplay: ToolUseDisplayConfig;
 }
 

--- a/src/card/reply-dispatcher.ts
+++ b/src/card/reply-dispatcher.ts
@@ -39,7 +39,7 @@ export type { CreateFeishuReplyDispatcherParams } from './reply-dispatcher-types
 
 export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherParams): FeishuReplyDispatcherResult {
   const core = LarkClient.runtime;
-  const { cfg, agentId, chatId, sessionKey, replyToMessageId, accountId, replyInThread } = params;
+  const { cfg, agentId, chatId, sessionKey, replyToMessageId, accountId, replyInThread, threadId } = params;
 
   // Resolve account so we can read per-account config (e.g. replyMode)
   const account = getLarkAccount(cfg, accountId);
@@ -266,6 +266,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                   replyToMessageId,
                   replyInThread,
                   accountId,
+                  threadId,
                 });
               } catch (fallbackErr) {
                 if (staticGuard?.terminate('deliver.textFallback', fallbackErr)) return;
@@ -296,6 +297,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                     replyToMessageId,
                     replyInThread,
                     accountId,
+                    threadId,
                   });
                 } catch (fallbackErr) {
                   if (staticGuard?.terminate('deliver.textFallback', fallbackErr)) return;
@@ -322,6 +324,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                 replyToMessageId,
                 replyInThread,
                 accountId,
+                threadId,
               });
             } catch (err) {
               if (staticGuard?.terminate('deliver.textChunk', err)) return;

--- a/src/messaging/inbound/dispatch-builders.ts
+++ b/src/messaging/inbound/dispatch-builders.ts
@@ -16,25 +16,61 @@ import type { LarkClient } from '../../core/lark-client';
 import { threadScopedKey } from '../../channel/chat-queue';
 import type { DispatchContext } from './dispatch-context';
 import { nonBotMentions } from './mention';
+import type { SentinelEntry } from './sentinel-store';
 
 // ---------------------------------------------------------------------------
 // Mention annotation
 // ---------------------------------------------------------------------------
 
+const MENTION_USAGE_HINT =
+  'To @mention in a reply, use `<at user_id="ou_xxx">Name</at>`; plain "@Name" won\'t notify.';
+
 /**
  * Build a `[System: ...]` mention annotation when the message @-mentions
- * non-bot users.  Returns `undefined` when there are no user mentions.
+ * non-self-bot users or when the previous reply had unresolved mentions.
+ * Returns `undefined` when there is nothing to report.
  *
  * Sender identity / chat metadata are handled by the SDK's own
  * `buildInboundUserContextPrefix` (via SenderId, SenderName, ReplyToBody,
  * InboundHistory, etc.), so we only inject the mention data that the SDK
  * does not natively support.
  */
-export function buildMentionAnnotation(ctx: MessageContext): string | undefined {
-  const mentions = nonBotMentions(ctx);
+export function buildMentionAnnotation(
+  ctx: MessageContext,
+  sentinels?: SentinelEntry[],
+): string | undefined {
+  const sections = [
+    formatMentionList(nonBotMentions(ctx)),
+    formatSentinelFeedback(sentinels),
+  ].filter((s): s is string => !!s);
+
+  if (sections.length === 0) return undefined;
+  sections.push(MENTION_USAGE_HINT);
+  return `[System: ${sections.join(' ')}]`;
+}
+
+function formatMentionList(mentions: ReturnType<typeof nonBotMentions>): string | undefined {
   if (mentions.length === 0) return undefined;
-  const mentionDetails = mentions.map((t) => `${t.name} (open_id: ${t.openId})`).join(', ');
-  return `[System: This message @mentions the following users: ${mentionDetails}. Use these open_ids when performing actions involving these users. To @mention in a reply, use \`<at user_id="ou_xxx">Name</at>\`; plain "@Name" won't notify.]`;
+  const details = mentions.map((t) => `${t.name} (open_id: ${t.openId})`).join(', ');
+  return (
+    `This message @mentions the following users: ${details}. ` +
+    `Use these open_ids when performing actions involving these users.`
+  );
+}
+
+function formatSentinelFeedback(sentinels: SentinelEntry[] | undefined): string | undefined {
+  if (!sentinels || sentinels.length === 0) return undefined;
+  const lines = sentinels.map((s) => {
+    if (s.reason === 'not_found') {
+      return `"@${s.name}" was not recognized in the chat`;
+    }
+    if (s.reason === 'ambiguous' && s.candidates && s.candidates.length > 0) {
+      const ids = s.candidates.map((c) => c.openId).join(' / ');
+      return `"@${s.name}" matched multiple users (${ids}); use explicit <at user_id="...">`;
+    }
+    return `"@${s.name}" failed to resolve`;
+  });
+  return `Previous reply had unresolved mentions: ${lines.join('; ')}.`;
 }
 
 // ---------------------------------------------------------------------------
@@ -50,7 +86,11 @@ export function buildMentionAnnotation(ctx: MessageContext): string | undefined 
  * the body cleaner and avoiding misleading heuristics for non-text
  * message types (merge_forward, interactive cards, etc.).
  */
-export function buildMessageBody(ctx: MessageContext, quotedContent?: string): string {
+export function buildMessageBody(
+  ctx: MessageContext,
+  quotedContent?: string,
+  sentinels?: SentinelEntry[],
+): string {
   let messageBody = ctx.content;
   if (quotedContent) {
     messageBody = `[Replying to: "${quotedContent}"]\n\n${ctx.content}`;
@@ -59,7 +99,7 @@ export function buildMessageBody(ctx: MessageContext, quotedContent?: string): s
   const speaker = ctx.senderName ?? ctx.senderId;
   messageBody = `${speaker}: ${messageBody}`;
 
-  const mentionAnnotation = buildMentionAnnotation(ctx);
+  const mentionAnnotation = buildMentionAnnotation(ctx, sentinels);
   if (mentionAnnotation) {
     messageBody += `\n\n${mentionAnnotation}`;
   }
@@ -86,8 +126,11 @@ export function buildMessageBody(ctx: MessageContext, quotedContent?: string): s
  * The SDK's `detectAndLoadPromptImages` will discover image paths from
  * the text and inject them as multimodal content blocks.
  */
-export function buildBodyForAgent(ctx: MessageContext): string {
-  const mentionAnnotation = buildMentionAnnotation(ctx);
+export function buildBodyForAgent(
+  ctx: MessageContext,
+  sentinels?: SentinelEntry[],
+): string {
+  const mentionAnnotation = buildMentionAnnotation(ctx, sentinels);
   if (mentionAnnotation) {
     return `${ctx.content}\n\n${mentionAnnotation}`;
   }

--- a/src/messaging/inbound/dispatch.ts
+++ b/src/messaging/inbound/dispatch.ts
@@ -48,6 +48,7 @@ import {
   buildInboundPayload,
   buildMessageBody,
 } from './dispatch-builders';
+import { getSentinelStore } from './sentinel-store';
 import { type DispatchContext, buildDispatchContext, resolveThreadSessionKey } from './dispatch-context';
 import type { PermissionError } from './permission';
 import { mentionedBot } from './mention';
@@ -261,6 +262,7 @@ async function dispatchNormalMessage(
     chatType: dc.ctx.chatType,
     skipTyping,
     replyInThread: dc.isThread,
+    threadId: dc.isThread ? dc.ctx.threadId : undefined,
     toolUseDisplay,
   });
 
@@ -379,10 +381,16 @@ export async function dispatchToAgent(params: {
     });
   }
 
-  // 2. Build annotated message body
-  const messageBody = buildMessageBody(params.ctx, params.quotedContent);
+  // Consume any pending mention sentinels for this thread. Take and
+  // delete is one shot per inbound — capture once, hand to both body
+  // builders below.
+  const sentinelKey = threadScopedKey(dc.ctx.chatId, dc.isThread ? dc.ctx.threadId : undefined);
+  const sentinels = getSentinelStore(dc.account.accountId).consumeSentinels(sentinelKey);
 
-  // 3. Permission-error notification (optional side-effect).
+  // 3. Build annotated message body
+  const messageBody = buildMessageBody(params.ctx, params.quotedContent, sentinels);
+
+  // 4. Permission-error notification (optional side-effect).
   //    Isolated so a failure here does not block the main message dispatch.
   //    Skipped for comment targets: the streaming card dispatcher inside
   //    dispatchPermissionNotification sends via IM APIs which don't
@@ -395,7 +403,7 @@ export async function dispatchToAgent(params: {
     }
   }
 
-  // 4. Build main envelope (with group chat history)
+  // 5. Build main envelope (with group chat history)
   const { combinedBody, historyKey } = buildEnvelopeWithHistory(
     dc,
     messageBody,
@@ -403,12 +411,12 @@ export async function dispatchToAgent(params: {
     params.historyLimit,
   );
 
-  // 5. Build BodyForAgent with mention annotation (if any).
+  // 6. Build BodyForAgent with mention annotation (if any).
   //    SDK >= 2026.2.10 no longer falls back to Body for BodyForAgent,
   //    so we must set it explicitly to preserve the annotation.
-  const bodyForAgent = buildBodyForAgent(params.ctx);
+  const bodyForAgent = buildBodyForAgent(params.ctx, sentinels);
 
-  // 6. Build InboundHistory for SDK metadata injection (>= 2026.2.10).
+  // 7. Build InboundHistory for SDK metadata injection (>= 2026.2.10).
   //    The SDK's buildInboundUserContextPrefix renders these as structured
   //    JSON blocks; earlier SDK versions simply ignore unknown fields.
   const threadHistoryKey = threadScopedKey(dc.ctx.chatId, dc.isThread ? dc.ctx.threadId : undefined);
@@ -421,7 +429,7 @@ export async function dispatchToAgent(params: {
         }))
       : undefined;
 
-  // 7. Build inbound context payload
+  // 8. Build inbound context payload
   const isBareNewOrReset = /^\/(?:new|reset)\s*$/i.test((params.ctx.content ?? '').trim());
   const groupSystemPrompt = dc.isGroup
     ? params.groupConfig?.systemPrompt?.trim() || params.defaultGroupConfig?.systemPrompt?.trim() || undefined
@@ -461,7 +469,7 @@ export async function dispatchToAgent(params: {
     },
   });
 
-  // 8a. Intercept /feishu commands for i18n multi-locale card dispatch
+  // 9a. Intercept /feishu commands for i18n multi-locale card dispatch
   //     Must run BEFORE the SDK command check — the SDK does not recognise
   //     plugin-registered commands via isControlCommandMessage, so
   //     /feishu_* falls through to the AI agent otherwise.

--- a/src/messaging/inbound/mention.ts
+++ b/src/messaging/inbound/mention.ts
@@ -29,12 +29,12 @@ export function isMentionAll(mention: { key: string }): boolean {
   return mention.key === '@_all';
 }
 
-/** Whether the bot was @-mentioned. */
+/** Whether the receiving bot itself was @-mentioned. */
 export function mentionedBot(ctx: MessageContext): boolean {
   return ctx.mentions.some((m) => m.isBot);
 }
 
-/** All non-bot mentions. */
+/** All mentions excluding the receiving bot itself. */
 export function nonBotMentions(ctx: MessageContext): MentionInfo[] {
   return ctx.mentions.filter((m) => !m.isBot);
 }
@@ -105,3 +105,4 @@ export function buildMentionedCardContent(targets: MentionInfo[], message: strin
   const mentionTags = targets.map(formatMentionForCard).join(' ');
   return `${mentionTags}\n${message}`;
 }
+

--- a/src/messaging/inbound/sentinel-store.ts
+++ b/src/messaging/inbound/sentinel-store.ts
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Per-thread store for unresolved mention feedback. The outbound
+ * normalizer records a SentinelEntry whenever an `@Name` cannot be
+ * resolved; the next inbound message on the same thread consumes
+ * (take and delete) the entries, which buildMentionAnnotation surfaces
+ * as a system note so the next reply can disambiguate.
+ *
+ * Kept separate from UserNameCache because the lifecycle differs:
+ * 10-minute TTL, per-thread keying, and take-and-delete consumption.
+ */
+
+const DEFAULT_TTL_MS = 10 * 60 * 1000; // 10 min — short, avoid stale feedback
+const DEFAULT_MAX_THREADS = 200; // per-account
+
+export interface SentinelEntry {
+  /** Literal name as it appeared in the outbound text. */
+  name: string;
+  /** Why parsing failed. */
+  reason: 'not_found' | 'ambiguous';
+  /** Candidate open_ids when reason === 'ambiguous'. */
+  candidates?: Array<{ openId: string; kind?: 'user' | 'bot' }>;
+}
+
+interface StoredSentinels {
+  entries: SentinelEntry[];
+  expireAt: number;
+}
+
+function dedup(entries: SentinelEntry[]): SentinelEntry[] {
+  const seen = new Set<string>();
+  const out: SentinelEntry[] = [];
+  for (const e of entries) {
+    const key = `${e.reason}:${e.name}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(e);
+  }
+  return out;
+}
+
+export class SentinelStore {
+  private byThread = new Map<string, StoredSentinels>();
+  private maxThreads: number;
+  private ttlMs: number;
+
+  constructor(maxThreads = DEFAULT_MAX_THREADS, ttlMs = DEFAULT_TTL_MS) {
+    this.maxThreads = maxThreads;
+    this.ttlMs = ttlMs;
+  }
+
+  recordSentinels(threadKey: string, sentinels: SentinelEntry[]): void {
+    if (sentinels.length === 0) return;
+    const existing = this.byThread.get(threadKey);
+    const merged = existing ? [...existing.entries, ...sentinels] : sentinels;
+    this.byThread.delete(threadKey); // bump LRU
+    this.byThread.set(threadKey, {
+      entries: dedup(merged),
+      expireAt: Date.now() + this.ttlMs,
+    });
+    this.evict();
+  }
+
+  consumeSentinels(threadKey: string): SentinelEntry[] {
+    const stored = this.byThread.get(threadKey);
+    if (!stored) return [];
+    this.byThread.delete(threadKey);
+    if (stored.expireAt <= Date.now()) return [];
+    return stored.entries;
+  }
+
+  clear(): void {
+    this.byThread.clear();
+  }
+
+  private evict(): void {
+    while (this.byThread.size > this.maxThreads) {
+      const oldest = this.byThread.keys().next().value;
+      if (oldest === undefined) break;
+      this.byThread.delete(oldest);
+    }
+  }
+}
+
+const registry = new Map<string, SentinelStore>();
+
+export function getSentinelStore(
+  accountId: string,
+  maxThreads?: number,
+  ttlMs?: number,
+): SentinelStore {
+  let store = registry.get(accountId);
+  if (!store) {
+    store = new SentinelStore(maxThreads, ttlMs);
+    registry.set(accountId, store);
+  }
+  return store;
+}
+
+export function clearSentinelStore(accountId?: string): void {
+  if (accountId !== undefined) {
+    registry.get(accountId)?.clear();
+    registry.delete(accountId);
+  } else {
+    clearAllSentinelStores();
+  }
+}
+
+export function clearAllSentinelStores(): void {
+  for (const s of registry.values()) s.clear();
+  registry.clear();
+}

--- a/src/messaging/inbound/user-name-cache-store.ts
+++ b/src/messaging/inbound/user-name-cache-store.ts
@@ -3,58 +3,116 @@
  * SPDX-License-Identifier: MIT
  *
  * Account-scoped cache registry for Feishu user display names.
+ *
+ * Stores forward (openId → name + kind) and reverse (normalizedName → Set<openId>)
+ * indexes for mention resolution. Per-account, LRU + TTL.
  */
 
 const DEFAULT_MAX_SIZE = 500;
 const DEFAULT_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const DEFAULT_MAX_CHATS = 200;
 
-interface CacheEntry {
+export type PrincipalKind = 'user' | 'bot';
+
+interface NameEntry {
   name: string;
+  kind?: PrincipalKind;
   expireAt: number;
 }
 
+export interface MentionMatch {
+  openId: string;
+  name: string;
+  kind?: PrincipalKind;
+}
+
+export interface ChatMember {
+  openId: string;
+  name: string;
+  kind: PrincipalKind;
+}
+
+export interface ChatMembersEntry {
+  members: ChatMember[];
+  expireAt: number;
+}
+
+function normalizeName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
 export class UserNameCache {
-  private map = new Map<string, CacheEntry>();
+  private nameByOpenId = new Map<string, NameEntry>();
+  private openIdsByName = new Map<string, Set<string>>();
   private maxSize: number;
   private ttlMs: number;
+  private chatBots = new Map<string, ChatMembersEntry>();
+  private chatMembers = new Map<string, ChatMembersEntry>();
+  private inFlight = new Map<string, Promise<void>>();
+  private maxChats: number;
 
-  constructor(maxSize = DEFAULT_MAX_SIZE, ttlMs = DEFAULT_TTL_MS) {
+  constructor(
+    maxSize = DEFAULT_MAX_SIZE,
+    ttlMs = DEFAULT_TTL_MS,
+    maxChats = DEFAULT_MAX_CHATS,
+  ) {
     this.maxSize = maxSize;
     this.ttlMs = ttlMs;
+    this.maxChats = maxChats;
   }
 
   has(openId: string): boolean {
-    const entry = this.map.get(openId);
+    const entry = this.nameByOpenId.get(openId);
     if (!entry) return false;
     if (entry.expireAt <= Date.now()) {
-      this.map.delete(openId);
+      this.deleteOpenId(openId);
       return false;
     }
     return true;
   }
 
   get(openId: string): string | undefined {
-    const entry = this.map.get(openId);
+    const entry = this.nameByOpenId.get(openId);
     if (!entry) return undefined;
     if (entry.expireAt <= Date.now()) {
-      this.map.delete(openId);
+      this.deleteOpenId(openId);
       return undefined;
     }
-    this.map.delete(openId);
-    this.map.set(openId, entry);
+    // LRU bump
+    this.nameByOpenId.delete(openId);
+    this.nameByOpenId.set(openId, entry);
     return entry.name;
   }
 
   set(openId: string, name: string): void {
-    this.map.delete(openId);
-    this.map.set(openId, { name, expireAt: Date.now() + this.ttlMs });
-    this.evict();
+    this.writeEntry(openId, name, undefined);
+  }
+
+  setWithKind(openId: string, name: string, kind: PrincipalKind): void {
+    this.writeEntry(openId, name, kind);
+  }
+
+  lookupByName(name: string): MentionMatch[] {
+    const key = normalizeName(name);
+    const ids = this.openIdsByName.get(key);
+    if (!ids || ids.size === 0) return [];
+
+    const matches: MentionMatch[] = [];
+    for (const openId of ids) {
+      const entry = this.nameByOpenId.get(openId);
+      if (!entry) continue;
+      if (entry.expireAt <= Date.now()) {
+        this.deleteOpenId(openId);
+        continue;
+      }
+      matches.push({ openId, name: entry.name, kind: entry.kind });
+    }
+    return matches;
   }
 
   setMany(entries: Iterable<[string, string]>): void {
     for (const [openId, name] of entries) {
-      this.map.delete(openId);
-      this.map.set(openId, { name, expireAt: Date.now() + this.ttlMs });
+      this.writeEntryNoEvict(openId, name, undefined);
     }
     this.evict();
   }
@@ -73,14 +131,127 @@ export class UserNameCache {
     return result;
   }
 
+  recordChatBots(chatId: string, members: Array<{ openId: string; name: string }>): void {
+    const enriched: ChatMember[] = members.map((m) => ({ ...m, kind: 'bot' as PrincipalKind }));
+    this.chatBots.delete(chatId);
+    this.chatBots.set(chatId, { members: enriched, expireAt: Date.now() + this.ttlMs });
+    this.evictChats(this.chatBots);
+    for (const m of enriched) {
+      if (m.openId) this.writeEntryNoEvict(m.openId, m.name, 'bot');
+    }
+    this.evict();
+  }
+
+  recordChatMembers(chatId: string, members: ChatMember[]): void {
+    const enriched = members.slice();
+    this.chatMembers.delete(chatId);
+    this.chatMembers.set(chatId, { members: enriched, expireAt: Date.now() + this.ttlMs });
+    this.evictChats(this.chatMembers);
+    for (const m of enriched) {
+      if (m.openId) this.writeEntryNoEvict(m.openId, m.name, m.kind);
+    }
+    this.evict();
+  }
+
+  getChatBots(chatId: string): ChatMembersEntry | null {
+    const entry = this.chatBots.get(chatId);
+    if (!entry) return null;
+    if (entry.expireAt <= Date.now()) {
+      this.chatBots.delete(chatId);
+      return null;
+    }
+    return entry;
+  }
+
+  getChatMembers(chatId: string): ChatMembersEntry | null {
+    const entry = this.chatMembers.get(chatId);
+    if (!entry) return null;
+    if (entry.expireAt <= Date.now()) {
+      this.chatMembers.delete(chatId);
+      return null;
+    }
+    return entry;
+  }
+
+  getInflight(key: string): Promise<void> | undefined {
+    return this.inFlight.get(key);
+  }
+
+  setInflight(key: string, promise: Promise<void>): void {
+    this.inFlight.set(key, promise);
+  }
+
+  clearInflight(key: string): void {
+    this.inFlight.delete(key);
+  }
+
   clear(): void {
-    this.map.clear();
+    this.nameByOpenId.clear();
+    this.openIdsByName.clear();
+    this.chatBots.clear();
+    this.chatMembers.clear();
+    this.inFlight.clear();
+  }
+
+  // ----- private helpers -----
+
+  private writeEntry(openId: string, name: string, kind: PrincipalKind | undefined): void {
+    this.writeEntryNoEvict(openId, name, kind);
+    this.evict();
+  }
+
+  private writeEntryNoEvict(openId: string, name: string, kind: PrincipalKind | undefined): void {
+    // remove from old reverse bucket if name changed
+    const old = this.nameByOpenId.get(openId);
+    if (old) {
+      const oldKey = normalizeName(old.name);
+      const newKey = normalizeName(name);
+      if (oldKey !== newKey) {
+        this.removeFromReverse(oldKey, openId);
+      }
+    }
+
+    this.nameByOpenId.delete(openId);
+    this.nameByOpenId.set(openId, { name, kind, expireAt: Date.now() + this.ttlMs });
+
+    const key = normalizeName(name);
+    let bucket = this.openIdsByName.get(key);
+    if (!bucket) {
+      bucket = new Set();
+      this.openIdsByName.set(key, bucket);
+    }
+    bucket.add(openId);
+  }
+
+  private deleteOpenId(openId: string): void {
+    const entry = this.nameByOpenId.get(openId);
+    if (!entry) return;
+    this.nameByOpenId.delete(openId);
+    this.removeFromReverse(normalizeName(entry.name), openId);
+  }
+
+  private removeFromReverse(key: string, openId: string): void {
+    const bucket = this.openIdsByName.get(key);
+    if (!bucket) return;
+    bucket.delete(openId);
+    if (bucket.size === 0) {
+      this.openIdsByName.delete(key);
+    }
+  }
+
+  private evictChats(map: Map<string, ChatMembersEntry>): void {
+    while (map.size > this.maxChats) {
+      const oldest = map.keys().next().value;
+      if (oldest === undefined) break;
+      map.delete(oldest);
+    }
   }
 
   private evict(): void {
-    while (this.map.size > this.maxSize) {
-      const oldest = this.map.keys().next().value;
-      if (oldest !== undefined) this.map.delete(oldest);
+    while (this.nameByOpenId.size > this.maxSize) {
+      const oldest = this.nameByOpenId.keys().next().value;
+      if (oldest === undefined) break;
+      this.deleteOpenId(oldest);
     }
   }
 }

--- a/src/messaging/inbound/user-name-cache.ts
+++ b/src/messaging/inbound/user-name-cache.ts
@@ -15,6 +15,7 @@
 import type { LarkAccount } from '../../core/types';
 import { LarkClient } from '../../core/lark-client';
 import { getUserNameCache } from './user-name-cache-store';
+import type { ChatMember, PrincipalKind, UserNameCache } from './user-name-cache-store';
 import { type PermissionError, extractPermissionError } from './permission';
 
 export { UserNameCache, clearUserNameCache, getUserNameCache } from './user-name-cache-store';
@@ -75,14 +76,14 @@ export async function batchResolveUserNames(params: {
         const openId: string | undefined = item.open_id;
         if (!openId) continue;
         const name: string = item.name || item.display_name || item.nickname || item.en_name || '';
-        cache.set(openId, name);
+        cache.setWithKind(openId, name, 'user');
         result.set(openId, name);
         resolved.add(openId);
       }
       // Cache empty names for IDs the API didn't return (no permission, etc.)
       for (const id of chunk) {
         if (!resolved.has(id)) {
-          cache.set(id, '');
+          cache.setWithKind(id, '', 'user');
           result.set(id, '');
         }
       }
@@ -152,7 +153,7 @@ export async function resolveBotName(params: {
 
     // Cache even empty names to avoid repeated API calls for bots
     // whose names we cannot resolve.
-    cache.set(openId, name);
+    cache.setWithKind(openId, name, 'bot');
     return { name: name || undefined };
   } catch (err) {
     // Bot name resolution is best-effort: missing `bot:basic_info` scope
@@ -164,9 +165,171 @@ export async function resolveBotName(params: {
     } else {
       log(`feishu: failed to resolve bot name for ${openId}: ${String(err)}`);
     }
-    cache.set(openId, '');
+    cache.setWithKind(openId, '', 'bot');
     return {};
   }
+}
+
+// ---------------------------------------------------------------------------
+// Lazy chat-member prefetch
+// ---------------------------------------------------------------------------
+
+/** Returns the numeric Feishu API error code from a thrown error, or null. */
+function extractApiCode(err: unknown): number | null {
+  const permErr = extractPermissionError(err);
+  if (typeof permErr?.code === 'number') return permErr.code;
+  if (err && typeof err === 'object') {
+    const code = (err as { response?: { data?: { code?: unknown } } }).response?.data?.code;
+    if (typeof code === 'number') return code;
+  }
+  return null;
+}
+
+/** Configuration for one chat-prefetch endpoint. */
+interface ChatPrefetchSpec<M> {
+  /** Tag used in in-flight key and log lines, e.g. 'bots' or 'members'. */
+  tag: string;
+  /** API endpoint, given the chatId. */
+  url: (chatId: string) => string;
+  /** Query string. */
+  params: Record<string, unknown>;
+  parseItem: (raw: unknown) => M | null;
+  /** True iff a fresh snapshot is already in the cache for this chat. */
+  isFresh: (cache: UserNameCache, chatId: string) => boolean;
+  /** Write a member list (used both on success and on the empty-on-error path). */
+  record: (cache: UserNameCache, chatId: string, members: M[]) => void;
+}
+
+/**
+ * Runs a chat-member prefetch with shared lifecycle:
+ *
+ * 1. Skip on unconfigured account or empty chatId.
+ * 2. Dedup concurrent calls per (tag, chatId) via `cache.inFlight`.
+ * 3. Skip when an in-TTL snapshot already exists.
+ * 4. On API error, cache an empty list to short-circuit retries; on
+ *    transient errors, leave the cache untouched so the next call retries.
+ */
+async function runChatPrefetch<M>(
+  spec: ChatPrefetchSpec<M>,
+  account: LarkAccount,
+  chatId: string,
+  log: (...args: unknown[]) => void,
+): Promise<void> {
+  if (!account.configured || !chatId) return;
+
+  const cache = getUserNameCache(account.accountId);
+  const key = `${spec.tag}:${chatId}`;
+  const existing = cache.getInflight(key);
+  if (existing) return existing;
+  if (spec.isFresh(cache, chatId)) return;
+
+  const promise = (async () => {
+    try {
+      const client = LarkClient.fromAccount(account).sdk;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const res: any = await (client as any).request({
+        method: 'GET',
+        url: spec.url(chatId),
+        params: spec.params,
+      });
+      const items: unknown[] = (res as { data?: { items?: unknown[] } })?.data?.items ?? [];
+      const members = items.map(spec.parseItem).filter((m): m is M => m !== null);
+      spec.record(cache, chatId, members);
+    } catch (err) {
+      const apiCode = extractApiCode(err);
+      if (apiCode != null) {
+        // Application-level refusal: cache an empty list to short-circuit
+        // further retries. Persistent errors (e.g. missing scope) will not
+        // resolve within the cache TTL anyway.
+        log(`prefetchChat${spec.tag}[${chatId}]: API error code=${apiCode}, caching empty`);
+        spec.record(cache, chatId, []);
+      } else {
+        log(`prefetchChat${spec.tag}[${chatId}]: failed: ${String(err)}`);
+      }
+    } finally {
+      cache.clearInflight(key);
+    }
+  })();
+
+  cache.setInflight(key, promise);
+  return promise;
+}
+
+interface RawBotMember {
+  // /members/bots returns { bot_id, bot_name }; some related endpoints
+  // use { open_id, name }. Accept both shapes.
+  bot_id?: string;
+  bot_name?: string;
+  open_id?: string;
+  name?: string;
+}
+
+const CHAT_BOTS_SPEC: ChatPrefetchSpec<{ openId: string; name: string }> = {
+  tag: 'Bots',
+  url: (chatId) => `/open-apis/im/v1/chats/${chatId}/members/bots`,
+  params: {},
+  parseItem: (raw) => {
+    const it = raw as RawBotMember;
+    const openId = String(it.bot_id ?? it.open_id ?? '');
+    if (!openId) return null;
+    return { openId, name: String(it.bot_name ?? it.name ?? '') };
+  },
+  isFresh: (cache, chatId) => cache.getChatBots(chatId) !== null,
+  record: (cache, chatId, members) => cache.recordChatBots(chatId, members),
+};
+
+interface RawChatMember {
+  // /members returns `member_id`; some related endpoints use `open_id`.
+  // With `member_id_type=open_id` the value is an ou_-prefixed open_id.
+  member_id?: string;
+  open_id?: string;
+  name?: string;
+  // 'user' | 'app'; absent on /members, where every entry is a user.
+  member_type?: string;
+}
+
+function memberTypeToKind(type: string | undefined): PrincipalKind {
+  return type === 'app' ? 'bot' : 'user';
+}
+
+const CHAT_MEMBERS_SPEC: ChatPrefetchSpec<ChatMember> = {
+  tag: 'Members',
+  url: (chatId) => `/open-apis/im/v1/chats/${chatId}/members`,
+  params: { member_id_type: 'open_id', page_size: 100 },
+  parseItem: (raw) => {
+    const it = raw as RawChatMember;
+    const openId = String(it.member_id ?? it.open_id ?? '');
+    if (!openId) return null;
+    return { openId, name: String(it.name ?? ''), kind: memberTypeToKind(it.member_type) };
+  },
+  isFresh: (cache, chatId) => cache.getChatMembers(chatId) !== null,
+  record: (cache, chatId, members) => cache.recordChatMembers(chatId, members),
+};
+
+/**
+ * Fetches the bot members of a chat via
+ * `GET /open-apis/im/v1/chats/{chat_id}/members/bots` and writes them
+ * to the per-account cache.
+ */
+export async function prefetchChatBots(
+  account: LarkAccount,
+  chatId: string,
+  log: (...args: unknown[]) => void,
+): Promise<void> {
+  return runChatPrefetch(CHAT_BOTS_SPEC, account, chatId, log);
+}
+
+/**
+ * Fetches the human members of a chat via
+ * `GET /open-apis/im/v1/chats/{chat_id}/members` and writes them to
+ * the per-account cache.
+ */
+export async function prefetchChatMembers(
+  account: LarkAccount,
+  chatId: string,
+  log: (...args: unknown[]) => void,
+): Promise<void> {
+  return runChatPrefetch(CHAT_MEMBERS_SPEC, account, chatId, log);
 }
 
 /**
@@ -203,14 +366,14 @@ export async function resolveUserName(params: {
 
     // Cache even empty names to avoid repeated API calls for users
     // whose names we cannot resolve (e.g. due to permissions).
-    cache.set(openId, name);
+    cache.setWithKind(openId, name, 'user');
     return { name: name || undefined };
   } catch (err) {
     const permErr = extractPermissionError(err);
     if (permErr) {
       log(`feishu: permission error resolving user name: code=${permErr.code}`);
       // Cache empty name so we don't retry a known-failing openId
-      cache.set(openId, '');
+      cache.setWithKind(openId, '', 'user');
       return { permissionError: permErr };
     }
     log(`feishu: failed to resolve user name for ${openId}: ${String(err)}`);

--- a/src/messaging/outbound/deliver.ts
+++ b/src/messaging/outbound/deliver.ts
@@ -10,14 +10,17 @@
 
 import type { ClawdbotConfig } from 'openclaw/plugin-sdk';
 import type { FeishuSendResult } from '../types';
-import { createAccountScopedConfig } from '../../core/accounts';
+import { createAccountScopedConfig, getLarkAccount } from '../../core/accounts';
 import { LarkClient } from '../../core/lark-client';
+import { threadScopedKey } from '../../channel/chat-queue';
 import { normalizeFeishuTarget, resolveReceiveIdType } from '../../core/targets';
 import { parseFeishuCommentTarget } from '../../core/comment-target';
 import { optimizeMarkdownStyle } from '../../card/markdown-style';
 import { formatLarkError } from '../../core/api-error';
 import { larkLogger } from '../../core/lark-logger';
+import { getSentinelStore } from '../inbound/sentinel-store';
 import { uploadAndSendMediaLark } from './media';
+import { type NormalizeContext, type SentinelEntry, normalizeOutboundMentions } from './normalize-mentions';
 
 const log = larkLogger('outbound/deliver');
 
@@ -36,29 +39,47 @@ function buildPostContent(text: string): string {
   });
 }
 
-/**
- * Normalise `<at>` mention tags that the AI frequently writes incorrectly.
- *
- * Correct Feishu syntax:
- *   `<at user_id="ou_xxx">name</at>`   — mention a user
- *   `<at user_id="all"></at>`           — mention everyone
- *
- * Common AI mistakes this function fixes:
- *   `<at id=all></at>`           → `<at user_id="all"></at>`
- *   `<at id="ou_xxx"></at>`      → `<at user_id="ou_xxx"></at>`
- *   `<at open_id="ou_xxx"></at>` → `<at user_id="ou_xxx"></at>`
- *   `<at user_id=ou_xxx></at>`   → `<at user_id="ou_xxx"></at>`
- */
-function normalizeAtMentions(text: string): string {
-  return text.replace(/<at\s+(?:id|open_id|user_id)\s*=\s*"?([^">\s]+)"?\s*>/gi, '<at user_id="$1">');
+interface PreparedText {
+  text: string;
+  sentinels: SentinelEntry[];
+  resolvedAccountId: string | undefined;
 }
 
 /**
- * Pre-process text for Lark rendering:
- * mention normalisation + table conversion + style optimization.
+ * Pre-processes text before Feishu delivery. Runs the full mention
+ * normalizer (tag rewrite + plain `@Name` resolution + `@all` aliases),
+ * markdown-table conversion, and Markdown style optimization.
+ *
+ * Falls back to the raw text on any normalizer failure so a parser bug
+ * never blocks send. Sentinels collected during normalization are
+ * returned for the caller to record after the send succeeds.
  */
-function prepareTextForLark(cfg: ClawdbotConfig, text: string, accountId?: string): string {
-  let processed = normalizeAtMentions(text);
+async function prepareTextForLark(
+  cfg: ClawdbotConfig,
+  text: string,
+  to: string,
+  accountId?: string,
+): Promise<PreparedText> {
+  let processed = text;
+  let sentinels: SentinelEntry[] = [];
+  let resolvedAccountId: string | undefined = accountId;
+
+  if (text?.trim()) {
+    try {
+      const account = getLarkAccount(cfg, accountId ?? undefined);
+      const ctx: NormalizeContext = {
+        chatId: to,
+        account,
+        log: (...args) => log.warn(args.map(String).join(' ')),
+      };
+      const r = await normalizeOutboundMentions(text, ctx);
+      processed = r.normalizedText;
+      sentinels = r.sentinels;
+      resolvedAccountId = account.accountId;
+    } catch (err) {
+      log.warn(`normalizeOutboundMentions failed in prepareTextForLark, using raw text: ${String(err)}`);
+    }
+  }
 
   // Convert markdown tables to Feishu-compatible format using per-account
   // tableMode setting.
@@ -76,7 +97,21 @@ function prepareTextForLark(cfg: ClawdbotConfig, text: string, accountId?: strin
     // Runtime not available -- use the text as-is.
   }
 
-  return optimizeMarkdownStyle(processed, 1);
+  return {
+    text: optimizeMarkdownStyle(processed, 1),
+    sentinels,
+    resolvedAccountId,
+  };
+}
+
+function recordSentinelsForChat(
+  resolvedAccountId: string | undefined,
+  to: string,
+  threadId: string | undefined,
+  sentinels: SentinelEntry[],
+): void {
+  if (!resolvedAccountId || sentinels.length === 0) return;
+  getSentinelStore(resolvedAccountId).recordSentinels(threadScopedKey(to, threadId), sentinels);
 }
 
 /**
@@ -211,6 +246,8 @@ export interface SendTextLarkParams {
   replyToMessageId?: string;
   /** When true, the reply appears in the thread instead of main chat. */
   replyInThread?: boolean;
+  /** Thread root id when the reply lives inside a thread; used for sentinel keying. */
+  threadId?: string;
   /** Optional account identifier for multi-account setups. */
   accountId?: string;
 }
@@ -240,7 +277,7 @@ export interface SendTextLarkParams {
  * ```
  */
 export async function sendTextLark(params: SendTextLarkParams): Promise<FeishuSendResult> {
-  const { cfg, to, text, replyToMessageId, replyInThread, accountId } = params;
+  const { cfg, to, text, replyToMessageId, replyInThread, accountId, threadId } = params;
 
   // Detect card JSON in text — route to card sending before text preprocessing.
   const card = detectCardJson(text);
@@ -252,10 +289,12 @@ export async function sendTextLark(params: SendTextLarkParams): Promise<FeishuSe
 
   log.info(`sendTextLark: target=${to}, textLength=${text.length}`);
   const client = LarkClient.fromCfg(cfg, accountId).sdk;
-  const processedText = prepareTextForLark(cfg, text, accountId);
-  const content = buildPostContent(processedText);
+  const prepared = await prepareTextForLark(cfg, text, to, accountId);
+  const content = buildPostContent(prepared.text);
 
-  return sendImMessage({ client, to, content, msgType: 'post', replyToMessageId, replyInThread });
+  const result = await sendImMessage({ client, to, content, msgType: 'post', replyToMessageId, replyInThread });
+  recordSentinelsForChat(prepared.resolvedAccountId, to, threadId, prepared.sentinels);
+  return result;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/messaging/outbound/normalize-mentions.ts
+++ b/src/messaging/outbound/normalize-mentions.ts
@@ -1,0 +1,240 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Outbound mention normalizer for Feishu post messages. Rewrites <at>
+ * tag variants and resolves "@Name" to the canonical
+ * <at user_id="ou_xxx">Name</at> form expected by the Feishu API.
+ */
+
+import type { LarkAccount } from '../../core/types';
+import { getUserNameCache, prefetchChatBots, prefetchChatMembers } from '../inbound/user-name-cache';
+import type { PrincipalKind } from '../inbound/user-name-cache-store';
+
+/**
+ * Rewrites <at> tag attribute and quote variants to the canonical
+ * `<at user_id="ou_xxx">` form. Idempotent; pure string transform.
+ *
+ * Recognized variants: `id=`, `open_id=`, `user_id=`; double-quoted,
+ * single-quoted, or unquoted; `id=all` aligned to `user_id="all"` with
+ * "Everyone" name fill. `<person>` picker tags are left untouched.
+ */
+export function normalizeOutboundMentionsTagPass(text: string): string {
+  let out = text;
+
+  // <at id=all|user_id="all"|...></at> → <at user_id="all">Everyone</at>.
+  // Match an explicit closing tag so already-canonical input stays
+  // idempotent: a bare opening tag would match the optional-close form
+  // and corrupt the trailing "Everyone</at>" into a double close.
+  out = out.replace(
+    /<at\s+(?:id|user_id|open_id)\s*=\s*["']?all["']?\s*>\s*<\/at>/gi,
+    '<at user_id="all">Everyone</at>',
+  );
+
+  // Generic <at attr=ou_xxx> → <at user_id="ou_xxx">.
+  out = out.replace(
+    /<at\s+(?:id|open_id|user_id)\s*=\s*["']?(ou_[A-Za-z0-9_-]+)["']?\s*>/gi,
+    '<at user_id="$1">',
+  );
+
+  return out;
+}
+
+export type LogFn = (...args: unknown[]) => void;
+
+export interface NormalizeContext {
+  /** Chat where the message will be sent; keys lazy chat-member fetches. */
+  chatId: string;
+  account: LarkAccount;
+  /** Optional sink for prefetch errors during normalization. */
+  log?: LogFn;
+}
+
+export interface SentinelEntry {
+  name: string;
+  reason: 'not_found' | 'ambiguous';
+  candidates?: Array<{ openId: string; kind?: PrincipalKind }>;
+}
+
+export interface NormalizeResult {
+  normalizedText: string;
+  sentinels: SentinelEntry[];
+}
+
+interface PendingMiss {
+  start: number;
+  end: number;
+  name: string;
+}
+
+interface Replacement {
+  start: number;
+  end: number;
+  text: string;
+}
+
+const noopLog: LogFn = () => {};
+
+/** Spans excluded from the @Name scan: code, canonical tags, emails, URLs. */
+const MASK_PATTERNS: RegExp[] = [
+  /```[\s\S]*?```/g,
+  /`[^`\n]*`/g,
+  /<at\s+user_id="[^"]+">[^<]*<\/at>/g,
+  /<person\s+[^>]*>[^<]*<\/person>/g,
+  /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g,
+  /\b(?:https?|ftp|mailto):\/\/[^\s)\]<>]+/g,
+];
+
+// CJK range U+4E00–U+9FA5 covers ideographs so multibyte names match.
+const CANDIDATE_RE = /@([A-Za-z0-9\u4e00-\u9fa5_]+(?:[.-][A-Za-z0-9\u4e00-\u9fa5_]+)*)/g;
+
+/** Lazy-fetch fallbacks tried in order on cache miss. */
+type Prefetch = (account: LarkAccount, chatId: string, log: LogFn) => Promise<void>;
+const FALLBACK_PREFETCHES: Prefetch[] = [prefetchChatBots, prefetchChatMembers];
+
+/**
+ * Normalizes outbound text for Feishu: rewrites <at> tag variants and
+ * resolves plain "@Name" against the per-account name cache.
+ *
+ * On cache miss, fetches the chat's bot list and retries; if still
+ * unresolved, fetches the chat's member list and retries. Names that
+ * match multiple cache entries become ambiguous sentinels for next-turn
+ * disambiguation; remaining misses are dropped without a sentinel to
+ * avoid false positives on `@` followed by non-name CJK runs.
+ */
+export async function normalizeOutboundMentions(
+  text: string,
+  ctx: NormalizeContext,
+): Promise<NormalizeResult> {
+  let out = normalizeOutboundMentionsTagPass(text);
+
+  // Drop redundant `@` immediately preceding a canonical <at> tag.
+  out = out.replace(/@(<at\s+user_id="ou_[A-Za-z0-9_-]+">[^<]*<\/at>)/g, '$1');
+
+  const inMask = buildMaskPredicate(out);
+  const sentinels: SentinelEntry[] = [];
+  const replacements: Replacement[] = [];
+
+  // First sweep: resolve from cache; defer misses for lazy fetch.
+  let pending: PendingMiss[] = [];
+  for (const m of out.matchAll(CANDIDATE_RE)) {
+    const start = m.index!;
+    if (inMask(start)) continue;
+    const end = start + m[0].length;
+    const r = resolveCandidate(m[1], ctx);
+    if (r.kind === 'resolved') {
+      replacements.push(makeReplacement(start, end, r));
+    } else if (r.entry.reason === 'ambiguous') {
+      sentinels.push(r.entry);
+    } else {
+      pending.push({ start, end, name: m[1] });
+    }
+  }
+
+  // Retry through each fallback in turn; remaining misses are dropped.
+  for (const prefetch of FALLBACK_PREFETCHES) {
+    if (pending.length === 0) break;
+    pending = await retryWithPrefetch(pending, prefetch, ctx, replacements, sentinels);
+  }
+
+  return { normalizedText: applyReplacements(out, replacements), sentinels };
+}
+
+function buildMaskPredicate(text: string): (idx: number) => boolean {
+  const masks: Array<[number, number]> = [];
+  for (const re of MASK_PATTERNS) {
+    for (const m of text.matchAll(re)) {
+      masks.push([m.index!, m.index! + m[0].length]);
+    }
+  }
+  return (idx) => masks.some(([s, e]) => idx >= s && idx < e);
+}
+
+function makeReplacement(
+  start: number,
+  end: number,
+  r: ResolvedCandidate,
+): Replacement {
+  return { start, end, text: `<at user_id="${r.openId}">${r.displayName}</at>` };
+}
+
+async function retryWithPrefetch(
+  pending: PendingMiss[],
+  prefetch: Prefetch,
+  ctx: NormalizeContext,
+  replacements: Replacement[],
+  sentinels: SentinelEntry[],
+): Promise<PendingMiss[]> {
+  await prefetch(ctx.account, ctx.chatId, ctx.log ?? noopLog);
+  const stillMissing: PendingMiss[] = [];
+  for (const p of pending) {
+    const r = resolveCandidate(p.name, ctx);
+    if (r.kind === 'resolved') {
+      replacements.push(makeReplacement(p.start, p.end, r));
+    } else if (r.entry.reason === 'ambiguous') {
+      sentinels.push(r.entry);
+    } else {
+      stillMissing.push(p);
+    }
+  }
+  return stillMissing;
+}
+
+/**
+ * Applies non-overlapping replacements in a single left-to-right pass.
+ * Builds an array of literal chunks then joins it once — O(n + total
+ * replacement length), no string-concat quadratic behavior.
+ */
+function applyReplacements(text: string, replacements: Replacement[]): string {
+  if (replacements.length === 0) return text;
+  const sorted = [...replacements].sort((a, b) => a.start - b.start);
+  const out: string[] = [];
+  let cursor = 0;
+  for (const r of sorted) {
+    if (r.start < cursor) continue; // drop overlapping replacements defensively
+    out.push(text.slice(cursor, r.start), r.text);
+    cursor = r.end;
+  }
+  out.push(text.slice(cursor));
+  return out.join('');
+}
+
+interface ResolvedCandidate {
+  kind: 'resolved';
+  openId: string;
+  displayName: string;
+}
+
+type CandidateResolution = ResolvedCandidate | { kind: 'sentinel'; entry: SentinelEntry };
+
+/**
+ * Aliases for "mention everyone" that may appear as plain text instead
+ * of the canonical `<at user_id="all">` tag. Match is case-insensitive.
+ */
+const ALL_ALIASES = new Set(['all', 'everyone', '所有人']);
+
+function resolveCandidate(name: string, ctx: NormalizeContext): CandidateResolution {
+  // Literal @-everyone aliases map to the canonical Feishu @all tag,
+  // bypassing the per-account name cache. The display name "Everyone"
+  // matches what the tag-level normalizer fills in for empty <at> bodies.
+  if (ALL_ALIASES.has(name.toLowerCase())) {
+    return { kind: 'resolved', openId: 'all', displayName: 'Everyone' };
+  }
+
+  const cache = getUserNameCache(ctx.account.accountId);
+  const matches = cache.lookupByName(name);
+  if (matches.length === 1) {
+    return { kind: 'resolved', openId: matches[0].openId, displayName: matches[0].name };
+  }
+  if (matches.length > 1) {
+    return {
+      kind: 'sentinel',
+      entry: {
+        name,
+        reason: 'ambiguous',
+        candidates: matches.map((m) => ({ openId: m.openId, kind: m.kind })),
+      },
+    };
+  }
+  return { kind: 'sentinel', entry: { name, reason: 'not_found' } };
+}

--- a/src/messaging/outbound/outbound.ts
+++ b/src/messaging/outbound/outbound.ts
@@ -13,12 +13,12 @@
 
 import type { ClawdbotConfig } from 'openclaw/plugin-sdk';
 import type { ChannelOutboundAdapter } from 'openclaw/plugin-sdk/channel-send-result';
-import type { FeishuSendResult } from '../types';
 import { LarkClient } from '../../core/lark-client';
 import { larkLogger } from '../../core/lark-logger';
 import { parseFeishuRouteTarget } from '../../core/targets';
 import { isCommentTarget } from '../../core/comment-target';
 import { isSyntheticTarget } from '../../core/synthetic-target';
+import type { FeishuSendResult } from '../types';
 import { sendCardLark, sendCommentReplyLark, sendMediaLark, sendTextLark } from './deliver';
 
 const log = larkLogger('outbound/outbound');
@@ -117,6 +117,7 @@ interface FeishuSendContext {
   to: string;
   replyToMessageId?: string;
   replyInThread: boolean;
+  threadId?: string;
   accountId?: string;
 }
 
@@ -149,6 +150,7 @@ function resolveFeishuSendContext(params: {
     to: routeTarget.target,
     replyToMessageId,
     replyInThread,
+    threadId: explicitThreadId,
     accountId: params.accountId ?? undefined,
   };
 }
@@ -212,13 +214,20 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     const ctx = resolveFeishuSendContext({ cfg, to, accountId, replyToId, threadId });
 
     // Feishu media messages do not support inline captions — send text first.
+    // Capture the result so the no-mediaUrl path can return it without re-sending.
+    let captionResult: { messageId: string; chatId: string; warning?: string } | undefined;
     if (text?.trim()) {
-      await sendTextLark({ ...ctx, to: ctx.to, text });
+      captionResult = await sendTextLark({ ...ctx, to: ctx.to, text });
     }
 
-    // No mediaUrl — text-only fallback.
+    // No mediaUrl — text-only flow.
     if (!mediaUrl) {
       log.info('sendMedia: no mediaUrl provided, falling back to text-only');
+      if (captionResult) {
+        // Caption was already sent above; return that result.
+        return { channel: 'feishu', ...captionResult };
+      }
+      // No caption text — send empty/raw text to satisfy the contract.
       const result = await sendTextLark({ ...ctx, to: ctx.to, text: text ?? '' });
       return { channel: 'feishu', ...result };
     }

--- a/src/messaging/outbound/send.ts
+++ b/src/messaging/outbound/send.ts
@@ -7,12 +7,57 @@
 
 import type { ClawdbotConfig } from 'openclaw/plugin-sdk';
 import type { FeishuSendResult, MentionInfo  } from '../types';
-import { createAccountScopedConfig } from '../../core/accounts';
+import { createAccountScopedConfig, getLarkAccount } from '../../core/accounts';
 import { LarkClient } from '../../core/lark-client';
+import { larkLogger } from '../../core/lark-logger';
+import { threadScopedKey } from '../../channel/chat-queue';
 import { normalizeFeishuTarget, normalizeMessageId, resolveReceiveIdType } from '../../core/targets';
 import { runWithMessageUnavailableGuard } from '../../core/message-unavailable';
 import { optimizeMarkdownStyle } from '../../card/markdown-style';
 import { buildMentionedCardContent, buildMentionedMessage } from '../inbound/mention';
+import { getSentinelStore } from '../inbound/sentinel-store';
+import { type NormalizeContext, type SentinelEntry, normalizeOutboundMentions } from './normalize-mentions';
+
+const sendLog = larkLogger('outbound/send');
+
+/**
+ * Runs the outbound text through mention normalization. Returns the
+ * input unchanged on any failure so a parser bug never blocks send.
+ * Sentinels collected during normalization are returned for the caller
+ * to record after a successful send.
+ */
+async function normalizeFeishuOutboundText(
+  cfg: ClawdbotConfig,
+  to: string,
+  text: string,
+  accountId?: string,
+): Promise<{ text: string; sentinels: SentinelEntry[]; resolvedAccountId: string | undefined }> {
+  if (!text?.trim()) return { text, sentinels: [], resolvedAccountId: accountId };
+  try {
+    const account = getLarkAccount(cfg, accountId ?? undefined);
+    const ctx: NormalizeContext = {
+      chatId: to,
+      account,
+      log: (...args) => sendLog.warn(args.map(String).join(' ')),
+    };
+    const r = await normalizeOutboundMentions(text, ctx);
+    return { text: r.normalizedText, sentinels: r.sentinels, resolvedAccountId: account.accountId };
+  } catch (err) {
+    sendLog.warn(`normalizeOutboundMentions failed, using raw text: ${String(err)}`);
+    return { text, sentinels: [], resolvedAccountId: accountId };
+  }
+}
+
+function recordFeishuSendSentinels(
+  resolvedAccountId: string | undefined,
+  to: string,
+  threadId: string | undefined,
+  sentinels: SentinelEntry[],
+): void {
+  if (!resolvedAccountId || sentinels.length === 0) return;
+  const threadKey = threadScopedKey(to, threadId);
+  getSentinelStore(resolvedAccountId).recordSentinels(threadKey, sentinels);
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -35,6 +80,8 @@ export interface SendFeishuMessageParams {
   accountId?: string;
   /** When true, the reply appears in the thread instead of main chat. */
   replyInThread?: boolean;
+  /** Thread root id when the reply lives inside a thread; used for sentinel keying. */
+  threadId?: string;
   /**
    * Optional multi-locale texts for i18n post messages.
    * When provided, builds a multi-locale post structure (e.g. { zh_cn: ..., en_us: ... })
@@ -107,7 +154,20 @@ function convertMarkdownTablesForFeishu(cfg: ClawdbotConfig, text: string, accou
  * @returns The send result containing the new message ID.
  */
 export async function sendMessageFeishu(params: SendFeishuMessageParams): Promise<FeishuSendResult> {
-  const { cfg, to, text, replyToMessageId, mentions, accountId, replyInThread, i18nTexts } = params;
+  const { cfg, to, replyToMessageId, mentions, accountId, replyInThread, i18nTexts, threadId } = params;
+  let { text } = params;
+
+  // Mention normalization. Single-locale path rewrites `text`; the
+  // i18nTexts path rewrites each locale below. Sentinels are recorded
+  // after the send succeeds.
+  let normalizationSentinels: SentinelEntry[] = [];
+  let normalizationAccountId: string | undefined = accountId ?? undefined;
+  if (!i18nTexts && text?.trim()) {
+    const r = await normalizeFeishuOutboundText(cfg, to, text, accountId ?? undefined);
+    text = r.text;
+    normalizationSentinels = r.sentinels;
+    normalizationAccountId = r.resolvedAccountId;
+  }
 
   const client = LarkClient.fromCfg(cfg, accountId).sdk;
 
@@ -178,6 +238,7 @@ export async function sendMessageFeishu(params: SendFeishuMessageParams): Promis
         }),
     });
 
+    recordFeishuSendSentinels(normalizationAccountId, to, threadId, normalizationSentinels);
     return {
       messageId: response?.data?.message_id ?? '',
       chatId: response?.data?.chat_id ?? '',
@@ -204,6 +265,7 @@ export async function sendMessageFeishu(params: SendFeishuMessageParams): Promis
     },
   });
 
+  recordFeishuSendSentinels(normalizationAccountId, to, threadId, normalizationSentinels);
   return {
     messageId: response?.data?.message_id ?? '',
     chatId: response?.data?.chat_id ?? '',

--- a/src/messaging/types.ts
+++ b/src/messaging/types.ts
@@ -225,7 +225,7 @@ export interface MentionInfo {
   openId: string;
   /** Display name. */
   name: string;
-  /** Whether this mention targets the bot itself. */
+  /** True iff this mention targets the receiving bot itself (openId === botOpenId). */
   isBot: boolean;
 }
 

--- a/tests/mention-annotation-with-sentinels.test.ts
+++ b/tests/mention-annotation-with-sentinels.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { buildMentionAnnotation } from '../src/messaging/inbound/dispatch-builders';
+import type { MessageContext } from '../src/messaging/types';
+import type { SentinelEntry } from '../src/messaging/inbound/sentinel-store';
+
+function makeCtx(overrides: Partial<MessageContext> = {}): MessageContext {
+  return {
+    chatId: 'oc_x',
+    messageId: 'om_x',
+    senderId: 'ou_user1',
+    chatType: 'group',
+    content: 'hi',
+    contentType: 'text',
+    resources: [],
+    mentions: [],
+    mentionAll: false,
+    rawMessage: {} as any,
+    rawSender: {} as any,
+    ...overrides,
+  };
+}
+
+describe('buildMentionAnnotation with sentinels', () => {
+  it('returns undefined when no mentions and no sentinels', () => {
+    expect(buildMentionAnnotation(makeCtx())).toBeUndefined();
+    expect(buildMentionAnnotation(makeCtx(), [])).toBeUndefined();
+  });
+
+  it('returns annotation with mentions only (PR #477 behavior preserved)', () => {
+    const ctx = makeCtx({
+      mentions: [{ key: '@_1', openId: 'ou_a', name: 'Alice', isBot: false }],
+    });
+    const out = buildMentionAnnotation(ctx);
+    expect(out).toContain('Alice');
+    expect(out).toContain('open_id: ou_a');
+    expect(out).not.toContain('Previous reply');
+  });
+
+  it('appends sentinel feedback for not_found', () => {
+    const sentinels: SentinelEntry[] = [{ name: 'Charlie', reason: 'not_found' }];
+    const out = buildMentionAnnotation(makeCtx(), sentinels);
+    expect(out).toContain('Previous reply had unresolved mentions');
+    expect(out).toContain('"@Charlie"');
+    expect(out).toContain('not recognized');
+  });
+
+  it('appends sentinel feedback for ambiguous with candidates', () => {
+    const sentinels: SentinelEntry[] = [
+      { name: 'Zhang', reason: 'ambiguous', candidates: [{ openId: 'ou_a' }, { openId: 'ou_b' }] },
+    ];
+    const out = buildMentionAnnotation(makeCtx(), sentinels);
+    expect(out).toContain('"@Zhang"');
+    expect(out).toContain('matched multiple');
+    expect(out).toContain('ou_a');
+    expect(out).toContain('ou_b');
+  });
+
+  it('combines mentions and sentinels in same annotation', () => {
+    const ctx = makeCtx({
+      mentions: [{ key: '@_1', openId: 'ou_a', name: 'Alice', isBot: false }],
+    });
+    const sentinels: SentinelEntry[] = [{ name: 'Charlie', reason: 'not_found' }];
+    const out = buildMentionAnnotation(ctx, sentinels);
+    expect(out).toContain('Alice');
+    expect(out).toContain('Charlie');
+  });
+});

--- a/tests/outbound-mentions-disambiguation.test.ts
+++ b/tests/outbound-mentions-disambiguation.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LarkAccount } from '../src/core/types';
+import { LarkClient } from '../src/core/lark-client';
+import {
+  clearUserNameCache,
+  getUserNameCache,
+} from '../src/messaging/inbound/user-name-cache';
+import { normalizeOutboundMentions } from '../src/messaging/outbound/normalize-mentions';
+
+const fakeAccount: LarkAccount = {
+  accountId: 'acct_t13',
+  appId: 'cli',
+  configured: true,
+  config: {},
+} as unknown as LarkAccount;
+
+describe('cache unique hit', () => {
+  beforeEach(() => clearUserNameCache());
+  afterEach(() => vi.restoreAllMocks());
+
+  it('uses cache openId when single match', async () => {
+    // Cache pre-seeded as if by inbound mention enrichment.
+    getUserNameCache('acct_t13').setWithKind('ou_alice', 'Alice', 'user');
+
+    const result = await normalizeOutboundMentions(`Hi @Alice`, {
+      chatId: 'oc_x',
+      account: fakeAccount,
+    });
+
+    expect(result.normalizedText).toBe(`Hi <at user_id="ou_alice">Alice</at>`);
+    expect(result.sentinels).toEqual([]);
+  });
+});
+
+describe('ambiguous match emits sentinel', () => {
+  beforeEach(() => clearUserNameCache());
+
+  it('emits ambiguous sentinel when cache returns multiple candidates', async () => {
+    const cache = getUserNameCache('acct_t13');
+    cache.setWithKind('ou_a', 'Zhang', 'user');
+    cache.setWithKind('ou_b', 'Zhang', 'user');
+
+    const result = await normalizeOutboundMentions(`Hi @Zhang`, {
+      chatId: 'oc_x',
+      account: fakeAccount,
+    });
+
+    expect(result.normalizedText).toBe(`Hi @Zhang`); // original text preserved
+    expect(result.sentinels).toHaveLength(1);
+    expect(result.sentinels[0].reason).toBe('ambiguous');
+    expect(result.sentinels[0].candidates).toHaveLength(2);
+  });
+});
+
+describe('cache miss → lazy chat-member fetch', () => {
+  beforeEach(() => clearUserNameCache());
+  afterEach(() => vi.restoreAllMocks());
+
+  it('triggers prefetchChatBots on miss and resolves', async () => {
+    vi.spyOn(LarkClient, 'fromAccount').mockReturnValue({
+      sdk: {
+        request: vi.fn().mockResolvedValue({
+          data: { items: [{ open_id: 'ou_bot_c', name: 'BotC' }] },
+        }),
+      } as any,
+    } as any);
+
+    const result = await normalizeOutboundMentions(`Hi @BotC`, {
+      chatId: 'oc_x',
+      account: fakeAccount,
+    });
+
+    expect(result.normalizedText).toBe(`Hi <at user_id="ou_bot_c">BotC</at>`);
+  });
+
+  it('falls back to prefetchChatMembers when chat-bots is empty', async () => {
+    let calls = 0;
+    vi.spyOn(LarkClient, 'fromAccount').mockReturnValue({
+      sdk: {
+        request: vi.fn().mockImplementation(({ url }: any) => {
+          calls += 1;
+          if (url.includes('/members/bots')) {
+            return { data: { items: [] } };
+          }
+          // /members
+          return { data: { items: [{ open_id: 'ou_user_c', name: 'CharlieUser', member_type: 'user' }] } };
+        }),
+      } as any,
+    } as any);
+
+    const result = await normalizeOutboundMentions(`Hi @CharlieUser`, {
+      chatId: 'oc_x',
+      account: fakeAccount,
+    });
+
+    expect(calls).toBe(2);
+    expect(result.normalizedText).toBe(`Hi <at user_id="ou_user_c">CharlieUser</at>`);
+  });
+
+  it('drops candidate (no sentinel) when both lazy fetches return empty', async () => {
+    // Cache miss + chat-bots miss + chat-members miss → drop. Emitting a
+    // not_found sentinel here would mislead next-turn disambiguation
+    // because the regex matches CJK runs after `@` that are usually not
+    // real mentions (pronouns, short noun phrases).
+    vi.spyOn(LarkClient, 'fromAccount').mockReturnValue({
+      sdk: {
+        request: vi.fn().mockResolvedValue({ data: { items: [] } }),
+      } as any,
+    } as any);
+
+    const result = await normalizeOutboundMentions(`Hi @PhantomUser`, {
+      chatId: 'oc_x',
+      account: fakeAccount,
+    });
+
+    expect(result.normalizedText).toBe(`Hi @PhantomUser`);
+    expect(result.sentinels).toEqual([]);
+  });
+});
+
+describe('rename scenario', () => {
+  beforeEach(() => clearUserNameCache());
+
+  it('after rename old name is not resolvable', async () => {
+    const cache = getUserNameCache('acct_t13');
+    cache.setWithKind('ou_a', 'OldName', 'user');
+    cache.setWithKind('ou_a', 'NewName', 'user'); // rename
+
+    const result = await normalizeOutboundMentions(`Hi @OldName`, {
+      chatId: 'oc_x',
+      account: fakeAccount,
+    });
+
+    // OldName must no longer resolve; a full cache + lazy-fetch miss emits no sentinel.
+    expect(result.normalizedText).toBe(`Hi @OldName`);
+    expect(result.sentinels).toEqual([]);
+
+    const result2 = await normalizeOutboundMentions(`Hi @NewName`, {
+      chatId: 'oc_x',
+      account: fakeAccount,
+    });
+    expect(result2.normalizedText).toBe(`Hi <at user_id="ou_a">NewName</at>`);
+  });
+});

--- a/tests/outbound-mentions-variants.test.ts
+++ b/tests/outbound-mentions-variants.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { normalizeOutboundMentions } from '../src/messaging/outbound/normalize-mentions';
+import { normalizeOutboundMentionsTagPass } from '../src/messaging/outbound/normalize-mentions';
+import type { LarkAccount } from '../src/core/types';
+import { clearUserNameCache, getUserNameCache } from '../src/messaging/inbound/user-name-cache';
+
+describe('tag-level normalization', () => {
+  it('passes through standard <at user_id="ou_xxx">Name</at>', () => {
+    const t = '<at user_id="ou_abc">Alice</at> hi';
+    expect(normalizeOutboundMentionsTagPass(t)).toBe(t);
+  });
+
+  it('normalizes single-quoted user_id', () => {
+    expect(
+      normalizeOutboundMentionsTagPass(`<at user_id='ou_abc'>Alice</at>`),
+    ).toBe(`<at user_id="ou_abc">Alice</at>`);
+  });
+
+  it('normalizes unquoted user_id', () => {
+    expect(normalizeOutboundMentionsTagPass(`<at user_id=ou_abc>Alice</at>`)).toBe(
+      `<at user_id="ou_abc">Alice</at>`,
+    );
+  });
+
+  it('normalizes id= attribute (card syntax leaked to post)', () => {
+    expect(normalizeOutboundMentionsTagPass(`<at id="ou_abc">Alice</at>`)).toBe(
+      `<at user_id="ou_abc">Alice</at>`,
+    );
+    expect(normalizeOutboundMentionsTagPass(`<at id=ou_abc></at>`)).toBe(
+      `<at user_id="ou_abc"></at>`,
+    );
+  });
+
+  it('normalizes open_id= attribute', () => {
+    expect(normalizeOutboundMentionsTagPass(`<at open_id="ou_abc">Alice</at>`)).toBe(
+      `<at user_id="ou_abc">Alice</at>`,
+    );
+  });
+
+  it('normalizes <at id=all> and <at user_id="all">', () => {
+    expect(normalizeOutboundMentionsTagPass(`<at id=all></at>`)).toBe(
+      `<at user_id="all">Everyone</at>`,
+    );
+    expect(normalizeOutboundMentionsTagPass(`<at user_id="all"></at>`)).toBe(
+      `<at user_id="all">Everyone</at>`,
+    );
+  });
+
+  it('@all is idempotent: canonical input unchanged on second pass', () => {
+    const canonical = `<at user_id="all">Everyone</at>`;
+    expect(normalizeOutboundMentionsTagPass(canonical)).toBe(canonical);
+    expect(normalizeOutboundMentionsTagPass(normalizeOutboundMentionsTagPass(canonical))).toBe(canonical);
+  });
+
+  it('preserves <person id="ou_xxx"> as-is (legitimate Feishu picker tag)', () => {
+    const t = `<person id='ou_abc'></person>`;
+    expect(normalizeOutboundMentionsTagPass(t)).toBe(t);
+  });
+});
+
+const fakeAccount = { accountId: 'acct_t12', appId: 'cli', configured: true, config: {} } as unknown as LarkAccount;
+
+describe('multi-wrap cleanup', () => {
+  beforeEach(() => clearUserNameCache());
+  afterEach(() => vi.restoreAllMocks());
+
+  it('strips @ prefix from already-wrapped <at>', async () => {
+    const result = await normalizeOutboundMentions(
+      `hi @<at user_id="ou_abc">Alice</at> there`,
+      { chatId: 'oc_x', account: fakeAccount },
+    );
+    expect(result.normalizedText).toBe(`hi <at user_id="ou_abc">Alice</at> there`);
+  });
+});
+
+describe('plain @all aliases', () => {
+  beforeEach(() => clearUserNameCache());
+
+  it('rewrites plain "@所有人" to <at user_id="all">Everyone</at>', async () => {
+    const result = await normalizeOutboundMentions(`@所有人 测试`, {
+      chatId: 'oc_x',
+      account: fakeAccount,
+    });
+    expect(result.normalizedText).toBe(`<at user_id="all">Everyone</at> 测试`);
+    expect(result.sentinels).toEqual([]);
+  });
+
+  it('rewrites plain "@everyone" (case-insensitive) to canonical @all', async () => {
+    const result = await normalizeOutboundMentions(`Hi @Everyone, ready?`, {
+      chatId: 'oc_x',
+      account: fakeAccount,
+    });
+    expect(result.normalizedText).toBe(`Hi <at user_id="all">Everyone</at>, ready?`);
+  });
+
+  it('rewrites plain "@all" to canonical @all', async () => {
+    const result = await normalizeOutboundMentions(`@all heads up`, {
+      chatId: 'oc_x',
+      account: fakeAccount,
+    });
+    expect(result.normalizedText).toBe(`<at user_id="all">Everyone</at> heads up`);
+  });
+
+  it('"@allusers" / "@Allen" remain plain (alias check is exact)', async () => {
+    const r1 = await normalizeOutboundMentions(`@allusers ping`, {
+      chatId: 'oc_x',
+      account: fakeAccount,
+    });
+    expect(r1.normalizedText).toBe(`@allusers ping`);
+
+    const r2 = await normalizeOutboundMentions(`hi @Allen`, {
+      chatId: 'oc_x',
+      account: fakeAccount,
+    });
+    expect(r2.normalizedText).toBe(`hi @Allen`);
+  });
+});
+
+describe('plain @Name masking', () => {
+  beforeEach(() => clearUserNameCache());
+
+  it('skips @ in fenced code blocks', async () => {
+    const t = '```\n@Name\n```';
+    const result = await normalizeOutboundMentions(t, { chatId: 'oc_x', account: fakeAccount });
+    expect(result.normalizedText).toBe(t);
+    expect(result.sentinels).toEqual([]);
+  });
+
+  it('skips email-like @', async () => {
+    const t = 'Email me at alice@example.com please';
+    const result = await normalizeOutboundMentions(t, { chatId: 'oc_x', account: fakeAccount });
+    expect(result.normalizedText).toBe(t);
+    expect(result.sentinels).toEqual([]);
+  });
+
+  it('skips @ inside URLs (handle in path / query)', async () => {
+    const cases = [
+      'see https://twitter.com/@elonmusk for news',
+      'docs at https://github.com/@user/repo',
+      'click [link](https://twitter.com/@user) here',
+      'support: mailto://team@company.com',
+    ];
+    for (const t of cases) {
+      const result = await normalizeOutboundMentions(t, { chatId: 'oc_x', account: fakeAccount });
+      expect(result.normalizedText, `case: ${t}`).toBe(t);
+      expect(result.sentinels, `case: ${t}`).toEqual([]);
+    }
+  });
+
+  it('idempotent: running twice gives same output', async () => {
+    getUserNameCache('acct_t12').setWithKind('ou_a', 'Alice', 'user');
+    const t = `<at user_id="ou_a">Alice</at> @Bob`;
+    const r1 = await normalizeOutboundMentions(t, { chatId: 'oc_x', account: fakeAccount });
+    const r2 = await normalizeOutboundMentions(r1.normalizedText, { chatId: 'oc_x', account: fakeAccount });
+    expect(r2.normalizedText).toBe(r1.normalizedText);
+  });
+});

--- a/tests/sentinel-store.test.ts
+++ b/tests/sentinel-store.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  clearAllSentinelStores,
+  getSentinelStore,
+  type SentinelEntry,
+} from '../src/messaging/inbound/sentinel-store';
+
+describe('SentinelStore', () => {
+  beforeEach(() => clearAllSentinelStores());
+  afterEach(() => clearAllSentinelStores());
+
+  it('record then consume returns entries; second consume returns empty', () => {
+    const store = getSentinelStore('acct1');
+    const e: SentinelEntry = { name: 'Alice', reason: 'not_found' };
+    store.recordSentinels('thread1', [e]);
+
+    expect(store.consumeSentinels('thread1')).toEqual([e]);
+    expect(store.consumeSentinels('thread1')).toEqual([]);
+  });
+
+  it('multiple records on same thread accumulate (de-dup by name)', () => {
+    const store = getSentinelStore('acct1');
+    store.recordSentinels('thread1', [{ name: 'Alice', reason: 'not_found' }]);
+    store.recordSentinels('thread1', [
+      { name: 'Bob', reason: 'not_found' },
+      { name: 'Alice', reason: 'not_found' }, // duplicate, should de-dup
+    ]);
+    const out = store.consumeSentinels('thread1');
+    expect(out.map((s) => s.name).sort()).toEqual(['Alice', 'Bob']);
+  });
+
+  it('TTL expiry returns empty on consume', async () => {
+    const store = getSentinelStore('acct1', /*maxThreads*/ 200, /*ttlMs*/ 1);
+    store.recordSentinels('thread1', [{ name: 'X', reason: 'not_found' }]);
+    await new Promise((res) => setTimeout(res, 5));
+    expect(store.consumeSentinels('thread1')).toEqual([]);
+  });
+
+  it('different threads are isolated', () => {
+    const store = getSentinelStore('acct1');
+    store.recordSentinels('threadA', [{ name: 'A', reason: 'not_found' }]);
+    store.recordSentinels('threadB', [{ name: 'B', reason: 'not_found' }]);
+    expect(store.consumeSentinels('threadA').map((s) => s.name)).toEqual(['A']);
+    expect(store.consumeSentinels('threadB').map((s) => s.name)).toEqual(['B']);
+  });
+
+  it('LRU eviction beyond maxThreads', () => {
+    const store = getSentinelStore('acct1', /*maxThreads*/ 3);
+    store.recordSentinels('t1', [{ name: 'A', reason: 'not_found' }]);
+    store.recordSentinels('t2', [{ name: 'B', reason: 'not_found' }]);
+    store.recordSentinels('t3', [{ name: 'C', reason: 'not_found' }]);
+    store.recordSentinels('t4', [{ name: 'D', reason: 'not_found' }]); // triggers evict
+    expect(store.consumeSentinels('t1')).toEqual([]); // t1 evicted
+    expect(store.consumeSentinels('t4').map((s) => s.name)).toEqual(['D']);
+  });
+
+  it('different accounts are isolated', () => {
+    getSentinelStore('acct1').recordSentinels('thread1', [{ name: 'X', reason: 'not_found' }]);
+    expect(getSentinelStore('acct2').consumeSentinels('thread1')).toEqual([]);
+  });
+});

--- a/tests/user-name-cache-invariants.test.ts
+++ b/tests/user-name-cache-invariants.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest';
+import { UserNameCache } from '../src/messaging/inbound/user-name-cache-store';
+
+describe('UserNameCache: kind annotation', () => {
+  it('setWithKind stores kind alongside name', () => {
+    const cache = new UserNameCache();
+    cache.setWithKind('ou_a', 'Alice', 'user');
+    cache.setWithKind('ou_b', 'BotB', 'bot');
+
+    // existing get(openId) still returns the name string
+    expect(cache.get('ou_a')).toBe('Alice');
+    expect(cache.get('ou_b')).toBe('BotB');
+
+    // new lookupByName exposes the principal kind
+    expect(cache.lookupByName('Alice')).toEqual([{ openId: 'ou_a', name: 'Alice', kind: 'user' }]);
+    expect(cache.lookupByName('BotB')).toEqual([{ openId: 'ou_b', name: 'BotB', kind: 'bot' }]);
+  });
+
+  it('set without kind keeps kind undefined', () => {
+    const cache = new UserNameCache();
+    cache.set('ou_x', 'Xeno');
+    const matches = cache.lookupByName('Xeno');
+    expect(matches).toEqual([{ openId: 'ou_x', name: 'Xeno', kind: undefined }]);
+  });
+});
+
+describe('UserNameCache: reverse-index invariants', () => {
+  it('rename: rewriting an openId with a different name removes the old reverse bucket', () => {
+    const cache = new UserNameCache();
+    cache.setWithKind('ou_a', 'Alice', 'user');
+    cache.setWithKind('ou_a', 'AliceRenamed', 'user');
+
+    expect(cache.lookupByName('Alice')).toEqual([]);
+    expect(cache.lookupByName('AliceRenamed')).toEqual([
+      { openId: 'ou_a', name: 'AliceRenamed', kind: 'user' },
+    ]);
+  });
+
+  it('two openIds sharing same name: both appear in reverse bucket; deleting one preserves the other', () => {
+    const cache = new UserNameCache();
+    cache.setWithKind('ou_a', 'Zhang', 'user');
+    cache.setWithKind('ou_b', 'Zhang', 'user');
+
+    const both = cache.lookupByName('Zhang');
+    expect(both).toHaveLength(2);
+    expect(both.map((m) => m.openId).sort()).toEqual(['ou_a', 'ou_b']);
+
+    // overwrite ou_a with a different name; ou_b should remain
+    cache.setWithKind('ou_a', 'OtherName', 'user');
+
+    expect(cache.lookupByName('Zhang')).toEqual([
+      { openId: 'ou_b', name: 'Zhang', kind: 'user' },
+    ]);
+  });
+
+  it('LRU eviction also removes the entry from the reverse index', () => {
+    const cache = new UserNameCache(/*maxSize*/ 2);
+    cache.setWithKind('ou_a', 'Alice', 'user');
+    cache.setWithKind('ou_b', 'Bob', 'user');
+    cache.setWithKind('ou_c', 'Charlie', 'user'); // triggers evict of ou_a
+
+    expect(cache.get('ou_a')).toBeUndefined();
+    expect(cache.lookupByName('Alice')).toEqual([]); // critical: reverse index cleaned
+    expect(cache.lookupByName('Bob')).toEqual([
+      { openId: 'ou_b', name: 'Bob', kind: 'user' },
+    ]);
+    expect(cache.lookupByName('Charlie')).toEqual([
+      { openId: 'ou_c', name: 'Charlie', kind: 'user' },
+    ]);
+  });
+});
+
+describe('UserNameCache: chat members snapshots', () => {
+  it('recordChatBots writes chatBots entry and seeds nameByOpenId with kind=bot', () => {
+    const cache = new UserNameCache();
+    cache.recordChatBots('oc_chat1', [
+      { openId: 'ou_bot1', name: 'BotOne' },
+      { openId: 'ou_bot2', name: 'BotTwo' },
+    ]);
+
+    const entry = cache.getChatBots('oc_chat1');
+    expect(entry).not.toBeNull();
+    expect(entry!.members).toHaveLength(2);
+
+    // bots also seeded into name forward + reverse with kind='bot'
+    expect(cache.get('ou_bot1')).toBe('BotOne');
+    expect(cache.lookupByName('BotOne')).toEqual([{ openId: 'ou_bot1', name: 'BotOne', kind: 'bot' }]);
+  });
+
+  it('recordChatMembers writes chatMembers entry with mixed kind', () => {
+    const cache = new UserNameCache();
+    cache.recordChatMembers('oc_chat2', [
+      { openId: 'ou_u1', name: 'Alice', kind: 'user' },
+      { openId: 'ou_b1', name: 'Robo', kind: 'bot' },
+    ]);
+
+    const entry = cache.getChatMembers('oc_chat2');
+    expect(entry!.members).toHaveLength(2);
+    expect(cache.lookupByName('Alice')).toEqual([{ openId: 'ou_u1', name: 'Alice', kind: 'user' }]);
+    expect(cache.lookupByName('Robo')).toEqual([{ openId: 'ou_b1', name: 'Robo', kind: 'bot' }]);
+  });
+
+  it('getChatBots returns null after TTL', () => {
+    const cache = new UserNameCache(500, 1); // 1 ms TTL
+    cache.recordChatBots('oc_chat3', [{ openId: 'ou_x', name: 'X' }]);
+
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(cache.getChatBots('oc_chat3')).toBeNull();
+        resolve();
+      }, 10);
+    });
+  });
+
+  it('clear wipes chatBots and chatMembers too', () => {
+    const cache = new UserNameCache();
+    cache.recordChatBots('oc_a', [{ openId: 'ou_a', name: 'A' }]);
+    cache.recordChatMembers('oc_b', [{ openId: 'ou_b', name: 'B', kind: 'user' }]);
+
+    cache.clear();
+
+    expect(cache.getChatBots('oc_a')).toBeNull();
+    expect(cache.getChatMembers('oc_b')).toBeNull();
+    expect(cache.get('ou_a')).toBeUndefined();
+    expect(cache.get('ou_b')).toBeUndefined();
+  });
+});
+
+describe('UserNameCache: in-flight dedup', () => {
+  it('set/get/clear preserve promise identity per key, with key isolation', () => {
+    const cache = new UserNameCache();
+    const p1 = Promise.resolve();
+    const p2 = Promise.resolve();
+
+    cache.setInflight('bots:oc_a', p1);
+    cache.setInflight('members:oc_a', p2);
+    expect(cache.getInflight('bots:oc_a')).toBe(p1);
+    expect(cache.getInflight('members:oc_a')).toBe(p2);
+
+    cache.clearInflight('bots:oc_a');
+    expect(cache.getInflight('bots:oc_a')).toBeUndefined();
+    expect(cache.getInflight('members:oc_a')).toBe(p2); // sibling untouched
+  });
+});
+
+describe('UserNameCache: chat-members LRU and rewrite', () => {
+  it('evictChats removes oldest chat when maxChats is exceeded', () => {
+    const cache = new UserNameCache(/*maxSize*/ 500, /*ttlMs*/ 30 * 60 * 1000, /*maxChats*/ 2);
+    cache.recordChatBots('oc_a', [{ openId: 'ou_a', name: 'A' }]);
+    cache.recordChatBots('oc_b', [{ openId: 'ou_b', name: 'B' }]);
+    cache.recordChatBots('oc_c', [{ openId: 'ou_c', name: 'C' }]); // triggers evict of oc_a
+
+    expect(cache.getChatBots('oc_a')).toBeNull();
+    expect(cache.getChatBots('oc_b')).not.toBeNull();
+    expect(cache.getChatBots('oc_c')).not.toBeNull();
+  });
+
+  it('recordChatBots on existing chatId bumps LRU position', () => {
+    const cache = new UserNameCache(500, 30 * 60 * 1000, /*maxChats*/ 2);
+    cache.recordChatBots('oc_a', [{ openId: 'ou_a', name: 'A' }]);
+    cache.recordChatBots('oc_b', [{ openId: 'ou_b', name: 'B' }]);
+
+    // Re-record oc_a — it should move to the tail (newest)
+    cache.recordChatBots('oc_a', [{ openId: 'ou_a', name: 'A' }]);
+
+    cache.recordChatBots('oc_c', [{ openId: 'ou_c', name: 'C' }]); // should evict oc_b (oldest), not oc_a
+
+    expect(cache.getChatBots('oc_a')).not.toBeNull(); // bumped, survived
+    expect(cache.getChatBots('oc_b')).toBeNull();      // oldest, evicted
+    expect(cache.getChatBots('oc_c')).not.toBeNull();
+  });
+});

--- a/tests/user-name-cache-r2-prefetch.test.ts
+++ b/tests/user-name-cache-r2-prefetch.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LarkAccount } from '../src/core/types';
+import { LarkClient } from '../src/core/lark-client';
+import { clearUserNameCache, getUserNameCache } from '../src/messaging/inbound/user-name-cache';
+import { prefetchChatBots } from '../src/messaging/inbound/user-name-cache';
+
+const noopLog = () => {};
+
+function makeAccount(): LarkAccount {
+  return {
+    accountId: 'acct1',
+    appId: 'cli_test',
+    configured: true,
+    config: {},
+  } as unknown as LarkAccount;
+}
+
+describe('prefetchChatBots', () => {
+  beforeEach(() => {
+    clearUserNameCache();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls /open-apis/im/v1/chats/{id}/members/bots and seeds cache', async () => {
+    const account = makeAccount();
+    const requestSpy = vi.fn().mockResolvedValue({
+      data: { items: [{ open_id: 'ou_bot1', name: 'BotOne' }, { open_id: 'ou_bot2', name: 'BotTwo' }] },
+    });
+    vi.spyOn(LarkClient, 'fromAccount').mockReturnValue({
+      sdk: { request: requestSpy } as any,
+    } as any);
+
+    await prefetchChatBots(account, 'oc_chat1', noopLog);
+
+    expect(requestSpy).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/open-apis/im/v1/chats/oc_chat1/members/bots',
+      params: {},
+    });
+
+    const cache = getUserNameCache('acct1');
+    expect(cache.getChatBots('oc_chat1')!.members).toEqual([
+      { openId: 'ou_bot1', name: 'BotOne', kind: 'bot' },
+      { openId: 'ou_bot2', name: 'BotTwo', kind: 'bot' },
+    ]);
+    expect(cache.lookupByName('BotOne')).toEqual([{ openId: 'ou_bot1', name: 'BotOne', kind: 'bot' }]);
+  });
+
+  it('dedups concurrent calls to same chatId', async () => {
+    const account = makeAccount();
+    let resolveRequest: (value: any) => void = () => {};
+    const requestSpy = vi.fn().mockReturnValue(
+      new Promise((res) => {
+        resolveRequest = res;
+      }),
+    );
+    vi.spyOn(LarkClient, 'fromAccount').mockReturnValue({
+      sdk: { request: requestSpy } as any,
+    } as any);
+
+    const p1 = prefetchChatBots(account, 'oc_chat1', noopLog);
+    const p2 = prefetchChatBots(account, 'oc_chat1', noopLog);
+
+    expect(requestSpy).toHaveBeenCalledTimes(1); // second call dedups via in-flight cache
+    resolveRequest({ data: { items: [{ open_id: 'ou_x', name: 'X' }] } });
+    await Promise.all([p1, p2]);
+  });
+
+  it('swallows permission error and writes empty list to avoid retry', async () => {
+    const account = makeAccount();
+    vi.spyOn(LarkClient, 'fromAccount').mockReturnValue({
+      sdk: {
+        request: vi.fn().mockRejectedValue({ response: { data: { code: 99991663, msg: 'forbidden' } } }),
+      } as any,
+    } as any);
+
+    await prefetchChatBots(account, 'oc_chat1', noopLog);
+
+    const cache = getUserNameCache('acct1');
+    expect(cache.getChatBots('oc_chat1')!.members).toEqual([]);
+  });
+
+  it('does not write cache on network error (preserves retry potential)', async () => {
+    const account = makeAccount();
+    vi.spyOn(LarkClient, 'fromAccount').mockReturnValue({
+      sdk: {
+        request: vi.fn().mockRejectedValue(new Error('network down')),
+      } as any,
+    } as any);
+
+    await prefetchChatBots(account, 'oc_chat1', noopLog);
+
+    const cache = getUserNameCache('acct1');
+    expect(cache.getChatBots('oc_chat1')).toBeNull(); // not written on network error
+  });
+
+  it('skips when account.configured is false', async () => {
+    const account = { ...makeAccount(), configured: false } as LarkAccount;
+    const requestSpy = vi.fn();
+    vi.spyOn(LarkClient, 'fromAccount').mockReturnValue({ sdk: { request: requestSpy } as any } as any);
+
+    await prefetchChatBots(account, 'oc_chat1', noopLog);
+
+    expect(requestSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips API call when chatBots cache already fresh', async () => {
+    const account = makeAccount();
+    // Pre-seed a fresh chatBots entry
+    getUserNameCache('acct1').recordChatBots('oc_chat1', [{ openId: 'ou_b', name: 'Bot' }]);
+
+    const requestSpy = vi.fn();
+    vi.spyOn(LarkClient, 'fromAccount').mockReturnValue({ sdk: { request: requestSpy } as any } as any);
+
+    await prefetchChatBots(account, 'oc_chat1', noopLog);
+
+    expect(requestSpy).not.toHaveBeenCalled();
+  });
+});
+
+import { prefetchChatMembers } from '../src/messaging/inbound/user-name-cache';
+import { resolveBotName, resolveUserName } from '../src/messaging/inbound/user-name-cache';
+
+describe('prefetchChatMembers', () => {
+  beforeEach(() => {
+    clearUserNameCache();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls /open-apis/im/v1/chats/{id}/members and seeds cache with kind from member_type', async () => {
+    const account = makeAccount();
+    const requestSpy = vi.fn().mockResolvedValue({
+      data: {
+        items: [
+          { open_id: 'ou_u1', name: 'Alice', member_type: 'user' },
+          { open_id: 'ou_b1', name: 'Robo', member_type: 'app' },
+        ],
+      },
+    });
+    vi.spyOn(LarkClient, 'fromAccount').mockReturnValue({
+      sdk: { request: requestSpy } as any,
+    } as any);
+
+    await prefetchChatMembers(account, 'oc_chat2', noopLog);
+
+    expect(requestSpy).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/open-apis/im/v1/chats/oc_chat2/members',
+      params: { member_id_type: 'open_id', page_size: 100 },
+    });
+
+    const cache = getUserNameCache('acct1');
+    expect(cache.getChatMembers('oc_chat2')!.members).toEqual([
+      { openId: 'ou_u1', name: 'Alice', kind: 'user' },
+      { openId: 'ou_b1', name: 'Robo', kind: 'bot' },
+    ]);
+  });
+
+  it('dedups concurrent calls and swallows permission error', async () => {
+    const account = makeAccount();
+    vi.spyOn(LarkClient, 'fromAccount').mockReturnValue({
+      sdk: {
+        request: vi.fn().mockRejectedValue({ response: { data: { code: 99991663, msg: 'no scope' } } }),
+      } as any,
+    } as any);
+
+    await prefetchChatMembers(account, 'oc_chat3', noopLog);
+
+    const cache = getUserNameCache('acct1');
+    expect(cache.getChatMembers('oc_chat3')!.members).toEqual([]);
+  });
+
+  it('skips API call when chatMembers cache already fresh', async () => {
+    const account = makeAccount();
+    getUserNameCache('acct1').recordChatMembers('oc_chat4', [
+      { openId: 'ou_u', name: 'User', kind: 'user' },
+    ]);
+
+    const requestSpy = vi.fn();
+    vi.spyOn(LarkClient, 'fromAccount').mockReturnValue({ sdk: { request: requestSpy } as any } as any);
+
+    await prefetchChatMembers(account, 'oc_chat4', noopLog);
+
+    expect(requestSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveBotName / resolveUserName: kind tagging', () => {
+  beforeEach(() => clearUserNameCache());
+  afterEach(() => vi.restoreAllMocks());
+
+  it('resolveBotName tags kind=bot on cache write', async () => {
+    const account = makeAccount();
+    vi.spyOn(LarkClient, 'fromAccount').mockReturnValue({
+      sdk: {
+        request: vi.fn().mockResolvedValue({
+          data: { bots: { ou_b: { name: 'BotName' } } },
+        }),
+      } as any,
+    } as any);
+
+    const result = await resolveBotName({ account, openId: 'ou_b', log: noopLog });
+
+    expect(result.name).toBe('BotName');
+    expect(getUserNameCache('acct1').lookupByName('BotName')).toEqual([
+      { openId: 'ou_b', name: 'BotName', kind: 'bot' },
+    ]);
+  });
+
+  it('resolveUserName tags kind=user on cache write', async () => {
+    const account = makeAccount();
+    vi.spyOn(LarkClient, 'fromAccount').mockReturnValue({
+      sdk: {
+        contact: {
+          user: {
+            get: vi.fn().mockResolvedValue({ data: { user: { name: 'UserName' } } }),
+          },
+        },
+      } as any,
+    } as any);
+
+    const result = await resolveUserName({ account, openId: 'ou_u', log: noopLog });
+
+    expect(result.name).toBe('UserName');
+    expect(getUserNameCache('acct1').lookupByName('UserName')).toEqual([
+      { openId: 'ou_u', name: 'UserName', kind: 'user' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Add an outbound mention normalizer that runs at the text-prep layer of both Feishu post-message send paths — the reply-dispatcher path via `sendMessageFeishu` and the channel-adapter path via `sendTextLark` / `prepareTextForLark`. Without it, `@Name` in an outbound reply renders as plain text — Feishu does not auto-detect mentions, only the explicit `<at user_id="ou_xxx">` tag form.
- Canonicalise `<at>` tag attribute and quote variants (`id=`, `open_id=`, unquoted, `id=all`, …) into the canonical `<at user_id="ou_xxx">Name</at>` form. Idempotent.
- Resolve plain `@Name` against a per-account name cache, with lazy fallback to `/chats/{id}/members/bots` and `/chats/{id}/members` on miss. Multi-candidate matches become ambiguous sentinels; remaining misses are dropped silently to avoid false positives on non-mention `@` usage in CJK prose.
- Recognise plain `@all` / `@everyone` / `@所有人` as the canonical Feishu @all tag, bypassing the cache.
- Skip the @-name scan inside code blocks, inline code, canonical `<at>` / `<person>` tags, email addresses, and URLs.
- Per-thread `SentinelStore`: when the previous reply produced an ambiguous mention, append a hint to the existing PR #477 `[System: ...]` mention annotation on the next inbound so the next reply can disambiguate. Sentinel record/consume both key off `threadScopedKey(chatId, threadId)`, so a sentinel produced inside a thread surfaces in the same thread (and only there).
- Drive-by: fix a pre-existing double-send in `feishuOutbound.sendMedia` where the caption was sent twice on the no-`mediaUrl` path.

## Caveat for downstream consumers

Components that read the `[System: ...]` mention annotation now see a new sentence type — `Previous reply had unresolved mentions: "@X" matched multiple users (ou_a / ou_b); use explicit <at user_id="...">` — emitted only when the prior outbound had ambiguous mentions.

## Scope

Post message path only. The card surface (`sendCardFeishu` / `sendMarkdownCardFeishu` / streaming card) is unchanged and out of scope.
