### PR TITLE
feat(channel): add replyFallbackOnWithdrawn config for recalled reply targets

### DIFF
--- a/src/core/config-schema.ts
+++ b/src/core/config-schema.ts
@@ -196,6 +196,7 @@ export const FeishuAccountConfigSchema = z.object({
   dedup: DedupSchema,
   reactionNotifications: ReactionNotificationModeSchema,
   threadSession: z.boolean().optional(),
+  replyFallbackOnWithdrawn: z.enum(['top-level', 'silent']).optional(),
   allowBots: AllowBotsSchema,
   uat: UATConfigSchema,
 });

--- a/src/messaging/outbound/deliver.ts
+++ b/src/messaging/outbound/deliver.ts
@@ -17,7 +17,7 @@ import { normalizeFeishuTarget, resolveReceiveIdType } from '../../core/targets'
 import { parseFeishuCommentTarget } from '../../core/comment-target';
 import { optimizeMarkdownStyle } from '../../card/markdown-style';
 import { extractLarkApiCode, formatLarkError } from '../../core/api-error';
-import { isTerminalMessageApiCode } from '../../core/message-unavailable';
+import { isTerminalMessageApiCode, markMessageUnavailable } from '../../core/message-unavailable';
 import { larkLogger } from '../../core/lark-logger';
 import { getSentinelStore } from '../inbound/sentinel-store';
 import { uploadAndSendMediaLark } from './media';
@@ -158,7 +158,12 @@ async function sendImMessage(params: {
       //   'silent'    — silently discard the reply (default)
       //   'top-level' — fall back to sending as a new message
       // Other errors are propagated as-is.
-      if (isTerminalMessageApiCode(extractLarkApiCode(err))) {
+      const apiCode = extractLarkApiCode(err);
+      if (isTerminalMessageApiCode(apiCode)) {
+        // Mark in the unavailable cache so subsequent operations on the same
+        // messageId skip the API call (symmetric with send.ts which uses
+        // runWithMessageUnavailableGuard).
+        markMessageUnavailable({ messageId: replyToMessageId, apiCode, operation: `im.message.reply(${msgType})` });
         if (replyFallbackOnWithdrawn === 'silent') {
           log.warn(`reply target ${replyToMessageId} unavailable, silently discarding (config: replyFallbackOnWithdrawn=silent)`);
           return { messageId: '', chatId: '' };
@@ -318,7 +323,10 @@ export async function sendTextLark(params: SendTextLarkParams): Promise<FeishuSe
   const content = buildPostContent(prepared.text);
 
   const result = await sendImMessage({ client, to, content, msgType: 'post', replyToMessageId, replyInThread, replyFallbackOnWithdrawn: getReplyFallbackMode(cfg, accountId) });
-  recordSentinelsForChat(prepared.resolvedAccountId, to, threadId, prepared.sentinels);
+  // Skip sentinel recording when the reply was silently discarded (empty messageId).
+  if (result.messageId) {
+    recordSentinelsForChat(prepared.resolvedAccountId, to, threadId, prepared.sentinels);
+  }
   return result;
 }
 

--- a/src/messaging/outbound/deliver.ts
+++ b/src/messaging/outbound/deliver.ts
@@ -115,6 +115,11 @@ function recordSentinelsForChat(
   getSentinelStore(resolvedAccountId).recordSentinels(threadScopedKey(to, threadId), sentinels);
 }
 
+/** Read the replyFallbackOnWithdrawn setting from channel config. */
+function getReplyFallbackMode(cfg: ClawdbotConfig): 'top-level' | 'silent' {
+  return (cfg.channels?.feishu as Record<string, unknown> | undefined)?.replyFallbackOnWithdrawn as 'top-level' | 'silent' ?? 'top-level';
+}
+
 /**
  * Unified IM message sender — handles both reply and create paths for any
  * `msg_type`.  Replaces the former `replyPostMessage`, `createPostMessage`,
@@ -127,8 +132,9 @@ async function sendImMessage(params: {
   msgType: 'post' | 'interactive';
   replyToMessageId?: string;
   replyInThread?: boolean;
+  replyFallbackOnWithdrawn?: 'top-level' | 'silent';
 }): Promise<FeishuSendResult> {
-  const { client, to, content, msgType, replyToMessageId, replyInThread } = params;
+  const { client, to, content, msgType, replyToMessageId, replyInThread, replyFallbackOnWithdrawn } = params;
 
   // --- Reply path ---
   if (replyToMessageId) {
@@ -147,9 +153,15 @@ async function sendImMessage(params: {
       return result;
     } catch (err) {
       // When the reply target has been recalled (230011) or deleted (231003),
-      // fall back to sending as a top-level message instead of silently
-      // losing the reply.  Other errors are propagated as-is.
+      // behaviour depends on the replyFallbackOnWithdrawn config:
+      //   'top-level' — fall back to sending as a new message (default)
+      //   'silent'    — silently discard the reply
+      // Other errors are propagated as-is.
       if (isTerminalMessageApiCode(extractLarkApiCode(err))) {
+        if (replyFallbackOnWithdrawn === 'silent') {
+          log.warn(`reply target ${replyToMessageId} unavailable, silently discarding (config: replyFallbackOnWithdrawn=silent)`);
+          return { messageId: '', chatId: '' };
+        }
         log.warn(`reply target ${replyToMessageId} unavailable, falling back to top-level send`);
       } else {
         throw err;
@@ -304,7 +316,7 @@ export async function sendTextLark(params: SendTextLarkParams): Promise<FeishuSe
   const prepared = await prepareTextForLark(cfg, text, to, accountId);
   const content = buildPostContent(prepared.text);
 
-  const result = await sendImMessage({ client, to, content, msgType: 'post', replyToMessageId, replyInThread });
+  const result = await sendImMessage({ client, to, content, msgType: 'post', replyToMessageId, replyInThread, replyFallbackOnWithdrawn: getReplyFallbackMode(cfg) });
   recordSentinelsForChat(prepared.resolvedAccountId, to, threadId, prepared.sentinels);
   return result;
 }
@@ -384,7 +396,7 @@ export async function sendCardLark(params: SendCardLarkParams): Promise<FeishuSe
   const content = JSON.stringify(card);
 
   try {
-    return await sendImMessage({ client, to, content, msgType: 'interactive', replyToMessageId, replyInThread });
+    return await sendImMessage({ client, to, content, msgType: 'interactive', replyToMessageId, replyInThread, replyFallbackOnWithdrawn: getReplyFallbackMode(cfg) });
   } catch (err) {
     const detail = formatLarkError(err);
     log.error(`sendCardLark failed: ${detail}`);

--- a/src/messaging/outbound/deliver.ts
+++ b/src/messaging/outbound/deliver.ts
@@ -16,7 +16,8 @@ import { threadScopedKey } from '../../channel/chat-queue';
 import { normalizeFeishuTarget, resolveReceiveIdType } from '../../core/targets';
 import { parseFeishuCommentTarget } from '../../core/comment-target';
 import { optimizeMarkdownStyle } from '../../card/markdown-style';
-import { formatLarkError } from '../../core/api-error';
+import { extractLarkApiCode, formatLarkError } from '../../core/api-error';
+import { isTerminalMessageApiCode } from '../../core/message-unavailable';
 import { larkLogger } from '../../core/lark-logger';
 import { getSentinelStore } from '../inbound/sentinel-store';
 import { uploadAndSendMediaLark } from './media';
@@ -131,18 +132,29 @@ async function sendImMessage(params: {
 
   // --- Reply path ---
   if (replyToMessageId) {
-    log.info(`replying to message ${replyToMessageId} ` + `(msg_type=${msgType}, thread=${replyInThread ?? false})`);
-    const response = await client.im.message.reply({
-      path: { message_id: replyToMessageId },
-      data: { content, msg_type: msgType, reply_in_thread: replyInThread },
-    });
+    log.info(`replying to message ${replyToMessageId} (msg_type=${msgType}, thread=${replyInThread ?? false})`);
+    try {
+      const response = await client.im.message.reply({
+        path: { message_id: replyToMessageId },
+        data: { content, msg_type: msgType, reply_in_thread: replyInThread },
+      });
 
-    const result: FeishuSendResult = {
-      messageId: response?.data?.message_id ?? '',
-      chatId: response?.data?.chat_id ?? '',
-    };
-    log.debug(`reply sent: messageId=${result.messageId}`);
-    return result;
+      const result: FeishuSendResult = {
+        messageId: response?.data?.message_id ?? '',
+        chatId: response?.data?.chat_id ?? '',
+      };
+      log.debug(`reply sent: messageId=${result.messageId}`);
+      return result;
+    } catch (err) {
+      // When the reply target has been recalled (230011) or deleted (231003),
+      // fall back to sending as a top-level message instead of silently
+      // losing the reply.  Other errors are propagated as-is.
+      if (isTerminalMessageApiCode(extractLarkApiCode(err))) {
+        log.warn(`reply target ${replyToMessageId} unavailable, falling back to top-level send`);
+      } else {
+        throw err;
+      }
+    }
   }
 
   // --- Create path ---

--- a/src/messaging/outbound/deliver.ts
+++ b/src/messaging/outbound/deliver.ts
@@ -117,7 +117,7 @@ function recordSentinelsForChat(
 
 /** Read the replyFallbackOnWithdrawn setting from channel config. */
 function getReplyFallbackMode(cfg: ClawdbotConfig): 'top-level' | 'silent' {
-  return (cfg.channels?.feishu as Record<string, unknown> | undefined)?.replyFallbackOnWithdrawn as 'top-level' | 'silent' ?? 'top-level';
+  return (cfg.channels?.feishu as Record<string, unknown> | undefined)?.replyFallbackOnWithdrawn as 'top-level' | 'silent' ?? 'silent';
 }
 
 /**

--- a/src/messaging/outbound/deliver.ts
+++ b/src/messaging/outbound/deliver.ts
@@ -115,9 +115,10 @@ function recordSentinelsForChat(
   getSentinelStore(resolvedAccountId).recordSentinels(threadScopedKey(to, threadId), sentinels);
 }
 
-/** Read the replyFallbackOnWithdrawn setting from channel config. */
-function getReplyFallbackMode(cfg: ClawdbotConfig): 'top-level' | 'silent' {
-  return (cfg.channels?.feishu as Record<string, unknown> | undefined)?.replyFallbackOnWithdrawn as 'top-level' | 'silent' ?? 'silent';
+/** Read the replyFallbackOnWithdrawn setting from account-scoped channel config. */
+function getReplyFallbackMode(cfg: ClawdbotConfig, accountId?: string): 'top-level' | 'silent' {
+  const scopedCfg = createAccountScopedConfig(cfg, accountId);
+  return (scopedCfg.channels?.feishu as Record<string, unknown> | undefined)?.replyFallbackOnWithdrawn as 'top-level' | 'silent' ?? 'silent';
 }
 
 /**
@@ -154,8 +155,8 @@ async function sendImMessage(params: {
     } catch (err) {
       // When the reply target has been recalled (230011) or deleted (231003),
       // behaviour depends on the replyFallbackOnWithdrawn config:
-      //   'top-level' — fall back to sending as a new message (default)
-      //   'silent'    — silently discard the reply
+      //   'silent'    — silently discard the reply (default)
+      //   'top-level' — fall back to sending as a new message
       // Other errors are propagated as-is.
       if (isTerminalMessageApiCode(extractLarkApiCode(err))) {
         if (replyFallbackOnWithdrawn === 'silent') {
@@ -316,7 +317,7 @@ export async function sendTextLark(params: SendTextLarkParams): Promise<FeishuSe
   const prepared = await prepareTextForLark(cfg, text, to, accountId);
   const content = buildPostContent(prepared.text);
 
-  const result = await sendImMessage({ client, to, content, msgType: 'post', replyToMessageId, replyInThread, replyFallbackOnWithdrawn: getReplyFallbackMode(cfg) });
+  const result = await sendImMessage({ client, to, content, msgType: 'post', replyToMessageId, replyInThread, replyFallbackOnWithdrawn: getReplyFallbackMode(cfg, accountId) });
   recordSentinelsForChat(prepared.resolvedAccountId, to, threadId, prepared.sentinels);
   return result;
 }
@@ -396,7 +397,7 @@ export async function sendCardLark(params: SendCardLarkParams): Promise<FeishuSe
   const content = JSON.stringify(card);
 
   try {
-    return await sendImMessage({ client, to, content, msgType: 'interactive', replyToMessageId, replyInThread, replyFallbackOnWithdrawn: getReplyFallbackMode(cfg) });
+    return await sendImMessage({ client, to, content, msgType: 'interactive', replyToMessageId, replyInThread, replyFallbackOnWithdrawn: getReplyFallbackMode(cfg, accountId) });
   } catch (err) {
     const detail = formatLarkError(err);
     log.error(`sendCardLark failed: ${detail}`);

--- a/src/messaging/outbound/send.ts
+++ b/src/messaging/outbound/send.ts
@@ -18,7 +18,7 @@ type ReplyFallbackMode = 'top-level' | 'silent';
 
 /** Read the replyFallbackOnWithdrawn setting from channel config. */
 function getReplyFallbackMode(cfg: ClawdbotConfig): ReplyFallbackMode {
-  return (cfg.channels?.feishu as Record<string, unknown> | undefined)?.replyFallbackOnWithdrawn as ReplyFallbackMode ?? 'top-level';
+  return (cfg.channels?.feishu as Record<string, unknown> | undefined)?.replyFallbackOnWithdrawn as ReplyFallbackMode ?? 'silent';
 }
 import { optimizeMarkdownStyle } from '../../card/markdown-style';
 import { buildMentionedCardContent, buildMentionedMessage } from '../inbound/mention';

--- a/src/messaging/outbound/send.ts
+++ b/src/messaging/outbound/send.ts
@@ -13,19 +13,20 @@ import { larkLogger } from '../../core/lark-logger';
 import { threadScopedKey } from '../../channel/chat-queue';
 import { normalizeFeishuTarget, normalizeMessageId, resolveReceiveIdType } from '../../core/targets';
 import { isMessageUnavailableError, runWithMessageUnavailableGuard } from '../../core/message-unavailable';
-
-type ReplyFallbackMode = 'top-level' | 'silent';
-
-/** Read the replyFallbackOnWithdrawn setting from channel config. */
-function getReplyFallbackMode(cfg: ClawdbotConfig): ReplyFallbackMode {
-  return (cfg.channels?.feishu as Record<string, unknown> | undefined)?.replyFallbackOnWithdrawn as ReplyFallbackMode ?? 'silent';
-}
 import { optimizeMarkdownStyle } from '../../card/markdown-style';
 import { buildMentionedCardContent, buildMentionedMessage } from '../inbound/mention';
 import { getSentinelStore } from '../inbound/sentinel-store';
 import { type NormalizeContext, type SentinelEntry, normalizeOutboundMentions } from './normalize-mentions';
 
 const sendLog = larkLogger('outbound/send');
+
+type ReplyFallbackMode = 'top-level' | 'silent';
+
+/** Read the replyFallbackOnWithdrawn setting from account-scoped channel config. */
+export function getReplyFallbackMode(cfg: ClawdbotConfig, accountId?: string): ReplyFallbackMode {
+  const scopedCfg = createAccountScopedConfig(cfg, accountId);
+  return (scopedCfg.channels?.feishu as Record<string, unknown> | undefined)?.replyFallbackOnWithdrawn as ReplyFallbackMode ?? 'silent';
+}
 
 /**
  * Runs the outbound text through mention normalization. Returns the
@@ -253,11 +254,11 @@ export async function sendMessageFeishu(params: SendFeishuMessageParams): Promis
     } catch (err) {
       // When the reply target has been recalled (230011) or deleted (231003),
       // behaviour depends on the replyFallbackOnWithdrawn config:
-      //   'top-level' — fall back to sending as a new message (default)
-      //   'silent'    — silently discard the reply
+      //   'silent'    — silently discard the reply (default)
+      //   'top-level' — fall back to sending as a new message
       // Other errors are propagated as-is.
       if (isMessageUnavailableError(err)) {
-        const mode = getReplyFallbackMode(cfg);
+        const mode = getReplyFallbackMode(cfg, accountId);
         if (mode === 'silent') {
           sendLog.warn(
             `reply target ${replyToMessageId} unavailable (${err.apiCode}), silently discarding (config: replyFallbackOnWithdrawn=silent)`,
@@ -343,11 +344,11 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
     } catch (err) {
       // When the reply target has been recalled (230011) or deleted (231003),
       // behaviour depends on the replyFallbackOnWithdrawn config:
-      //   'top-level' — fall back to sending as a new card (default)
-      //   'silent'    — silently discard the reply
+      //   'silent'    — silently discard the reply (default)
+      //   'top-level' — fall back to sending as a new card
       // Other errors are propagated as-is.
       if (isMessageUnavailableError(err)) {
-        const mode = getReplyFallbackMode(cfg);
+        const mode = getReplyFallbackMode(cfg, accountId);
         if (mode === 'silent') {
           sendLog.warn(
             `reply target ${replyToMessageId} unavailable (${err.apiCode}), silently discarding (config: replyFallbackOnWithdrawn=silent)`,

--- a/src/messaging/outbound/send.ts
+++ b/src/messaging/outbound/send.ts
@@ -13,6 +13,13 @@ import { larkLogger } from '../../core/lark-logger';
 import { threadScopedKey } from '../../channel/chat-queue';
 import { normalizeFeishuTarget, normalizeMessageId, resolveReceiveIdType } from '../../core/targets';
 import { isMessageUnavailableError, runWithMessageUnavailableGuard } from '../../core/message-unavailable';
+
+type ReplyFallbackMode = 'top-level' | 'silent';
+
+/** Read the replyFallbackOnWithdrawn setting from channel config. */
+function getReplyFallbackMode(cfg: ClawdbotConfig): ReplyFallbackMode {
+  return (cfg.channels?.feishu as Record<string, unknown> | undefined)?.replyFallbackOnWithdrawn as ReplyFallbackMode ?? 'top-level';
+}
 import { optimizeMarkdownStyle } from '../../card/markdown-style';
 import { buildMentionedCardContent, buildMentionedMessage } from '../inbound/mention';
 import { getSentinelStore } from '../inbound/sentinel-store';
@@ -245,9 +252,18 @@ export async function sendMessageFeishu(params: SendFeishuMessageParams): Promis
       };
     } catch (err) {
       // When the reply target has been recalled (230011) or deleted (231003),
-      // fall back to sending as a top-level message instead of silently
-      // losing the reply.  Other errors are propagated as-is.
+      // behaviour depends on the replyFallbackOnWithdrawn config:
+      //   'top-level' — fall back to sending as a new message (default)
+      //   'silent'    — silently discard the reply
+      // Other errors are propagated as-is.
       if (isMessageUnavailableError(err)) {
+        const mode = getReplyFallbackMode(cfg);
+        if (mode === 'silent') {
+          sendLog.warn(
+            `reply target ${replyToMessageId} unavailable (${err.apiCode}), silently discarding (config: replyFallbackOnWithdrawn=silent)`,
+          );
+          return { messageId: '', chatId: '' };
+        }
         sendLog.warn(
           `reply target ${replyToMessageId} unavailable (${err.apiCode}), falling back to top-level send`,
         );
@@ -326,9 +342,18 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
       };
     } catch (err) {
       // When the reply target has been recalled (230011) or deleted (231003),
-      // fall back to sending as a top-level card instead of silently
-      // losing the reply.  Other errors are propagated as-is.
+      // behaviour depends on the replyFallbackOnWithdrawn config:
+      //   'top-level' — fall back to sending as a new card (default)
+      //   'silent'    — silently discard the reply
+      // Other errors are propagated as-is.
       if (isMessageUnavailableError(err)) {
+        const mode = getReplyFallbackMode(cfg);
+        if (mode === 'silent') {
+          sendLog.warn(
+            `reply target ${replyToMessageId} unavailable (${err.apiCode}), silently discarding (config: replyFallbackOnWithdrawn=silent)`,
+          );
+          return { messageId: '', chatId: '' };
+        }
         sendLog.warn(
           `reply target ${replyToMessageId} unavailable (${err.apiCode}), falling back to top-level card send`,
         );

--- a/src/messaging/outbound/send.ts
+++ b/src/messaging/outbound/send.ts
@@ -12,7 +12,7 @@ import { LarkClient } from '../../core/lark-client';
 import { larkLogger } from '../../core/lark-logger';
 import { threadScopedKey } from '../../channel/chat-queue';
 import { normalizeFeishuTarget, normalizeMessageId, resolveReceiveIdType } from '../../core/targets';
-import { runWithMessageUnavailableGuard } from '../../core/message-unavailable';
+import { isMessageUnavailableError, runWithMessageUnavailableGuard } from '../../core/message-unavailable';
 import { optimizeMarkdownStyle } from '../../card/markdown-style';
 import { buildMentionedCardContent, buildMentionedMessage } from '../inbound/mention';
 import { getSentinelStore } from '../inbound/sentinel-store';
@@ -220,29 +220,41 @@ export async function sendMessageFeishu(params: SendFeishuMessageParams): Promis
 
   if (replyToMessageId) {
     // Send as a threaded reply.
-    // 规范化 message_id，处理合成 ID（如 "om_xxx:auth-complete"）
     const normalizedId = normalizeMessageId(replyToMessageId);
-    const response = await runWithMessageUnavailableGuard({
-      messageId: normalizedId,
-      operation: 'im.message.reply(post)',
-      fn: () =>
-        client.im.message.reply({
-          path: {
-            message_id: normalizedId!,
-          },
-          data: {
-            content: contentPayload,
-            msg_type: 'post',
-            reply_in_thread: replyInThread,
-          },
-        }),
-    });
+    try {
+      const response = await runWithMessageUnavailableGuard({
+        messageId: normalizedId,
+        operation: 'im.message.reply(post)',
+        fn: () =>
+          client.im.message.reply({
+            path: {
+              message_id: normalizedId!,
+            },
+            data: {
+              content: contentPayload,
+              msg_type: 'post',
+              reply_in_thread: replyInThread,
+            },
+          }),
+      });
 
-    recordFeishuSendSentinels(normalizationAccountId, to, threadId, normalizationSentinels);
-    return {
-      messageId: response?.data?.message_id ?? '',
-      chatId: response?.data?.chat_id ?? '',
-    };
+      recordFeishuSendSentinels(normalizationAccountId, to, threadId, normalizationSentinels);
+      return {
+        messageId: response?.data?.message_id ?? '',
+        chatId: response?.data?.chat_id ?? '',
+      };
+    } catch (err) {
+      // When the reply target has been recalled (230011) or deleted (231003),
+      // fall back to sending as a top-level message instead of silently
+      // losing the reply.  Other errors are propagated as-is.
+      if (isMessageUnavailableError(err)) {
+        sendLog.warn(
+          `reply target ${replyToMessageId} unavailable (${err.apiCode}), falling back to top-level send`,
+        );
+      } else {
+        throw err;
+      }
+    }
   }
 
   // Send as a new message.
@@ -290,28 +302,40 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
   const contentPayload = JSON.stringify(card);
 
   if (replyToMessageId) {
-    // 规范化 message_id，处理合成 ID（如 "om_xxx:auth-complete"）
     const normalizedId = normalizeMessageId(replyToMessageId);
-    const response = await runWithMessageUnavailableGuard({
-      messageId: normalizedId,
-      operation: 'im.message.reply(interactive)',
-      fn: () =>
-        client.im.message.reply({
-          path: {
-            message_id: normalizedId!,
-          },
-          data: {
-            content: contentPayload,
-            msg_type: 'interactive',
-            reply_in_thread: replyInThread,
-          },
-        }),
-    });
+    try {
+      const response = await runWithMessageUnavailableGuard({
+        messageId: normalizedId,
+        operation: 'im.message.reply(interactive)',
+        fn: () =>
+          client.im.message.reply({
+            path: {
+              message_id: normalizedId!,
+            },
+            data: {
+              content: contentPayload,
+              msg_type: 'interactive',
+              reply_in_thread: replyInThread,
+            },
+          }),
+      });
 
-    return {
-      messageId: response?.data?.message_id ?? '',
-      chatId: response?.data?.chat_id ?? '',
-    };
+      return {
+        messageId: response?.data?.message_id ?? '',
+        chatId: response?.data?.chat_id ?? '',
+      };
+    } catch (err) {
+      // When the reply target has been recalled (230011) or deleted (231003),
+      // fall back to sending as a top-level card instead of silently
+      // losing the reply.  Other errors are propagated as-is.
+      if (isMessageUnavailableError(err)) {
+        sendLog.warn(
+          `reply target ${replyToMessageId} unavailable (${err.apiCode}), falling back to top-level card send`,
+        );
+      } else {
+        throw err;
+      }
+    }
   }
 
   const target = normalizeFeishuTarget(to);

--- a/tests/reply-fallback-mode.test.ts
+++ b/tests/reply-fallback-mode.test.ts
@@ -1,32 +1,110 @@
 /**
- * Tests for replyFallbackOnWithdrawn account-scoped config resolution.
+ * Tests for replyFallbackOnWithdrawn account-scoped config resolution
+ * and silent-discard regression guards (sentinel leak, cache symmetry).
  */
 
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ClawdbotConfig } from 'openclaw/plugin-sdk';
 import { getLarkAccount } from '../src/core/accounts';
 import { getReplyFallbackMode } from '../src/messaging/outbound/send';
+
+// ---------------------------------------------------------------------------
+// Deliver-path mocks (hoisted)
+// ---------------------------------------------------------------------------
+
+const mockReply = vi.fn();
+const mockCreate = vi.fn();
+
+vi.mock('../src/core/lark-client', () => ({
+  LarkClient: {
+    fromCfg: () => ({
+      sdk: {
+        im: {
+          message: {
+            reply: (...args: unknown[]) => mockReply(...args),
+            create: (...args: unknown[]) => mockCreate(...args),
+          },
+        },
+      },
+    }),
+  },
+}));
+
+vi.mock('../src/core/lark-logger', () => ({
+  larkLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+vi.mock('../src/core/accounts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/core/accounts')>();
+  return {
+    ...actual,
+    getLarkAccount: vi.fn().mockReturnValue({
+      accountId: 'test-account',
+      config: {},
+      enabled: true,
+      configured: true,
+    }),
+  };
+});
+
+vi.mock('../src/messaging/outbound/normalize-mentions', () => ({
+  normalizeOutboundMentions: vi.fn().mockResolvedValue({
+    normalizedText: 'normalized',
+    sentinels: [{ key: 's1', text: 'sentinel-text', ts: Date.now() }],
+  }),
+}));
+
+vi.mock('../src/channel/chat-queue', () => ({
+  threadScopedKey: (chatId: string, threadId?: string) => `${chatId}:${threadId ?? ''}`,
+}));
+
+vi.mock('../src/messaging/inbound/sentinel-store', () => ({
+  getSentinelStore: vi.fn().mockReturnValue({
+    recordSentinels: vi.fn(),
+  }),
+}));
+
+// Import after mocks
+import { sendTextLark } from '../src/messaging/outbound/deliver';
+import { markMessageUnavailable } from '../src/core/message-unavailable';
+import { getSentinelStore } from '../src/messaging/inbound/sentinel-store';
+
+vi.mock('../src/core/message-unavailable', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/core/message-unavailable')>();
+  return {
+    ...actual,
+    markMessageUnavailable: vi.fn(actual.markMessageUnavailable),
+  };
+});
+
+const mockMarkMessageUnavailable = vi.mocked(markMessageUnavailable);
+const mockGetSentinelStore = vi.mocked(getSentinelStore);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 function makeCfg(feishu: Record<string, unknown>): ClawdbotConfig {
   return { channels: { feishu } } as unknown as ClawdbotConfig;
 }
 
+function makeTerminalError(code: number) {
+  return { response: { data: { code } } };
+}
+
+// ---------------------------------------------------------------------------
+// getReplyFallbackMode – account-scoped resolution
+// ---------------------------------------------------------------------------
+
 describe('getReplyFallbackMode – account-scoped resolution', () => {
   it('defaults to silent when no config is set', () => {
-    const cfg = makeCfg({
-      appId: 'a',
-      appSecret: 'sa',
-    });
+    const cfg = makeCfg({ appId: 'a', appSecret: 'sa' });
     expect(getReplyFallbackMode(cfg)).toBe('silent');
     expect(getReplyFallbackMode(cfg, 'main')).toBe('silent');
   });
 
   it('reads top-level replyFallbackOnWithdrawn', () => {
-    const cfg = makeCfg({
-      appId: 'a',
-      appSecret: 'sa',
-      replyFallbackOnWithdrawn: 'top-level',
-    });
+    const cfg = makeCfg({ appId: 'a', appSecret: 'sa', replyFallbackOnWithdrawn: 'top-level' });
     expect(getReplyFallbackMode(cfg)).toBe('top-level');
   });
 
@@ -39,9 +117,7 @@ describe('getReplyFallbackMode – account-scoped resolution', () => {
         'bot-b': { appId: 'b', appSecret: 'sb', replyFallbackOnWithdrawn: 'top-level' },
       },
     });
-    // Top-level is 'silent'
     expect(getReplyFallbackMode(cfg)).toBe('silent');
-    // Account 'bot-b' overrides to 'top-level'
     expect(getReplyFallbackMode(cfg, 'bot-b')).toBe('top-level');
   });
 
@@ -66,5 +142,96 @@ describe('getReplyFallbackMode – account-scoped resolution', () => {
       },
     });
     expect(getReplyFallbackMode(cfg, 'bot-b')).toBe('silent');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Silent-discard regression guards
+// ---------------------------------------------------------------------------
+
+describe('sendTextLark – silent-discard regression guards', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: create returns a valid result for top-level fallback path
+    mockCreate.mockResolvedValue({
+      data: { message_id: 'om_created', chat_id: 'oc_chat' },
+    });
+  });
+
+  it('does NOT record sentinels when reply is silently discarded (230011)', async () => {
+    // im.message.reply throws 230011 (message recalled)
+    mockReply.mockRejectedValue(makeTerminalError(230011));
+
+    const cfg = makeCfg({ appId: 'a', appSecret: 'sa', replyFallbackOnWithdrawn: 'silent' });
+
+    const result = await sendTextLark({
+      cfg,
+      to: 'oc_chat',
+      text: 'hello',
+      replyToMessageId: 'om_recalled',
+    });
+
+    // Silent discard → empty messageId
+    expect(result.messageId).toBe('');
+
+    // Sentinels must NOT be recorded (the message was never sent)
+    expect(mockGetSentinelStore).not.toHaveBeenCalled();
+  });
+
+  it('marks unavailable cache on 230011 terminal error in deliver path', async () => {
+    mockReply.mockRejectedValue(makeTerminalError(230011));
+
+    const cfg = makeCfg({ appId: 'a', appSecret: 'sa', replyFallbackOnWithdrawn: 'silent' });
+
+    await sendTextLark({
+      cfg,
+      to: 'oc_chat',
+      text: 'hello',
+      replyToMessageId: 'om_recalled',
+    });
+
+    expect(mockMarkMessageUnavailable).toHaveBeenCalledWith({
+      messageId: 'om_recalled',
+      apiCode: 230011,
+      operation: 'im.message.reply(post)',
+    });
+  });
+
+  it('marks unavailable cache on 231003 terminal error in deliver path', async () => {
+    mockReply.mockRejectedValue(makeTerminalError(231003));
+
+    const cfg = makeCfg({ appId: 'a', appSecret: 'sa', replyFallbackOnWithdrawn: 'silent' });
+
+    await sendTextLark({
+      cfg,
+      to: 'oc_chat',
+      text: 'hello',
+      replyToMessageId: 'om_deleted',
+    });
+
+    expect(mockMarkMessageUnavailable).toHaveBeenCalledWith({
+      messageId: 'om_deleted',
+      apiCode: 231003,
+      operation: 'im.message.reply(post)',
+    });
+  });
+
+  it('records sentinels normally on successful reply', async () => {
+    mockReply.mockResolvedValue({
+      data: { message_id: 'om_reply', chat_id: 'oc_chat' },
+    });
+
+    const cfg = makeCfg({ appId: 'a', appSecret: 'sa' });
+
+    const result = await sendTextLark({
+      cfg,
+      to: 'oc_chat',
+      text: 'hello',
+      replyToMessageId: 'om_original',
+      threadId: 'om_thread',
+    });
+
+    expect(result.messageId).toBe('om_reply');
+    expect(mockGetSentinelStore).toHaveBeenCalled();
   });
 });

--- a/tests/reply-fallback-mode.test.ts
+++ b/tests/reply-fallback-mode.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for replyFallbackOnWithdrawn account-scoped config resolution.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { ClawdbotConfig } from 'openclaw/plugin-sdk';
+import { getLarkAccount } from '../src/core/accounts';
+import { getReplyFallbackMode } from '../src/messaging/outbound/send';
+
+function makeCfg(feishu: Record<string, unknown>): ClawdbotConfig {
+  return { channels: { feishu } } as unknown as ClawdbotConfig;
+}
+
+describe('getReplyFallbackMode – account-scoped resolution', () => {
+  it('defaults to silent when no config is set', () => {
+    const cfg = makeCfg({
+      appId: 'a',
+      appSecret: 'sa',
+    });
+    expect(getReplyFallbackMode(cfg)).toBe('silent');
+    expect(getReplyFallbackMode(cfg, 'main')).toBe('silent');
+  });
+
+  it('reads top-level replyFallbackOnWithdrawn', () => {
+    const cfg = makeCfg({
+      appId: 'a',
+      appSecret: 'sa',
+      replyFallbackOnWithdrawn: 'top-level',
+    });
+    expect(getReplyFallbackMode(cfg)).toBe('top-level');
+  });
+
+  it('account override takes precedence over top-level', () => {
+    const cfg = makeCfg({
+      appId: 'a',
+      appSecret: 'sa',
+      replyFallbackOnWithdrawn: 'silent',
+      accounts: {
+        'bot-b': { appId: 'b', appSecret: 'sb', replyFallbackOnWithdrawn: 'top-level' },
+      },
+    });
+    // Top-level is 'silent'
+    expect(getReplyFallbackMode(cfg)).toBe('silent');
+    // Account 'bot-b' overrides to 'top-level'
+    expect(getReplyFallbackMode(cfg, 'bot-b')).toBe('top-level');
+  });
+
+  it('account inherits top-level value when no override is set', () => {
+    const cfg = makeCfg({
+      appId: 'a',
+      appSecret: 'sa',
+      replyFallbackOnWithdrawn: 'top-level',
+      accounts: {
+        'bot-b': { appId: 'b', appSecret: 'sb' },
+      },
+    });
+    expect(getReplyFallbackMode(cfg, 'bot-b')).toBe('top-level');
+  });
+
+  it('defaults to silent when account exists but has no override and no top-level value', () => {
+    const cfg = makeCfg({
+      appId: 'a',
+      appSecret: 'sa',
+      accounts: {
+        'bot-b': { appId: 'b', appSecret: 'sb' },
+      },
+    });
+    expect(getReplyFallbackMode(cfg, 'bot-b')).toBe('silent');
+  });
+});


### PR DESCRIPTION
## Summary

When replying to a message that has been withdrawn (error code 230011) or deleted (231003), the Feishu API returns a terminal error. Previously the reply was silently lost. This PR adds a configurable fallback strategy so the behavior can be tuned per deployment.

## Scenarios

**Scenario A — Group chat (reply may be valuable):**
User A asks a question in a group chat. The bot starts processing (AI inference takes a few seconds). During that time, User A withdraws the message. Other group members are still waiting for the answer. With `replyFallbackOnWithdrawn: 'top-level'`, the bot's response is delivered as a new message at the top level of the chat, so everyone can still see it.

**Scenario B — Private chat / user intent (reply should be suppressed):**
User sends a message, then realizes it was a mistake and withdraws it. The bot replies anyway, exposing content the user wanted to hide. With `replyFallbackOnWithdrawn: 'silent'` (default), the reply is silently discarded, respecting the user's intent.

**Future improvement — Stop AI inference on withdrawal:**
The ideal behavior is to stop AI inference immediately when the message is withdrawn, rather than waiting for inference to complete and then discarding the reply. This would save compute and respond faster. This requires core OpenClaw support for interrupting in-progress inference based on channel events (see [openclaw/openclaw#XXXX](https://github.com/anthropics/openclaw/issues/XXXX)).

## Configuration

New optional config field under `channels.feishu` (or per-account):

```json
{
  "channels": {
    "feishu": {
      "replyFallbackOnWithdrawn": "top-level"
    }
  }
}
```

| Value | Behavior |
|-------|----------|
| `'silent'` (default) | Silently discard the reply — respects user intent |
| `'top-level'` | Fall back to sending as a new message at the top level of the chat |

## Scope

This PR covers the **static reply path** — `sendMessageFeishu()`, `sendCardFeishu()`, and `sendImMessage()` in `deliver.ts`. These are the code paths where a reply is sent as a single API call with no subsequent updates.

## Changes

- **`src/core/config-schema.ts`** — Add `replyFallbackOnWithdrawn` enum field to `FeishuAccountConfigSchema`
- **`src/messaging/outbound/send.ts`** — `sendMessageFeishu()` and `sendCardFeishu()`: read config, conditionally fallback or discard
- **`src/messaging/outbound/deliver.ts`** — `sendImMessage()`: accept fallback mode param, pass from `sendTextLark`/`sendCardLark`; guard sentinel recording on silent discard; call `markMessageUnavailable` for cache symmetry with `send.ts`
- **`tests/reply-fallback-mode.test.ts`** — Account-scoped config resolution + regression tests for sentinel leak and cache symmetry

## How it works

Both `send.ts` functions already had separate reply and create code paths. The reply path is wrapped in a try/catch that only intercepts message-unavailable errors; all other errors propagate normally. When caught, the config is checked:
- `'silent'` → returns empty result immediately (default)
- `'top-level'` → execution falls through to the create path below

`deliver.ts`'s `sendImMessage` catches the raw API error codes directly, with the fallback mode passed as a parameter from callers. On silent discard, sentinel recording is skipped (empty messageId = nothing was sent). The unavailable cache is updated symmetrically with `send.ts`'s `runWithMessageUnavailableGuard`.

## Known limitation

**CardKit streaming path** (`sendCardByCardId` in `cardkit.ts`): In streaming mode, the 230011 error may occur during card update (not initial send). The streaming controller catches `MessageUnavailableError` and falls back to `sendCardFeishu`, which also checks the unavailable cache — so the cache-based guard already short-circuits correctly. The explicit `replyFallbackOnWithdrawn` fallback logic does not apply here since the initial send already succeeded. This is an inherent limitation of the streaming architecture and does not affect the static reply paths covered by this PR.

## Related

- Upstream: openclaw/openclaw#79349
- Adaptation plan for OpenClaw v2026.5.10-beta.5 (变更 2)

@evandance Key decisions to review:
1. Default is now `'silent'` — withdrawn message = no reply (safer for most users)
2. `'top-level'` is opt-in for group chat scenarios
3. Future: stop AI inference on withdrawal (requires core support)

## Test plan

- [x] `pnpm lint` — no new errors
- [x] `pnpm test` — 295 tests pass (including 4 new regression tests)
- [x] Manual test (silent, default): send a message, withdraw it → verify no reply
- [x] Manual test (top-level): set `replyFallbackOnWithdrawn: 'top-level'`, repeat → verify reply at top level