### PR TITLE
fix(channel): dispatch Schema 2 form submit actions by name

### DIFF
--- a/src/channel/interactive-dispatch.ts
+++ b/src/channel/interactive-dispatch.ts
@@ -26,7 +26,7 @@ interface FeishuCardActionTriggerEvent {
   open_chat_id?: string;
   open_message_id?: string;
   context?: { open_chat_id?: string; open_message_id?: string };
-  action?: { value?: { action?: string } };
+  action?: { value?: { action?: string }; name?: string };
 }
 
 function extractBasics(data: unknown): {
@@ -37,7 +37,7 @@ function extractBasics(data: unknown): {
 } | null {
   try {
     const ev = data as FeishuCardActionTriggerEvent;
-    const action = ev.action?.value?.action;
+    const action = ev.action?.value?.action ?? ev.action?.name;
     if (!action || typeof action !== 'string') return null;
     const openChatId = ev.open_chat_id ?? ev.context?.open_chat_id;
     const openMessageId = ev.open_message_id ?? ev.context?.open_message_id;

--- a/tests/interactive-dispatch.test.ts
+++ b/tests/interactive-dispatch.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  dispatchPluginInteractiveHandler: vi.fn(),
+  sendMessageFeishu: vi.fn(),
+  sendCardFeishu: vi.fn(),
+  updateCardFeishu: vi.fn(),
+}));
+
+vi.mock('openclaw/plugin-sdk/plugin-runtime', () => ({
+  dispatchPluginInteractiveHandler: mocks.dispatchPluginInteractiveHandler,
+}));
+
+vi.mock('../src/core/lark-logger', () => ({
+  larkLogger: () => ({ warn: vi.fn(), debug: vi.fn(), info: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock('../src/messaging/outbound/send', () => ({
+  sendMessageFeishu: mocks.sendMessageFeishu,
+  sendCardFeishu: mocks.sendCardFeishu,
+  updateCardFeishu: mocks.updateCardFeishu,
+}));
+
+import { dispatchFeishuPluginInteractiveHandler } from '../src/channel/interactive-dispatch';
+
+describe('dispatchFeishuPluginInteractiveHandler', () => {
+  it('dispatches legacy card actions from action.value.action', async () => {
+    const handler = vi.fn().mockReturnValue({ toast: { type: 'success', content: 'ok' } });
+    mocks.dispatchPluginInteractiveHandler.mockImplementationOnce(async ({ data, invoke }) => {
+      expect(data).toBe('followup_demo:submit');
+      await invoke({
+        registration: { handler },
+        namespace: 'followup_demo',
+        payload: 'submit',
+      });
+      return { matched: true };
+    });
+
+    const result = await dispatchFeishuPluginInteractiveHandler({
+      cfg: {} as never,
+      accountId: 'default',
+      data: {
+        operator: { open_id: 'ou_123' },
+        open_chat_id: 'oc_123',
+        open_message_id: 'om_123',
+        action: { value: { action: 'followup_demo:submit' } },
+      },
+    });
+
+    expect(result).toEqual({ toast: { type: 'success', content: 'ok' } });
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'followup_demo:submit',
+        namespace: 'followup_demo',
+        payload: 'submit',
+        senderId: 'ou_123',
+        conversationId: 'oc_123',
+        messageId: 'om_123',
+      }),
+    );
+  });
+
+  it('falls back to action.name for Schema 2 form submit callbacks', async () => {
+    const handler = vi.fn().mockReturnValue({ toast: { type: 'success', content: 'submitted' } });
+    mocks.dispatchPluginInteractiveHandler.mockImplementationOnce(async ({ data, invoke }) => {
+      expect(data).toBe('followup_demo:submit:fu_123');
+      await invoke({
+        registration: { handler },
+        namespace: 'followup_demo',
+        payload: 'submit:fu_123',
+      });
+      return { matched: true };
+    });
+
+    const event = {
+      operator: { user_id: 'ou_456' },
+      context: {
+        open_chat_id: 'oc_456',
+        open_message_id: 'om_456',
+      },
+      action: {
+        tag: 'button',
+        name: 'followup_demo:submit:fu_123',
+        form_value: {
+          feedback: 'works',
+        },
+      },
+    };
+
+    const result = await dispatchFeishuPluginInteractiveHandler({
+      cfg: {} as never,
+      accountId: 'default',
+      data: event,
+    });
+
+    expect(result).toEqual({ toast: { type: 'success', content: 'submitted' } });
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'followup_demo:submit:fu_123',
+        namespace: 'followup_demo',
+        payload: 'submit:fu_123',
+        senderId: 'ou_456',
+        conversationId: 'oc_456',
+        messageId: 'om_456',
+        rawEvent: event,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add `action.name` as a fallback routing source for Feishu Schema 2 interactive card callbacks.
- Cover both legacy `action.value.action` and Schema 2 form submit callback routing in tests.

## Root Cause

`dispatchFeishuPluginInteractiveHandler()` only read `ev.action?.value?.action` when deciding which plugin interactive handler to invoke.

For Schema 2 cards with input components and a submit button, Feishu `form_submit` callbacks may keep the routing identifier in `action.name` while `action.value.action` is absent. In that case, openclaw-lark receives the callback but returns before calling the standard plugin interactive dispatch pipeline.

## Fix

Fallback to `ev.action?.name` when `ev.action?.value?.action` is unavailable:

```ts
const action = ev.action?.value?.action ?? ev.action?.name;
```

This keeps existing cards working unchanged while allowing form submit callbacks to reach registered interactive handlers.

## Validation

- `pnpm test -- tests/interactive-dispatch.test.ts`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run typecheck`
