### PR TITLE
fix: 禁用 axios 自动代理读取，修复 HTTP_PROXY 导致 URL 拼接错误 (#493)

### DIFF
--- a/src/core/lark-client.ts
+++ b/src/core/lark-client.ts
@@ -29,22 +29,22 @@ import { getUserAgent } from './version';
 const log = larkLogger('core/lark-client');
 
 // ---------------------------------------------------------------------------
-// 注入 User-Agent 到所有飞书 SDK 请求
+// Inject User-Agent into all Feishu SDK requests
 // ---------------------------------------------------------------------------
 
 const GLOBAL_LARK_USER_AGENT_KEY = 'LARK_USER_AGENT';
 
 function installGlobalUserAgent(): void {
-  // node-sdk 内置拦截器最终会读取 global.LARK_USER_AGENT 并覆盖 User-Agent
+  // node-sdk's built-in interceptor reads global.LARK_USER_AGENT to override User-Agent
   (globalThis as Record<string, unknown>)[GLOBAL_LARK_USER_AGENT_KEY] = getUserAgent();
 }
 
 installGlobalUserAgent();
-// 禁用 axios 自动代理读取，避免 HTTP_PROXY 环境变量导致 URL 拼接错误。
-// 代理路由由 OpenClaw 核心的 global-agent 统一管理。
+// Disable axios auto-proxy to prevent HTTP_PROXY env vars from corrupting request URLs.
+// Proxy routing is managed centrally by OpenClaw core's global-agent.
 (Lark.defaultHttpInstance.defaults as Record<string, unknown>).proxy = false;
 Lark.defaultHttpInstance.interceptors.request.handlers = [];
-// 使用 interceptors 在所有 HTTP 请求中注入 User-Agent header
+// Inject User-Agent header into all HTTP requests via interceptor
 Lark.defaultHttpInstance.interceptors.request.use(
   (req) => {
     if (req.headers) {

--- a/src/core/lark-client.ts
+++ b/src/core/lark-client.ts
@@ -40,6 +40,9 @@ function installGlobalUserAgent(): void {
 }
 
 installGlobalUserAgent();
+// 禁用 axios 自动代理读取，避免 HTTP_PROXY 环境变量导致 URL 拼接错误。
+// 代理路由由 OpenClaw 核心的 global-agent 统一管理。
+(Lark.defaultHttpInstance.defaults as Record<string, unknown>).proxy = false;
 Lark.defaultHttpInstance.interceptors.request.handlers = [];
 // 使用 interceptors 在所有 HTTP 请求中注入 User-Agent header
 Lark.defaultHttpInstance.interceptors.request.use(


### PR DESCRIPTION
## Summary

- 禁用 Lark SDK 默认 axios 实例的自动代理读取（`proxy: false`），修复当系统设置 `http_proxy` 环境变量时 API URL 被错误拼接的问题
- 代理路由由 OpenClaw 核心的 `global-agent` 统一管理，Lark SDK 不应自行处理代理

## Root Cause

`@larksuiteoapi/node-sdk` 使用 `axios.create()` 作为默认 HTTP 客户端。Axios v1.x 会自动读取 `HTTP_PROXY`/`HTTPS_PROXY` 环境变量并应用代理，与 OpenClaw 核心的 `global-agent` 产生冲突，导致 URL 被拼接为类似 `http://127.0.0.1:7890https://open.feishu.cn/xxxx` 的无效格式。

## Fix

在 `src/core/lark-client.ts` 中，于 `Lark.defaultHttpInstance` 上显式设置 `proxy: false`，仅增加 1 行代码。

## Test plan

- [x] `pnpm test` — 271 tests passed
- [x] `pnpm lint` — 0 errors
- [x] 手动验证：设置 `http_proxy` 环境变量后，飞书 API 请求正常

Fixes #493
