### PR TITLE
fix: pass agentId to resolveStorePath for correct multi-agent session store resolution

### DIFF
--- a/src/card/streaming-card-controller.ts
+++ b/src/card/streaming-card-controller.ts
@@ -141,13 +141,13 @@ export class StreamingCardController {
       const runtime = LarkClient.runtime as {
         agent?: {
           session?: {
-            resolveStorePath?: (storePath?: string) => string;
+            resolveStorePath?: (storePath?: string, opts?: { agentId?: string }) => string;
             loadSessionStore?: (storePath: string) => Record<string, Record<string, unknown>>;
           };
         };
         channel?: {
           session?: {
-            resolveStorePath?: (storePath?: string) => string;
+            resolveStorePath?: (storePath?: string, opts?: { agentId?: string }) => string;
           };
         };
       } | null;
@@ -171,9 +171,14 @@ export class StreamingCardController {
       const fallbackKey = key.replace(/^(agent):[^:]+:/, `$1:${defaultAgentId}:`);
       const candidateKeys = fallbackKey !== key ? [key, fallbackKey] : [key];
 
+      // Extract the agent ID from the session key so resolveStorePath
+      // resolves to the correct per-agent store instead of defaulting to "main".
+      const agentIdFromKey = key.startsWith('agent:') ? key.split(':')[1] : undefined;
+      const storeAgentId = agentIdFromKey ?? defaultAgentId;
+
       const sessionApi = runtime.agent?.session;
       if (sessionApi?.resolveStorePath && sessionApi?.loadSessionStore) {
-        const storePath = sessionApi.resolveStorePath(sessionStorePath);
+        const storePath = sessionApi.resolveStorePath(sessionStorePath, { agentId: storeAgentId });
         const store = sessionApi.loadSessionStore(storePath);
 
         let entry: Record<string, unknown> | undefined;
@@ -221,7 +226,7 @@ export class StreamingCardController {
         return undefined;
       }
 
-      const storePath = channelSession.resolveStorePath(sessionStorePath);
+      const storePath = channelSession.resolveStorePath(sessionStorePath, { agentId: storeAgentId });
       const raw = await readFile(storePath, 'utf8');
       const parsed: unknown = JSON.parse(raw);
       const store =


### PR DESCRIPTION
## Problem

In multi-agent OpenClaw setups, the streaming card footer fails to display session metrics (token counts, model info, etc.) for non-default agents. The footer shows no data because `getFooterSessionMetrics()` resolves all agents to the `main` agent's `sessions.json`.

## Root Cause

`resolveStorePath()` in `streaming-card-controller.ts` is called **without** an `agentId` parameter. The OpenClaw runtime's `resolveStorePath` defaults to `"main"` when no `agentId` is provided. This means:

- For agent `cook`, it tries to read `agent:main:…` entries from `main`'s store
- Cook's own entries are in `agent:cook:…` in cook's store
- Cook finds nothing → footer shows no data

This only manifests in **multi-agent** deployments. Single-agent setups (where the default agent IS `"main"`) work fine because the default matches reality.

The same bug exists for **both** code paths:
1. `sessionApi.resolveStorePath()` (runtime-provided in-memory store)
2. `channelSession.resolveStorePath()` (filesystem fallback store)

## Fix

Three changes in `src/card/streaming-card-controller.ts`:

1. **Extract agentId from session key**: Parse the agent ID from `this.deps.sessionKey` (format: `agent:<id>:…`)
2. **Pass agentId to resolveStorePath**: Both `resolveStorePath()` calls now receive `{ agentId: storeAgentId }` 
3. **Update TypeScript types**: Inline type declarations for `resolveStorePath` now accept the optional `opts` parameter

This pattern is **already used** in `src/card/tool-use-config.ts` line 35:
```ts
const storePath = resolveStorePath(sessionStorePath, { agentId });
```

## Testing

Verified on a production OpenClaw deployment with 10 agents (main, cook, margaret, zhangxiaolong, jobs, jonathan, wangyangming, jiamu, buffett, turing). Before this fix, all agents except `main` showed empty footers. After applying the fix and restarting, all agents correctly display their own session metrics.

## Related

- The same bug was independently identified and a local workaround patch was applied. This PR upstreams the fix.