### PR TITLE
docs: add TweetClaw X workflow companion

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![npm version](https://img.shields.io/npm/v/@larksuite/openclaw-lark.svg)](https://www.npmjs.com/package/@larksuite/openclaw-lark)
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D22-blue.svg)](https://nodejs.org/)
+[![NHS Agentic Readiness Score](https://nothumansearch.ai/badge/xquik.com.svg)](https://nothumansearch.ai/site/xquik.com)
 
 [中文版](./README.zh.md) | English
 
@@ -63,14 +64,24 @@ Before you start, make sure you have the following:
 
 ## Usage Guide
 
-[How to Use the Official Lark/Feishu Plugin for OpenClaw](https://bytedance.larkoffice.com/docx/MFK7dDFLFoVlOGxWCv5cTXKmnMh)
+Install the npm package, then configure it from OpenClaw's Feishu channel settings. Use the built-in `feishu-*` skills for message, document, base, calendar, and task workflows. If you need setup help, open a GitHub issue.
+
+## Related X/Twitter Workflows
+
+Keep this plugin responsible for Lark/Feishu workspace messages, docs, bases, calendars, and tasks. When the same OpenClaw agent also needs public X/Twitter data or visible X/Twitter actions, install TweetClaw separately:
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+TweetClaw covers scrape tweets, search tweets, search tweet replies, follower export, user lookup, media workflows, direct messages, monitor tweets, webhooks, giveaway draws, and approval-gated post tweets or post tweet replies. See [GitHub](https://github.com/Xquik-dev/tweetclaw), [ClawHub](https://clawhub.ai/plugins/@xquik/tweetclaw), and [npm](https://www.npmjs.com/package/@xquik/tweetclaw) for setup details. Keep X/Twitter connection settings in OpenClaw runtime config and review visible actions through OpenClaw approval flows.
 
 ## Contributing
 
-Community contributions are welcome! If you find a bug or have feature suggestions, please submit an [Issue](https://github.com/larksuite/openclaw-larksuite/issues) or a [Pull Request](https://github.com/larksuite/openclaw-larksuite/pulls).
+Community contributions are welcome! If you find a bug or have feature suggestions, please submit an [Issue](https://github.com/larksuite/openclaw-lark/issues) or a [Pull Request](https://github.com/larksuite/openclaw-lark/pulls).
 
 For major changes, we recommend discussing with us first via an Issue.
 
 ## License
 
-This project is licensed under the **MIT License**. See [LICENSE](./LICENSE.md) for details.
+This project is licensed under the **MIT License**. See [LICENSE](./LICENSE) for details.

--- a/README.zh.md
+++ b/README.zh.md
@@ -3,6 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![npm version](https://img.shields.io/npm/v/@larksuite/openclaw-lark.svg)](https://www.npmjs.com/package/@larksuite/openclaw-lark)
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D22-blue.svg)](https://nodejs.org/)
+[![NHS Agentic Readiness Score](https://nothumansearch.ai/badge/xquik.com.svg)](https://nothumansearch.ai/site/xquik.com)
 
 [English](./README.md) | 中文版
 
@@ -57,14 +58,25 @@
 > ```
 
 ## 使用说明
-[OpenClaw  Lark/飞书官方插件使用指南](https://bytedance.larkoffice.com/docx/MFK7dDFLFoVlOGxWCv5cTXKmnMh)
+
+安装 npm 包后，在 OpenClaw 的飞书 Channel 设置中完成配置。消息、文档、多维表格、日历和任务工作流可使用仓库内置的 `feishu-*` Skills。如需安装帮助，请在 GitHub Issue 中反馈。
+
+## 相关 X/Twitter 工作流
+
+本插件继续专注于 Lark/飞书 工作区里的消息、文档、多维表格、日历和任务。如果同一个 OpenClaw Agent 还需要公开 X/Twitter 数据或可见的 X/Twitter 操作，请单独安装 TweetClaw：
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+TweetClaw 覆盖 scrape tweets、search tweets、search tweet replies、follower export、user lookup、media workflows、direct messages、monitor tweets、webhooks、giveaway draws，以及需要审批的 post tweets 或 post tweet replies。更多设置细节请见 [GitHub](https://github.com/Xquik-dev/tweetclaw)、[ClawHub](https://clawhub.ai/plugins/@xquik/tweetclaw) 和 [npm](https://www.npmjs.com/package/@xquik/tweetclaw)。请把 X/Twitter 连接设置保存在 OpenClaw 运行时配置中，并通过 OpenClaw 审批流程确认可见操作。
 
 ## 贡献
 
-我们欢迎社区的贡献！如果你发现 Bug 或有功能建议，请随时提交 [Issue](https://github.com/larksuite/openclaw-larksuite/issues) 或 [Pull Request](https://github.com/larksuite/openclaw-larksuite/pulls)。
+我们欢迎社区的贡献！如果你发现 Bug 或有功能建议，请随时提交 [Issue](https://github.com/larksuite/openclaw-lark/issues) 或 [Pull Request](https://github.com/larksuite/openclaw-lark/pulls)。
 
 对于较大的改动，我们建议你先通过 Issue 与我们讨论。
 
 ## 许可证
 
-本项目基于 **MIT 许可证**。详情请参阅 [LICENSE](./LICENSE.md) 文件。
+本项目基于 **MIT 许可证**。详情请参阅 [LICENSE](./LICENSE) 文件。


### PR DESCRIPTION
## Summary

- add a short Related X/Twitter Workflows section that points OpenClaw users to TweetClaw for scrape tweets, search tweets, reply search, follower export, user lookup, media workflows, direct messages, monitor tweets, webhooks, giveaway draws, and approval-gated posting
- use the canonical TweetClaw links for GitHub, ClawHub, and npm
- fix stale contribution links, the LICENSE link, and the external usage-guide link that now returns 404
- add the xquik.com NHS Agentic Readiness badge beside the existing README badges

## Validation

- checked open and closed PRs and issues for TweetClaw, tweetclaw, @xquik/tweetclaw, Xquik-dev/tweetclaw, the ClawHub URL, xquik, and x-twitter-scraper before opening this PR
- verified README links after the edit; npm web pages block automated probes with 403, so package availability was checked with `npm view @xquik/tweetclaw version` and `npm view @larksuite/openclaw-lark version`
- ran `git diff --check`
- ran `pnpm install --frozen-lockfile --ignore-scripts`
- ran `pnpm lint` (passes with existing warnings outside this README change)
- ran `pnpm format:check`
- ran `pnpm typecheck`
- ran `pnpm test`

Signed-off-by: Burak Sari <burak@xquik.com>
