### PR TITLE
fix(vc): parse meet_number from video_chat with word labels

### DIFF
--- a/src/messaging/converters/video-chat.ts
+++ b/src/messaging/converters/video-chat.ts
@@ -13,18 +13,24 @@ export const convertVideoChat: ContentConverterFn = (raw) => {
     | {
         topic?: string;
         start_time?: string;
+        meet_number?: string;
       }
     | undefined;
 
   const topic = parsed?.topic ?? '';
+  const meetingNo = parsed?.meet_number?.trim() ?? '';
   const parts: string[] = [];
 
   if (topic) {
-    parts.push(`📹 ${topic}`);
+    parts.push(`Topic: ${topic}`);
   }
 
   if (parsed?.start_time) {
-    parts.push(`🕙 ${millisToDatetime(parsed.start_time)}`);
+    parts.push(`Start time: ${millisToDatetime(parsed.start_time)}`);
+  }
+
+  if (meetingNo) {
+    parts.push(`Meeting number: ${meetingNo}`);
   }
 
   const inner = parts.join('\n') || '[video chat]';


### PR DESCRIPTION
## Summary
- `convertVideoChat` 之前只解析 `topic` 和 `start_time`，丢失了消息体里的 `meet_number` 字段，导致 `<meeting>` 块对下游 Agent 不可见会议号，无法与 VC 事件路径里的同一会议关联或据此入会。
- 本次在 `video_chat` payload schema 中补上 `meet_number`；同时把 `<meeting>` 块的字段标签从 emoji icon (`📹` / `🕙` / `🆔`) 改为英文词标签 (`Topic:` / `Start time:` / `Meeting number:`)，让下游 Agent 收到的语义更明确（端到端验证时观察到 agent 会把 `🆔` 二次翻译为 `meeting_id`，词标签可避免这种命名漂移）。
- 各字段均按"非空才输出"渲染，向后兼容现有消费者。

## Test plan
- [x] 本地构造 `video_chat` 消息，验证 `<meeting>` 块包含 `Meeting number: <会议号>` 行
- [x] `meet_number` 缺失时回退到原有输出，不出现空 `Meeting number:` 行
- [x] 端到端验证：飞书发起会议邀请卡片，Agent 能从消息中读到会议号（实测会议号 311763680 / 777242820 均被 agent 准确报出）