### PR TITLE
fix(secrets): register Feishu SecretRef contract for runtime resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "bin/",
     "dist/",
     "skills/",
+    "secret-contract-api.js",
     "openclaw.plugin.json",
     "README.md",
     "LICENSE"
@@ -33,8 +34,8 @@
     "release": "node scripts/release.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "eslint src/ index.ts",
-    "lint:fix": "eslint src/ index.ts --fix",
+    "lint": "eslint src/ index.ts secret-contract-api.ts",
+    "lint:fix": "eslint src/ index.ts secret-contract-api.ts --fix",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write src/**/*.ts",
     "format:check": "prettier --check src/**/*.ts"
@@ -47,7 +48,7 @@
     "zod": "^4.3.6"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.3.22"
+    "openclaw": ">=2026.5.4"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/secret-contract-api.js
+++ b/secret-contract-api.js
@@ -1,0 +1,8 @@
+// Discovery shim: OpenClaw's external contract loader prefers this file at the
+// plugin root over `dist/secret-contract-api.mjs` when scanning for the
+// channel's secret contract. Plain JS so the loader can require/import it
+// without relying on a TypeScript runtime.
+export {
+  collectRuntimeConfigAssignments,
+  secretTargetRegistryEntries,
+} from './dist/secret-contract-api.mjs';

--- a/secret-contract-api.ts
+++ b/secret-contract-api.ts
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Feishu channel secret-contract registration. Declares which fields are
+ * SecretRef-shaped so OpenClaw's runtime resolves them at startup.
+ */
+
+import {
+  collectConditionalChannelFieldAssignments,
+  collectSimpleChannelFieldAssignments,
+  getChannelSurface,
+  hasOwnProperty,
+  normalizeSecretStringValue,
+} from 'openclaw/plugin-sdk/channel-secret-basic-runtime';
+import type {
+  ResolverContext,
+  SecretDefaults,
+  SecretTargetRegistryEntry,
+} from 'openclaw/plugin-sdk/channel-secret-basic-runtime';
+import type { OpenClawConfig } from 'openclaw/plugin-sdk';
+
+const SECRET_FIELDS = ['appSecret', 'encryptKey', 'verificationToken'] as const;
+
+/** Fields the Lark SDK only consumes when an account is in webhook mode. */
+const WEBHOOK_ONLY_FIELDS = ['encryptKey', 'verificationToken'] as const;
+
+export const secretTargetRegistryEntries: readonly SecretTargetRegistryEntry[] = SECRET_FIELDS.flatMap(
+  (field) => {
+    const acctPath = `channels.feishu.accounts.*.${field}`;
+    const topPath = `channels.feishu.${field}`;
+    return [
+      {
+        id: acctPath,
+        targetType: acctPath,
+        configFile: 'openclaw.json',
+        pathPattern: acctPath,
+        secretShape: 'secret_input',
+        expectedResolvedValue: 'string',
+        includeInPlan: true,
+        includeInConfigure: true,
+        includeInAudit: true,
+      },
+      {
+        id: topPath,
+        targetType: topPath,
+        configFile: 'openclaw.json',
+        pathPattern: topPath,
+        secretShape: 'secret_input',
+        expectedResolvedValue: 'string',
+        includeInPlan: true,
+        includeInConfigure: true,
+        includeInAudit: true,
+      },
+    ];
+  },
+);
+
+export function collectRuntimeConfigAssignments(params: {
+  config: OpenClawConfig;
+  defaults: SecretDefaults | undefined;
+  context: ResolverContext;
+}): void {
+  const resolved = getChannelSurface(params.config, 'feishu');
+  if (!resolved) return;
+
+  const { channel, surface } = resolved;
+
+  collectSimpleChannelFieldAssignments({
+    channelKey: 'feishu',
+    field: 'appSecret',
+    channel,
+    surface,
+    defaults: params.defaults,
+    context: params.context,
+    topInactiveReason: 'no enabled Feishu account inherits this top-level appSecret.',
+    accountInactiveReason: 'Feishu account is disabled.',
+  });
+
+  const baseConnectionMode =
+    normalizeSecretStringValue(channel.connectionMode) === 'webhook' ? 'webhook' : 'websocket';
+  const resolveAccountMode = (account: Record<string, unknown>): string | undefined =>
+    hasOwnProperty(account, 'connectionMode')
+      ? normalizeSecretStringValue(account.connectionMode)
+      : baseConnectionMode;
+
+  for (const field of WEBHOOK_ONLY_FIELDS) {
+    collectConditionalChannelFieldAssignments({
+      channelKey: 'feishu',
+      field,
+      channel,
+      surface,
+      defaults: params.defaults,
+      context: params.context,
+      topLevelActiveWithoutAccounts: baseConnectionMode === 'webhook',
+      topLevelInheritedAccountActive: ({ account, enabled }) =>
+        enabled && !hasOwnProperty(account, field) && resolveAccountMode(account) === 'webhook',
+      accountActive: ({ account, enabled }) => enabled && resolveAccountMode(account) === 'webhook',
+      topInactiveReason: `no enabled Feishu webhook-mode surface inherits this top-level ${field}.`,
+      accountInactiveReason: 'Feishu account is disabled or not running in webhook mode.',
+    });
+  }
+}

--- a/tests/secret-contract-api.test.ts
+++ b/tests/secret-contract-api.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for the Feishu channel secret-contract registration: structural
+ * shape of `secretTargetRegistryEntries` and assignment collection across
+ * top-level, account-scoped, plaintext, and connection-mode variants.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { OpenClawConfig } from 'openclaw/plugin-sdk';
+import type { ResolverContext } from 'openclaw/plugin-sdk/channel-secret-basic-runtime';
+
+import {
+  collectRuntimeConfigAssignments,
+  secretTargetRegistryEntries,
+} from '../secret-contract-api.ts';
+
+function secretRef(id: string) {
+  return { source: 'file' as const, provider: 'lark-secrets', id };
+}
+
+function makeResolverContext(sourceConfig: OpenClawConfig): ResolverContext {
+  return {
+    sourceConfig,
+    env: {} as NodeJS.ProcessEnv,
+    cache: {},
+    warnings: [],
+    warningKeys: new Set<string>(),
+    assignments: [],
+  };
+}
+
+/** Run `collectRuntimeConfigAssignments` over a synthetic Feishu section. */
+function runCollect(feishu: Record<string, unknown>) {
+  const cfg = { channels: { feishu } } as unknown as OpenClawConfig;
+  const context = makeResolverContext(cfg);
+  collectRuntimeConfigAssignments({ config: cfg, defaults: undefined, context });
+  return { cfg, context };
+}
+
+describe('Feishu secret contract API — structure', () => {
+  it('registers six targets covering top-level and account scope', () => {
+    expect(new Set(secretTargetRegistryEntries.map((entry) => entry.id))).toEqual(
+      new Set([
+        'channels.feishu.appSecret',
+        'channels.feishu.encryptKey',
+        'channels.feishu.verificationToken',
+        'channels.feishu.accounts.*.appSecret',
+        'channels.feishu.accounts.*.encryptKey',
+        'channels.feishu.accounts.*.verificationToken',
+      ]),
+    );
+    expect(secretTargetRegistryEntries).toHaveLength(6);
+  });
+
+  it('every target declares string-shaped secret_input with all lifecycle phases enabled', () => {
+    for (const entry of secretTargetRegistryEntries) {
+      expect(entry.secretShape).toBe('secret_input');
+      expect(entry.expectedResolvedValue).toBe('string');
+      expect(entry.configFile).toBe('openclaw.json');
+      expect(entry.includeInPlan).toBe(true);
+      expect(entry.includeInConfigure).toBe(true);
+      expect(entry.includeInAudit).toBe(true);
+      expect(entry.targetType).toBe(entry.id);
+      expect(entry.pathPattern).toBe(entry.id);
+    }
+  });
+});
+
+describe('Feishu secret contract API — appSecret (always required)', () => {
+  it('collects SecretRef assignment for top-level channels.feishu.appSecret', () => {
+    const { cfg, context } = runCollect({
+      enabled: true,
+      appId: 'cli_default',
+      appSecret: secretRef('/lark/top-appSecret'),
+      accounts: { default: { enabled: true } },
+    });
+
+    const topAssignment = context.assignments.find(
+      (a) => a.path === 'channels.feishu.appSecret',
+    );
+    expect(topAssignment).toBeDefined();
+    topAssignment!.apply('resolved-top-appSecret');
+    const feishu = cfg.channels?.feishu as Record<string, unknown>;
+    expect(feishu.appSecret).toBe('resolved-top-appSecret');
+  });
+
+  it('collects SecretRef assignment for account channels.feishu.accounts.*.appSecret', () => {
+    const { cfg, context } = runCollect({
+      enabled: true,
+      appId: 'cli_default',
+      accounts: {
+        mediaops: {
+          enabled: true,
+          appId: 'cli_mediaops',
+          appSecret: secretRef('/lark/acct-appSecret'),
+        },
+      },
+    });
+
+    const acctAssignment = context.assignments.find(
+      (a) => a.path === 'channels.feishu.accounts.mediaops.appSecret',
+    );
+    expect(acctAssignment).toBeDefined();
+    acctAssignment!.apply('resolved-acct-appSecret');
+    const account = (cfg.channels?.feishu as { accounts: Record<string, Record<string, unknown>> })
+      .accounts.mediaops;
+    expect(account.appSecret).toBe('resolved-acct-appSecret');
+  });
+
+  it('leaves plaintext channels.feishu.appSecret untouched', () => {
+    const { cfg, context } = runCollect({
+      enabled: true,
+      appId: 'cli_default',
+      appSecret: 'plaintext-appSecret',
+      accounts: { default: { enabled: true } },
+    });
+
+    const paths = context.assignments.map((a) => a.path);
+    expect(paths).not.toContain('channels.feishu.appSecret');
+    const feishu = cfg.channels?.feishu as Record<string, unknown>;
+    expect(feishu.appSecret).toBe('plaintext-appSecret');
+  });
+});
+
+describe.each(['encryptKey', 'verificationToken'] as const)(
+  'Feishu secret contract API — %s (webhook-conditional)',
+  (field) => {
+    it(`collects top-level ${field} SecretRef when connectionMode is webhook`, () => {
+      const { cfg, context } = runCollect({
+        enabled: true,
+        connectionMode: 'webhook',
+        appId: 'cli_default',
+        [field]: secretRef(`/lark/top-${field}`),
+        accounts: { default: { enabled: true } },
+      });
+
+      const topAssignment = context.assignments.find(
+        (a) => a.path === `channels.feishu.${field}`,
+      );
+      expect(topAssignment).toBeDefined();
+      topAssignment!.apply(`resolved-top-${field}`);
+      const feishu = cfg.channels?.feishu as Record<string, unknown>;
+      expect(feishu[field]).toBe(`resolved-top-${field}`);
+    });
+
+    it(`collects account ${field} SecretRef when account connectionMode is webhook`, () => {
+      const { cfg, context } = runCollect({
+        enabled: true,
+        appId: 'cli_default',
+        accounts: {
+          webhookbot: {
+            enabled: true,
+            connectionMode: 'webhook',
+            appId: 'cli_webhookbot',
+            [field]: secretRef(`/lark/acct-${field}`),
+          },
+        },
+      });
+
+      const acctPath = `channels.feishu.accounts.webhookbot.${field}`;
+      const acctAssignment = context.assignments.find((a) => a.path === acctPath);
+      expect(acctAssignment).toBeDefined();
+      acctAssignment!.apply(`resolved-acct-${field}`);
+      const account = (cfg.channels?.feishu as { accounts: Record<string, Record<string, unknown>> })
+        .accounts.webhookbot;
+      expect(account[field]).toBe(`resolved-acct-${field}`);
+    });
+
+    it(`skips top-level ${field} SecretRef and warns when default mode is websocket`, () => {
+      const { context } = runCollect({
+        enabled: true,
+        // connectionMode unset → defaults to websocket
+        appId: 'cli_default',
+        [field]: secretRef(`/lark/top-${field}`),
+        accounts: { default: { enabled: true } },
+      });
+
+      const paths = context.assignments.map((a) => a.path);
+      expect(paths).not.toContain(`channels.feishu.${field}`);
+      expect(context.warnings.length).toBeGreaterThan(0);
+      const warning = context.warnings.find((w) => w.path === `channels.feishu.${field}`);
+      expect(warning).toBeDefined();
+      expect(warning!.code).toBe('SECRETS_REF_IGNORED_INACTIVE_SURFACE');
+    });
+
+    it(`skips account ${field} SecretRef when account connectionMode is websocket`, () => {
+      const { context } = runCollect({
+        enabled: true,
+        connectionMode: 'webhook',
+        appId: 'cli_default',
+        accounts: {
+          wsbot: {
+            enabled: true,
+            connectionMode: 'websocket',
+            appId: 'cli_wsbot',
+            [field]: secretRef(`/lark/acct-${field}`),
+          },
+        },
+      });
+
+      const paths = context.assignments.map((a) => a.path);
+      expect(paths).not.toContain(`channels.feishu.accounts.wsbot.${field}`);
+    });
+
+    it(`leaves plaintext ${field} untouched in webhook mode`, () => {
+      const { cfg, context } = runCollect({
+        enabled: true,
+        connectionMode: 'webhook',
+        appId: 'cli_default',
+        [field]: `plaintext-${field}`,
+        accounts: { default: { enabled: true } },
+      });
+
+      const paths = context.assignments.map((a) => a.path);
+      expect(paths).not.toContain(`channels.feishu.${field}`);
+      const feishu = cfg.channels?.feishu as Record<string, unknown>;
+      expect(feishu[field]).toBe(`plaintext-${field}`);
+    });
+  },
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,6 @@
 
     "outDir": "dist"
   },
-  "include": ["index.ts", "src/**/*.ts", "tests/**/*.ts", "*.config.ts"],
+  "include": ["index.ts", "secret-contract-api.ts", "src/**/*.ts", "tests/**/*.ts", "*.config.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-  entry: { index: 'index.ts' },
+  entry: {
+    index: 'index.ts',
+    'secret-contract-api': 'secret-contract-api.ts',
+  },
   format: 'esm',
   target: 'node22',
   platform: 'node',


### PR DESCRIPTION
## Problem

When `channels.feishu.appSecret` (or `encryptKey` / `verificationToken`) is configured as an OpenClaw SecretRef object (e.g. `{source: "file", provider, id}`), the unresolved object reaches the Lark SDK and is serialized into the `app_secret` field of the tenant-token request. Feishu rejects the malformed payload with HTTP 400, and the WebSocket connection never establishes. Plaintext credentials are unaffected. Reports in #491 and #466.

## Root cause

OpenClaw 2026.5+ resolves channel SecretRefs through a per-channel contract API discovered at the plugin root. `@larksuite/openclaw-lark` shipped no such contract, so the platform's `prepareSecretsRuntimeSnapshot` had no way to know these fields were SecretRef-shaped and skipped resolution entirely.

## Fix

Register the six Feishu credential targets (top-level + per-account variants of `appSecret`, `encryptKey`, `verificationToken`) with `secret_input` shape and `expectedResolvedValue: "string"`, then build the contract as a separate tsdown entry and ship a root-level `secret-contract-api.js` discovery shim. Collection mirrors the bundled `@openclaw/feishu` reference:

- `appSecret` is collected unconditionally — the SDK always requires it.
- `encryptKey` and `verificationToken` are collected only on webhook-mode surfaces, avoiding spurious resolution failures on WebSocket-only accounts that legitimately don't carry these fields.

`peerDependencies.openclaw` is bumped to `>=2026.5.4` — the external contract loader appeared in 2026.5.3, and 2026.5.4 is the lowest version where the WS-startup repro has been confirmed in the field.

## Out of scope

- CLI `feishu-doctor` / `feishu-diagnose` SecretRef rendering improvements
- `src/core/token-store.ts` `createRequire` rewrite
- `PLUGIN_VERSION` → `getPluginVersion()` refactor

These items live in #466 and remain welcome as separate PRs once the CLA signature there is resolved.

## Test plan

- [x] `pnpm test` — 286 tests pass, including 15 new cases covering registry shape, top-level / account-scoped collection, plaintext passthrough, and webhook-vs-websocket conditional behaviour.
- [x] `pnpm build` — emits `dist/secret-contract-api.{mjs,d.mts}` from the new tsdown entry.
- [x] `pnpm pack --dry-run` — tarball includes the root shim plus the dist artifacts; no source or test files leak into the package.
- [x] Live verification against an OpenClaw 2026.5.4+ deployment with a file-mode SecretRef config — deferred to the maintainer running this on a staging gateway before merge.

## Attribution

Implementation adapted from #466 by @aresxu8866-hue. The CLA signature on #466 was blocked because the commit author email is not linked to a GitHub account; this PR re-authors the minimal subset that fixes the WS-startup blocker so the runtime fix can ship while the original contributor's CLA state is resolved.

Closes #491.
Refs #466.