### PR TITLE
Guide Feishu sends during streaming card replies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@larksuiteoapi/node-sdk": "^1.60.0",
-    "@sinclair/typebox": "0.34.48",
+    "@sinclair/typebox": "0.34.49",
     "image-size": "^2.0.2",
     "undici-types": "^8.1.0",
     "zod": "^4.3.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.60.0
         version: 1.60.0
       '@sinclair/typebox':
-        specifier: 0.34.48
-        version: 0.34.48
+        specifier: 0.34.49
+        version: 0.34.49
       image-size:
         specifier: ^2.0.2
         version: 2.0.2
@@ -1301,9 +1301,6 @@ packages:
 
   '@silvia-odwyer/photon-node@0.3.4':
     resolution: {integrity: sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==}
-
-  '@sinclair/typebox@0.34.48':
-    resolution: {integrity: sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==}
 
   '@sinclair/typebox@0.34.49':
     resolution: {integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==}
@@ -5824,7 +5821,7 @@ snapshots:
       '@aws-sdk/client-bedrock-runtime': 3.1024.0
       '@google/genai': 1.49.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))
       '@mistralai/mistralai': 1.14.1
-      '@sinclair/typebox': 0.34.48
+      '@sinclair/typebox': 0.34.49
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       chalk: 5.6.2
@@ -6144,8 +6141,6 @@ snapshots:
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@silvia-odwyer/photon-node@0.3.4': {}
-
-  '@sinclair/typebox@0.34.48': {}
 
   '@sinclair/typebox@0.34.49': {}
 

--- a/src/messaging/outbound/actions.ts
+++ b/src/messaging/outbound/actions.ts
@@ -21,6 +21,7 @@ import type {
 import type { ChannelMessageToolSchemaContribution, ChannelThreadingToolContext } from 'openclaw/plugin-sdk/channel-contract';
 import { extractToolSend } from 'openclaw/plugin-sdk/tool-send';
 import { readStringParam } from 'openclaw/plugin-sdk/param-readers';
+import { Type } from '@sinclair/typebox';
 import { jsonResult, readReactionParams } from '../../core/sdk-compat';
 
 import { LarkClient } from '../../core/lark-client';
@@ -37,11 +38,11 @@ const FEISHU_SEND_TEXT_DESCRIPTION =
 
 const FEISHU_MESSAGE_TOOL_SCHEMA = {
   properties: {
-    message: { type: 'string', description: FEISHU_SEND_TEXT_DESCRIPTION },
-    text: { type: 'string', description: FEISHU_SEND_TEXT_DESCRIPTION },
+    message: Type.Optional(Type.String({ description: FEISHU_SEND_TEXT_DESCRIPTION })),
+    text: Type.Optional(Type.String({ description: FEISHU_SEND_TEXT_DESCRIPTION })),
   },
   visibility: 'current-channel' as const,
-} as unknown as ChannelMessageToolSchemaContribution;
+} satisfies ChannelMessageToolSchemaContribution;
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/messaging/outbound/actions.ts
+++ b/src/messaging/outbound/actions.ts
@@ -18,7 +18,7 @@ import type {
   ChannelMessageActionName,
   OpenClawConfig,
 } from 'openclaw/plugin-sdk';
-import type { ChannelThreadingToolContext } from 'openclaw/plugin-sdk/channel-contract';
+import type { ChannelMessageToolSchemaContribution, ChannelThreadingToolContext } from 'openclaw/plugin-sdk/channel-contract';
 import { extractToolSend } from 'openclaw/plugin-sdk/tool-send';
 import { readStringParam } from 'openclaw/plugin-sdk/param-readers';
 import { jsonResult, readReactionParams } from '../../core/sdk-compat';
@@ -31,6 +31,17 @@ import { sendCardLark, sendTextLark } from './deliver';
 import { uploadAndSendMediaLark } from './media';
 
 const log = larkLogger('outbound/actions');
+
+const FEISHU_SEND_TEXT_DESCRIPTION =
+  'Text to send as a separate Feishu message. During a normal Feishu streaming-card reply, do not call send just to repeat or finalize the same answer; return the final answer normally so the active card can be completed by the reply dispatcher. Use send only when the user explicitly needs an additional separate message.';
+
+const FEISHU_MESSAGE_TOOL_SCHEMA = {
+  properties: {
+    message: { type: 'string', description: FEISHU_SEND_TEXT_DESCRIPTION },
+    text: { type: 'string', description: FEISHU_SEND_TEXT_DESCRIPTION },
+  },
+  visibility: 'current-channel' as const,
+} as unknown as ChannelMessageToolSchemaContribution;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -170,7 +181,7 @@ export const feishuMessageActions: ChannelMessageActionAdapter = {
     return {
       actions: Array.from(SUPPORTED_ACTIONS),
       capabilities: ['cards'],
-      schema: null,
+      schema: FEISHU_MESSAGE_TOOL_SCHEMA,
     };
   },
 

--- a/tests/message-actions-schema.test.ts
+++ b/tests/message-actions-schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { ClawdbotConfig } from 'openclaw/plugin-sdk';
+import { Type } from '@sinclair/typebox';
 import { feishuMessageActions } from '../src/messaging/outbound/actions';
 
 function configuredFeishuConfig(): ClawdbotConfig {
@@ -34,5 +35,25 @@ describe('Feishu message action discovery', () => {
         },
       },
     });
+  });
+
+  it('keeps send text fields optional in the composed TypeBox schema', () => {
+    const discovery = feishuMessageActions.describeMessageTool({
+      cfg: configuredFeishuConfig(),
+      currentChannelProvider: 'feishu',
+    });
+    const schema = discovery?.schema;
+    if (!schema || Array.isArray(schema)) {
+      throw new Error('expected a single Feishu message tool schema contribution');
+    }
+
+    const composedSchema = Type.Object({
+      action: Type.String(),
+      ...schema.properties,
+    });
+
+    expect(composedSchema.required).toContain('action');
+    expect(composedSchema.required ?? []).not.toContain('message');
+    expect(composedSchema.required ?? []).not.toContain('text');
   });
 });

--- a/tests/message-actions-schema.test.ts
+++ b/tests/message-actions-schema.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import type { ClawdbotConfig } from 'openclaw/plugin-sdk';
+import { feishuMessageActions } from '../src/messaging/outbound/actions';
+
+function configuredFeishuConfig(): ClawdbotConfig {
+  return {
+    channels: {
+      feishu: {
+        appId: 'cli_a',
+        appSecret: 'secret',
+      },
+    },
+  } as unknown as ClawdbotConfig;
+}
+
+describe('Feishu message action discovery', () => {
+  it('guides send text away from duplicate streaming-card final replies', () => {
+    const discovery = feishuMessageActions.describeMessageTool({
+      cfg: configuredFeishuConfig(),
+      currentChannelProvider: 'feishu',
+    });
+
+    expect(discovery?.actions).toContain('send');
+    expect(discovery?.schema).toMatchObject({
+      visibility: 'current-channel',
+      properties: {
+        message: {
+          type: 'string',
+          description: expect.stringContaining('do not call send'),
+        },
+        text: {
+          type: 'string',
+          description: expect.stringContaining('active card'),
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add Feishu-owned shared message tool schema guidance for `message` / `text`.
- Tell agents not to call `send` just to repeat or finalize the same answer while a normal Feishu streaming-card reply is active.
- Keep `send` runtime behavior predictable by avoiding module-scope active-card rerouting.

## Context
This supersedes #500. The earlier approach routed `feishu.send` through a process-local active-card map, which made empty-target sends implicit and fragile. This PR moves the fix to the tool-discovery layer instead.

## Validation
- pnpm vitest run tests/message-actions-schema.test.ts
- pnpm exec tsc --noEmit
- git diff --check