### PR TITLE
feat: 支持群聊 autoCreateThread 选项 (自动创建话题并隔离上下文)

### DIFF
--- a/src/core/config-schema.ts
+++ b/src/core/config-schema.ts
@@ -148,6 +148,7 @@ export const FeishuGroupSchema = z.object({
   allowFrom: AllowFromSchema,
   systemPrompt: z.string().optional(),
   allowBots: AllowBotsSchema,
+  autoCreateThread: z.enum(['disabled', 'enabled']).optional(),
 });
 
 // ---------------------------------------------------------------------------
@@ -197,6 +198,7 @@ export const FeishuAccountConfigSchema = z.object({
   reactionNotifications: ReactionNotificationModeSchema,
   threadSession: z.boolean().optional(),
   allowBots: AllowBotsSchema,
+  autoCreateThread: z.enum(['disabled', 'enabled']).optional(),
   uat: UATConfigSchema,
 });
 

--- a/src/messaging/inbound/dispatch-context.ts
+++ b/src/messaging/inbound/dispatch-context.ts
@@ -175,19 +175,22 @@ export async function resolveThreadSessionKey(params: {
   chatId: string;
   threadId: string;
   baseSessionKey: string;
+  forceIsolate?: boolean;
 }): Promise<string | undefined> {
-  const { accountScopedCfg, account, chatId, threadId, baseSessionKey } = params;
+  const { accountScopedCfg, account, chatId, threadId, baseSessionKey, forceIsolate } = params;
 
-  if (account.config?.threadSession !== true) return undefined;
+  if (!forceIsolate) {
+    if (account.config?.threadSession !== true) return undefined;
 
-  const threadCapable = await isThreadCapableGroup({
-    cfg: accountScopedCfg,
-    chatId,
-    accountId: account.accountId,
-  });
-  if (!threadCapable) {
-    log.info(`thread session skipped: group ${chatId} is not topic/thread mode`);
-    return undefined;
+    const threadCapable = await isThreadCapableGroup({
+      cfg: accountScopedCfg,
+      chatId,
+      accountId: account.accountId,
+    });
+    if (!threadCapable) {
+      log.info(`thread session skipped: group ${chatId} is not topic/thread mode`);
+      return undefined;
+    }
   }
 
   // 使用 SDK 标准函数，保证分隔符格式与 resolveThreadParentSessionKey 兼容

--- a/src/messaging/inbound/dispatch.ts
+++ b/src/messaging/inbound/dispatch.ts
@@ -370,14 +370,41 @@ export async function dispatchToAgent(params: {
     }
   }
 
-  // 1b. Resolve thread session isolation (async: may query group info API)
+  // 1b. Auto-create thread for new conversations when autoCreateThread is "enabled".
+  //     Unlike threadSession, this does NOT call isThreadCapableGroup — it trusts
+  //     the config directly and creates a new thread in the main group chat.
+  //     This mirrors the built-in channel behavior where autoCreateThread bypasses
+  //     the group capability check.
+  const autoCreateThreadCfg = dc.account?.config?.autoCreateThread === 'enabled';
+  const isFromThread = dc.isThread && dc.ctx.threadId; 
+  const shouldCreateAutoThread = !isFromThread && autoCreateThreadCfg && dc.isGroup;
+  const isFromExistingAutoThread = isFromThread && autoCreateThreadCfg && dc.isGroup;
+  if (shouldCreateAutoThread) {
+    log.info(`auto-thread: creating new thread in group ${dc.ctx.chatId}. Message ID: ${dc.ctx.messageId}`);
+    dc.isThread = true;
+    dc.ctx = { ...dc.ctx, threadId: dc.ctx.messageId };
+  } else if (isFromExistingAutoThread) {
+    // A hack to follow up automatically created threads.
+    if (!dc.ctx.rootId) {
+      log.warn(`auto-thread: no root ID for existing auto thread.`)
+    }
+    log.info(`auto-thread: continuing thread via root_id=${dc.ctx.rootId} in group
+        ${dc.ctx.chatId}. Thread ID is hacked from ${dc.ctx.threadId} to ${dc.ctx.rootId}`);
+    dc.ctx = { ...dc.ctx, threadId: dc.ctx.rootId };
+  } else {
+    log.info(`auto-thread: not proceeded`);
+  }
+
+  // 1c. Resolve thread session isolation (async: may query group info API)
   if (dc.isThread && dc.ctx.threadId) {
+    log.info(`Replying thread: ${dc.ctx.threadId}`);
     dc.threadSessionKey = await resolveThreadSessionKey({
       accountScopedCfg: dc.accountScopedCfg,
       account: dc.account,
       chatId: dc.ctx.chatId,
       threadId: dc.ctx.threadId,
       baseSessionKey: dc.route.sessionKey,
+      forceIsolate: autoCreateThreadCfg,
     });
   }
 


### PR DESCRIPTION
### Summary

- 新增 autoCreateThread 配置项（disabled / enabled），支持在群组和账号级别配置
- 开启后，bot 收到群聊非话题消息时，自动以该消息 ID 创建新话题作为 threadId，实现会话隔离
- 对话题内的后续消息，使用 rootId 作为 threadId 保持会话连续性
- resolveThreadSessionKey 增加 forceIsolate 参数，auto-thread 场景下跳过 threadSession 和 isThreadCapableGroup 检查
- 与原有 threadSession 互补：threadSession 依赖群聊话题模式，autoCreateThread 可在任意群聊中主动创建话题隔离

### Test plan
pnpm test — all tests pass
pnpm lint — no new warnings/errors
pnpm typecheck — no new warnings/errors