### PR TITLE
fix(build): avoid literal import.meta in src files for Node 22+ CJS compat

### DIFF
--- a/src/core/token-store.ts
+++ b/src/core/token-store.ts
@@ -29,8 +29,17 @@ import { larkLogger } from './lark-logger';
 const log = larkLogger('core/token-store');
 
 // Dynamic require to avoid security scanner false positive (child-process).
-// CJS (tsc output) has __filename; ESM (tsdown output) has import.meta.url.
-const _require = createRequire(typeof __filename !== 'undefined' ? __filename : import.meta.url);
+//
+// Both compile targets must work without a literal `import.meta` token in
+// source — see the long comment at the top of `./version.ts` for why a
+// `typeof __filename` guard around `import.meta.url` is not enough.
+//
+// We resolve `node:child_process` via `createRequire(__filename)` in CJS
+// output (Node's CJS wrapper provides `__filename`) and fall back to
+// `process.execPath` in ESM output. `createRequire`'s path argument is only
+// used as a base for relative resolution; `node:`-prefixed built-ins resolve
+// from anywhere, so any valid filesystem path works for the fallback.
+const _require = createRequire(typeof __filename === 'string' ? __filename : process.execPath);
 const _cpMod = ['child', 'process'].join('_');
 const _cp = _require(`node:${_cpMod}`) as typeof import('node:child_process');
 const execFile = promisify(_cp.execFile);

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -2,32 +2,62 @@
  * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
  * SPDX-License-Identifier: MIT
  *
- * 插件版本号管理
+ * Plugin version management.
  *
- * 从 package.json 读取版本号并生成 User-Agent 字符串。
+ * Reads the version from package.json and builds the User-Agent string.
+ *
+ * IMPORTANT: this file MUST NOT contain a literal `import.meta` token.
+ * Node 22+ detects ESM by scanning for ESM-only syntax (top-level
+ * `import`/`export`, top-level `await`, or any `import.meta` reference). If a
+ * downstream build pipeline emits this file with CommonJS-style `exports.*`
+ * assignments while preserving the `import.meta` token in the source, Node
+ * loads the file via the ESM loader, silently discarding every
+ * `exports.*` assignment. The module then appears as an empty namespace and
+ * every call site of `getUserAgent()` / `getPluginVersion()` throws
+ * `TypeError: getUserAgent is not a function` at runtime.
+ *
+ * Strategy: inject the version string at build time via tsdown's `define`
+ * (see `tsdown.config.ts`). A CJS-safe fallback reads `package.json` via
+ * the CJS `__dirname` global for any compile path where the define is not
+ * applied.
  */
 
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
 import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
-/** 缓存的版本号 */
+/** Build-time injected version. Undefined when the build step did not run. */
+declare const __PLUGIN_VERSION__: string | undefined;
+
+/** Cached version string. */
 let cachedVersion: string | undefined;
 
 /**
- * 获取插件版本号（从 package.json 读取）
+ * Return the plugin version. Build-time injection wins; otherwise read
+ * `package.json` via the CJS `__dirname` global.
  *
- * @returns 版本号字符串，如 "2026.2.28.5"；读取失败返回 "unknown"
+ * @returns Version string such as "2026.5.13"; "unknown" on read failure.
  */
 export function getPluginVersion(): string {
   if (cachedVersion) return cachedVersion;
 
-  try {
-    // 当前文件: src/core/version.ts → 向上两级到达项目根目录
-    const __filename = fileURLToPath(import.meta.url);
-    const __dirname = dirname(__filename);
-    const packageJsonPath = join(__dirname, '..', '..', 'package.json');
+  // Fast path: build-time injection (tsdown ESM output).
+  // `typeof` on an undeclared identifier returns 'undefined' without throwing,
+  // so this is safe under any compile target.
+  if (typeof __PLUGIN_VERSION__ === 'string' && __PLUGIN_VERSION__) {
+    cachedVersion = __PLUGIN_VERSION__;
+    return cachedVersion;
+  }
 
+  // CJS fallback path. `__dirname` is provided by Node's CommonJS module
+  // wrapper, so this branch only runs in CJS-compiled output. ESM-compiled
+  // output always hits the fast path above.
+  try {
+    if (typeof __dirname !== 'string') {
+      cachedVersion = 'unknown';
+      return cachedVersion;
+    }
+    // Current file: src/core/version.ts → walk up two levels to repo root.
+    const packageJsonPath = join(__dirname, '..', '..', 'package.json');
     const raw = readFileSync(packageJsonPath, 'utf8');
     const pkg = JSON.parse(raw) as { version?: string };
     cachedVersion = pkg.version ?? 'unknown';

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,4 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 import { defineConfig } from 'tsdown';
+
+// Read the package version without `import` attributes (keeps tsconfig
+// `module: ES2022` compatible).
+const __pkgDir = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(
+  readFileSync(join(__pkgDir, 'package.json'), 'utf8'),
+) as { version: string };
 
 export default defineConfig({
   entry: {
@@ -11,6 +21,13 @@ export default defineConfig({
   clean: true,
   outDir: 'dist',
   dts: true,
+  // Inject the package version as a build-time constant so `src/core/version.ts`
+  // does not need to read `package.json` at runtime via `import.meta.url`.
+  // See the long comment at the top of `src/core/version.ts` for why a literal
+  // `import.meta` token in source breaks any downstream CJS compile under Node 22+.
+  define: {
+    __PLUGIN_VERSION__: JSON.stringify(pkg.version),
+  },
   deps: {
     neverBundle: [
       /^openclaw(\/.*)?$/,


### PR DESCRIPTION
## Symptom

Under Node 22+, importing `@larksuite/openclaw-lark` via `require()` returns a module with broken exports. Every consumer crashes with:

```
TypeError: (0 , version_1.getUserAgent) is not a function
```

…or, for `token-store.js`:

```
Error: Cannot find module './lark-logger.js'
    at file:///…/node_modules/@larksuite/openclaw-lark/src/core/token-store.js:33:23
```

(note the `file://` scheme — Node loaded a CJS-looking file via the ESM loader).

This makes the plugin unusable inside OpenClaw 2026.5.18 on a clean install:

- `openclaw doctor` flags `Plugin "openclaw-lark" failed post-core payload smoke check`
- `openclaw plugins inspect openclaw-lark --runtime --json` reports `status: loaded` and lists all 39 tools, but those entries come from the static manifest. Any code path that actually exercises `src/core/version.ts` (e.g. the User-Agent injection in `lark-client.js`, `mcp/shared.js`, `feishu-fetch.js`) throws at runtime, so no Feishu tool call succeeds.

## Root cause

Node 22+ uses **syntactic** detection to decide whether a `.js` file is ESM: the presence of `import.meta` anywhere in the parsed source — even inside an unreachable branch guarded by `typeof __filename !== 'undefined'` — is enough to make Node load the file via the ESM loader.

When the loader runs the file as ESM:

- the top-level `exports.X = X` assignments emitted by a downstream CJS compile become no-ops (there is no `exports` global in ESM scope),
- the relative `require('./lark-logger.js')` calls hit ESM resolution rules and fail because the relative paths aren't fully specified.

`src/core/version.ts` and `src/core/token-store.ts` both contain literal `import.meta.url` references. `src/core/version.ts` uses it unconditionally; `src/core/token-store.ts` guards it behind `typeof __filename !== 'undefined' ? __filename : import.meta.url`, but the guard runs at runtime, *after* Node has already decided the module is ESM.

The npm tarball ships CJS-shaped artifacts (`"use strict"; Object.defineProperty(exports, "__esModule", { value: true });` …) that preserve `import.meta.url` literally, so the bug bites every consumer on Node 22+.

## Reproduction

```bash
node --version  # v22 or later — tested on v25.9.0
node -e "const v = require('@larksuite/openclaw-lark/src/core/version.js'); console.log(Object.keys(v))"
# []   ← should print [ 'getPluginVersion', 'getPlatform', 'getUserAgent' ]

node -e "const v = require('@larksuite/openclaw-lark/src/core/version.js'); v.getUserAgent()"
# TypeError: v.getUserAgent is not a function
```

## Fix

Remove every literal `import.meta` token from `src/`:

- **`src/core/version.ts`**: inject the version at build time via tsdown's `define` (new `__PLUGIN_VERSION__` constant) and fall back to a CJS-safe `__dirname`-based `package.json` read. The fallback uses `typeof __dirname` so it is safe even when the symbol is absent (`typeof` never throws on undeclared identifiers).
- **`src/core/token-store.ts`**: use `createRequire(__filename)` in CJS output and `createRequire(process.execPath)` as a path-only fallback in ESM output. `createRequire`'s path argument is only used as a base for relative resolution; `node:`-prefixed built-ins resolve from any base, so any valid filesystem path works for the fallback.
- **`tsdown.config.ts`**: register `define: { __PLUGIN_VERSION__: JSON.stringify(pkg.version) }`. `package.json` is read with `node:fs` rather than via an import attribute so the config stays compatible with the repo's `tsconfig.json` (`module: ES2022`).

The remaining occurrences of the string `import.meta` live inside JSDoc comments, which the Node lexer skips. Comments do not trigger ESM auto-detection.

## Verification

- `pnpm typecheck` — passes
- `pnpm build` — `dist/index.mjs` and `dist/secret-contract-api.mjs` contain **zero** `import.meta` literals; `__PLUGIN_VERSION__` is inlined as the package version string (verified by `grep -c "import\.meta" dist/*.mjs` → `0` for every file)
- `pnpm test` — 36 files / 298 tests pass
- `pnpm format:check` — clean
- `pnpm lint` — no new findings (8 pre-existing errors / 29 pre-existing warnings on `main` are unchanged)
- `tsc --module commonjs` on each patched file individually emits CJS that loads cleanly under Node 25.9.0 via `require()`:

  ```bash
  node -e "console.log(require('./version.js').getUserAgent())"
  # openclaw-lark/unknown/mac  (unknown because `define` isn't applied in this isolated repro;
  #                             real builds inject the real version)

  node -e "console.log(Object.keys(require('./token-store.js')))"
  # [ 'maskToken', 'getStoredToken', 'setStoredToken', 'removeStoredToken', 'tokenStatus' ]
  ```

## Adjacent observation (not part of this PR)

The npm tarball published for `2026.5.13` contains files that aren't in the repo's `"files"` whitelist (`src/`, `test/`, `tsdown.config.js`, `vitest.config.js`, …) and lacks the `dist/` directory that `package.json#main` (`./dist/index.js`) and `package.json#exports` point at. Node emits `DEP0128 — Invalid 'main' field` on every load. The release tooling appears to ship a `tsc` CJS-style compile of the whole tree instead of (or in addition to) the tsdown ESM output, which is the deeper cause of the `import.meta` bug here. I filed a separate issue (#524) for that since it's outside the scope of this source-level fix.

## Test plan

- [ ] `pnpm install && pnpm typecheck && pnpm build && pnpm test`
- [ ] Inspect `dist/index.mjs` to confirm `__PLUGIN_VERSION__` is inlined and no `import.meta` literals remain
- [ ] Smoke-test the package under Node 22+: `require('@larksuite/openclaw-lark')` and call `feishuPlugin.id`