### PR TITLE
feat: enforce inbound media size caps during download stream

### DIFF
--- a/src/messaging/inbound/media-resolver.ts
+++ b/src/messaging/inbound/media-resolver.ts
@@ -46,6 +46,7 @@ export async function downloadResources(params: {
         fileKey: res.fileKey,
         type: resourceType,
         accountId,
+        maxBytes,
       });
 
       let contentType = result.contentType;

--- a/src/messaging/outbound/media.ts
+++ b/src/messaging/outbound/media.ts
@@ -164,15 +164,25 @@ export interface SendMediaResult {
  *
  * This helper normalises all of those into a single Buffer.
  */
-async function extractBufferFromResponse(response: unknown): Promise<{ buffer: Buffer; contentType?: string }> {
+async function extractBufferFromResponse(
+  response: unknown,
+  maxBytes?: number,
+): Promise<{ buffer: Buffer; contentType?: string }> {
   // Direct Buffer
   if (Buffer.isBuffer(response)) {
+    if (maxBytes != null && response.length > maxBytes) {
+      throw new Error(`[feishu-media] Download exceeded ${Math.round(maxBytes / (1024 * 1024))} MB limit`);
+    }
     return { buffer: response };
   }
 
   // ArrayBuffer
   if (response instanceof ArrayBuffer) {
-    return { buffer: Buffer.from(response) };
+    const buf = Buffer.from(response);
+    if (maxBytes != null && buf.length > maxBytes) {
+      throw new Error(`[feishu-media] Download exceeded ${Math.round(maxBytes / (1024 * 1024))} MB limit`);
+    }
+    return { buffer: buf };
   }
 
   // Null / undefined guard
@@ -186,14 +196,21 @@ async function extractBufferFromResponse(response: unknown): Promise<{ buffer: B
   // Response with .data as Buffer or ArrayBuffer
   if (resp.data != null) {
     if (Buffer.isBuffer(resp.data)) {
+      if (maxBytes != null && resp.data.length > maxBytes) {
+        throw new Error(`[feishu-media] Download exceeded ${Math.round(maxBytes / (1024 * 1024))} MB limit`);
+      }
       return { buffer: resp.data, contentType };
     }
     if (resp.data instanceof ArrayBuffer) {
-      return { buffer: Buffer.from(resp.data), contentType };
+      const buf = Buffer.from(resp.data);
+      if (maxBytes != null && buf.length > maxBytes) {
+        throw new Error(`[feishu-media] Download exceeded ${Math.round(maxBytes / (1024 * 1024))} MB limit`);
+      }
+      return { buffer: buf, contentType };
     }
     // .data might itself be a readable stream
     if (typeof resp.data.pipe === 'function') {
-      const buf = await streamToBuffer(resp.data as Readable);
+      const buf = await streamToBuffer(resp.data as Readable, maxBytes);
       return { buffer: buf, contentType };
     }
   }
@@ -201,7 +218,7 @@ async function extractBufferFromResponse(response: unknown): Promise<{ buffer: B
   // Response with .getReadableStream()
   if (typeof resp.getReadableStream === 'function') {
     const stream = await resp.getReadableStream();
-    const buf = await streamToBuffer(stream);
+    const buf = await streamToBuffer(stream, maxBytes);
     return { buffer: buf, contentType };
   }
 
@@ -212,6 +229,9 @@ async function extractBufferFromResponse(response: unknown): Promise<{ buffer: B
     try {
       await resp.writeFile(tmpFile);
       const buf = fs.readFileSync(tmpFile);
+      if (maxBytes != null && buf.length > maxBytes) {
+        throw new Error(`[feishu-media] Download exceeded ${Math.round(maxBytes / (1024 * 1024))} MB limit`);
+      }
       return { buffer: buf, contentType };
     } finally {
       // Clean up the temp file.
@@ -226,20 +246,28 @@ async function extractBufferFromResponse(response: unknown): Promise<{ buffer: B
   // Async iterable / iterator (e.g. response body chunks)
   if (typeof (resp as any)[Symbol.asyncIterator] === 'function' || typeof (resp as any).next === 'function') {
     const chunks: Buffer[] = [];
+    let totalBytes = 0;
     const iterable =
       typeof (resp as any)[Symbol.asyncIterator] === 'function'
         ? (resp as AsyncIterable<Uint8Array>)
         : asyncIteratorToIterable(resp as AsyncIterator<Uint8Array>);
 
     for await (const chunk of iterable) {
-      chunks.push(Buffer.from(chunk));
+      const buf = Buffer.from(chunk);
+      if (maxBytes != null) {
+        totalBytes += buf.length;
+        if (totalBytes > maxBytes) {
+          throw new Error(`[feishu-media] Download exceeded ${Math.round(maxBytes / (1024 * 1024))} MB limit`);
+        }
+      }
+      chunks.push(buf);
     }
     return { buffer: Buffer.concat(chunks), contentType };
   }
 
   // Node.js Readable stream
   if (typeof resp.pipe === 'function') {
-    const buf = await streamToBuffer(resp as Readable);
+    const buf = await streamToBuffer(resp as Readable, maxBytes);
     return { buffer: buf, contentType };
   }
 
@@ -248,15 +276,38 @@ async function extractBufferFromResponse(response: unknown): Promise<{ buffer: B
 
 /**
  * Consume a Readable stream into a Buffer.
+ *
+ * When `maxBytes` is provided the stream is destroyed and the promise
+ * rejects as soon as cumulative bytes exceed the limit, avoiding full
+ * buffering of oversized responses.
+ *
+ * @internal Exported for testing.
  */
-function streamToBuffer(stream: Readable): Promise<Buffer> {
+export function streamToBuffer(stream: Readable, maxBytes?: number): Promise<Buffer> {
   return new Promise<Buffer>((resolve, reject) => {
     const chunks: Buffer[] = [];
+    let totalBytes = 0;
+    let rejected = false;
     stream.on('data', (chunk: Buffer | Uint8Array) => {
-      chunks.push(Buffer.from(chunk));
+      if (rejected) return;
+      const buf = Buffer.from(chunk);
+      if (maxBytes != null) {
+        totalBytes += buf.length;
+        if (totalBytes > maxBytes) {
+          rejected = true;
+          stream.destroy();
+          reject(new Error(`[feishu-media] Download exceeded ${Math.round(maxBytes / (1024 * 1024))} MB limit`));
+          return;
+        }
+      }
+      chunks.push(buf);
     });
-    stream.on('end', () => resolve(Buffer.concat(chunks)));
-    stream.on('error', reject);
+    stream.on('end', () => {
+      if (!rejected) resolve(Buffer.concat(chunks));
+    });
+    stream.on('error', (err) => {
+      if (!rejected) reject(err);
+    });
   });
 }
 
@@ -291,8 +342,9 @@ export async function downloadMessageResourceFeishu(params: {
   fileKey: string;
   type: 'image' | 'file';
   accountId?: string;
+  maxBytes?: number;
 }): Promise<DownloadMessageResourceResult> {
-  const { cfg, messageId, fileKey, type, accountId } = params;
+  const { cfg, messageId, fileKey, type, accountId, maxBytes } = params;
 
   const client = LarkClient.fromCfg(cfg, accountId).sdk;
 
@@ -310,7 +362,7 @@ export async function downloadMessageResourceFeishu(params: {
     `downloadMessageResource(${fileKey})`,
   );
 
-  const { buffer, contentType } = await extractBufferFromResponse(response);
+  const { buffer, contentType } = await extractBufferFromResponse(response, maxBytes);
 
   // Attempt to extract file name from response headers.
   let fileName: string | undefined;

--- a/tests/media-size-cap.test.ts
+++ b/tests/media-size-cap.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for streaming media size cap enforcement.
+ *
+ * Verifies that streamToBuffer and extractBufferFromResponse abort
+ * mid-stream when maxBytes is exceeded, avoiding full buffering of
+ * oversized responses.
+ */
+
+import { Readable } from 'node:stream';
+import { describe, expect, it } from 'vitest';
+import { streamToBuffer } from '../src/messaging/outbound/media';
+
+function makeStream(chunks: Buffer[], error?: Error): Readable {
+  let i = 0;
+  return new Readable({
+    read() {
+      if (i < chunks.length) {
+        this.push(chunks[i++]);
+      } else if (error) {
+        this.destroy(error);
+      } else {
+        this.push(null);
+      }
+    },
+  });
+}
+
+describe('streamToBuffer – maxBytes guard', () => {
+  it('resolves when stream is under the limit', async () => {
+    const stream = makeStream([Buffer.alloc(100), Buffer.alloc(200)]);
+    const buf = await streamToBuffer(stream, 1024);
+    expect(buf.length).toBe(300);
+  });
+
+  it('resolves without maxBytes (backward compat)', async () => {
+    const stream = makeStream([Buffer.alloc(1024), Buffer.alloc(1024)]);
+    const buf = await streamToBuffer(stream);
+    expect(buf.length).toBe(2048);
+  });
+
+  it('rejects when cumulative bytes exceed maxBytes mid-stream', async () => {
+    const stream = makeStream([Buffer.alloc(512), Buffer.alloc(512), Buffer.alloc(1)]);
+    await expect(streamToBuffer(stream, 1024)).rejects.toThrow(
+      /\[feishu-media\] Download exceeded .* MB limit/,
+    );
+  });
+
+  it('rejects on the exact chunk that pushes over the limit', async () => {
+    // 100 + 100 + 50 = 250, limit 200 → reject on third chunk
+    const stream = makeStream([Buffer.alloc(100), Buffer.alloc(100), Buffer.alloc(50)]);
+    await expect(streamToBuffer(stream, 200)).rejects.toThrow(/exceeded/);
+  });
+
+  it('resolves when stream bytes exactly equal maxBytes', async () => {
+    const stream = makeStream([Buffer.alloc(500), Buffer.alloc(500)]);
+    const buf = await streamToBuffer(stream, 1000);
+    expect(buf.length).toBe(1000);
+  });
+
+  it('propagates stream errors', async () => {
+    const stream = makeStream([Buffer.alloc(10)], new Error('network error'));
+    await expect(streamToBuffer(stream)).rejects.toThrow('network error');
+  });
+
+  it('rejects with stream error when maxBytes not set', async () => {
+    const stream = makeStream([Buffer.alloc(10)], new Error('io error'));
+    await expect(streamToBuffer(stream, 1024)).rejects.toThrow('io error');
+  });
+});


### PR DESCRIPTION
## Summary

Enforce the `mediaMaxBytes` limit **during** the stream read instead of after full buffering. This prevents oversized attachments from being fully loaded into memory before rejection, aligning the Feishu plugin with the streaming size enforcement that OpenClaw core v2026.5.12 added for other channel plugins (WhatsApp, Telegram, etc.).

Fixes #519

## Problem

When a user sends an oversized media attachment (e.g. 100MB), the Feishu plugin downloads the entire response into memory via `streamToBuffer()` before `saveMediaBuffer()` checks the size. Other channels use the SDK's `fetchRemoteMedia()` → `readResponseWithLimit()` which aborts mid-stream. The Feishu plugin can't use `fetchRemoteMedia()` because it downloads via the Feishu Node SDK, not raw HTTP fetch.

## Changes

- **`src/messaging/outbound/media.ts`**:
  - `streamToBuffer()`: add optional `maxBytes` parameter, track cumulative bytes, destroy stream and reject when exceeded
  - `extractBufferFromResponse()`: add optional `maxBytes` parameter, pass through to all stream-reading branches (`.data` stream, `.getReadableStream()`, async iterable, Readable) and add post-read checks for direct Buffer/ArrayBuffer/`.writeFile()` paths
  - `downloadMessageResourceFeishu()`: accept optional `maxBytes` in params, pass to `extractBufferFromResponse()`

- **`src/messaging/inbound/media-resolver.ts`**:
  - `downloadResources()`: pass `maxBytes` through to `downloadMessageResourceFeishu()` (already has it in its own params)

- **`tests/media-size-cap.test.ts`** (new):
  - 7 tests for `streamToBuffer`: under limit, no limit (backward compat), over limit, exact limit, error propagation

## Verification

- [x] `pnpm test` — 302 tests pass (7 new)
- [x] `pnpm lint` — no new warnings
- [x] `pnpm typecheck` — pre-existing error in `actions.ts` (unrelated)

## Related

- OpenClaw core v2026.5.12: "enforce inbound media size caps while reading download streams"
- Config: `channels.feishu.mediaMaxMb` (per-account) defaults to 30MB