### PR TITLE
fix: 多 Agent 路由场景下按当前 agent 读取 footer metrics

### DIFF
--- a/src/card/reply-dispatcher-types.ts
+++ b/src/card/reply-dispatcher-types.ts
@@ -168,6 +168,7 @@ export interface FooterSessionMetrics {
 
 export interface StreamingCardDeps {
   cfg: ClawdbotConfig;
+  agentId: string;
   sessionKey: string;
   accountId: string | undefined;
   chatId: string;

--- a/src/card/reply-dispatcher.ts
+++ b/src/card/reply-dispatcher.ts
@@ -92,6 +92,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const controller = useStreamingCards
     ? new StreamingCardController({
         cfg,
+        agentId,
         sessionKey,
         accountId,
         chatId,

--- a/src/card/streaming-card-controller.ts
+++ b/src/card/streaming-card-controller.ts
@@ -141,13 +141,13 @@ export class StreamingCardController {
       const runtime = LarkClient.runtime as {
         agent?: {
           session?: {
-            resolveStorePath?: (storePath?: string) => string;
+            resolveStorePath?: (storePath?: string, opts?: { agentId?: string }) => string;
             loadSessionStore?: (storePath: string) => Record<string, Record<string, unknown>>;
           };
         };
         channel?: {
           session?: {
-            resolveStorePath?: (storePath?: string) => string;
+            resolveStorePath?: (storePath?: string, opts?: { agentId?: string }) => string;
           };
         };
       } | null;
@@ -173,7 +173,7 @@ export class StreamingCardController {
 
       const sessionApi = runtime.agent?.session;
       if (sessionApi?.resolveStorePath && sessionApi?.loadSessionStore) {
-        const storePath = sessionApi.resolveStorePath(sessionStorePath);
+        const storePath = sessionApi.resolveStorePath(sessionStorePath, { agentId: this.deps.agentId });
         const store = sessionApi.loadSessionStore(storePath);
 
         let entry: Record<string, unknown> | undefined;
@@ -221,7 +221,7 @@ export class StreamingCardController {
         return undefined;
       }
 
-      const storePath = channelSession.resolveStorePath(sessionStorePath);
+      const storePath = channelSession.resolveStorePath(sessionStorePath, { agentId: this.deps.agentId });
       const raw = await readFile(storePath, 'utf8');
       const parsed: unknown = JSON.parse(raw);
       const store =


### PR DESCRIPTION
## 背景

修复 #502。

Fixes #502.

在 OpenClaw 多 Agent 路由场景下，飞书/Lark 消息已经能正确路由到非 main agent，例如 `coder`，但 streaming/card footer 里的模型/运行时指标可能不显示。

根因是 footer metrics 查询 session store 时，没有把当前路由到的 `agentId` 传给 `resolveStorePath(...)`，导致它默认去读 main/default agent 的 session store。对于被路由到非 main agent 的会话，模型和 token metrics 实际写在对应 agent 的 store 里，因此 footer lookup 读不到 `metrics.model`，最终 model footer 被跳过。

## 修改内容

本 PR 将当前路由的 `agentId` 传入 `StreamingCardController`，并在 footer metrics 的两条 session store 解析路径里使用它：

- `runtime.agent.session.resolveStorePath(...)`
- `runtime.channel.session.resolveStorePath(...)`

涉及文件：

- `src/card/reply-dispatcher-types.ts`
  - 给 `StreamingCardDeps` 增加 `agentId`
- `src/card/reply-dispatcher.ts`
  - 创建 `StreamingCardController` 时传入当前 `agentId`
- `src/card/streaming-card-controller.ts`
  - 调用 `resolveStorePath(sessionStorePath, { agentId: this.deps.agentId })`

## 验证

本地已验证：

```bash
npx pnpm typecheck
npx pnpm test
npx pnpm build
```

结果：

- TypeScript typecheck 通过
- 测试通过：27 个 test files / 214 个 tests
- build 通过

另外也已把相同修复临时覆盖到本地运行中的 `@larksuite/openclaw-lark` runtime 包进行验证，确认 footer/model 显示功能正常。
