### PR TITLE
fix: migrate wide_screen_mode to width_mode in CardKit v2 output (#487)

### DIFF
--- a/src/card/builder.ts
+++ b/src/card/builder.ts
@@ -37,6 +37,7 @@ export interface CardElement {
 export interface FeishuCard {
   config: {
     wide_screen_mode: boolean;
+    width_mode?: 'fill' | 'compact';
     update_multi?: boolean;
     locales?: string[];
     summary?: { content: string };
@@ -701,6 +702,7 @@ export function buildStreamingPreAnswerCard(params: {
   return {
     schema: '2.0',
     config: {
+      width_mode: 'fill',
       streaming_mode: true,
       locales: ['zh_cn', 'en_us'],
       summary: {
@@ -764,9 +766,14 @@ function buildStreamingToolUseActivePanel(params: { steps: ToolUseDisplayStep[];
 }
 
 export function toCardKit2(card: FeishuCard): Record<string, unknown> {
+  const config: Record<string, unknown> = card.config ? { ...card.config } : {};
+  if (config.wide_screen_mode === true) {
+    config.width_mode = 'fill';
+    delete config.wide_screen_mode;
+  }
   const result: Record<string, unknown> = {
     schema: '2.0',
-    config: card.config,
+    config,
     body: { elements: card.elements },
   };
   if (card.header) result.header = card.header;

--- a/tests/builder-footer-runtime.test.ts
+++ b/tests/builder-footer-runtime.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { buildCardContent, compactNumber, formatFooterRuntimeSegments } from '../src/card/builder';
+import { buildCardContent, compactNumber, formatFooterRuntimeSegments, toCardKit2 } from '../src/card/builder';
 import type { ToolUseDisplayStep } from '../src/card/tool-use-display';
 
 // ---------------------------------------------------------------------------
@@ -245,5 +245,62 @@ describe('buildCardContent – tool-use step rendering', () => {
     expect(((outputRow?.text ?? {}) as Record<string, unknown>).content).toContain('```text');
     expect(((outputRow?.text ?? {}) as Record<string, unknown>).content).toContain('exit code 1');
     expect(outputRow?.margin).toBe(toolUseContentIndent);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toCardKit2 – wide_screen_mode → width_mode migration
+// ---------------------------------------------------------------------------
+
+describe('toCardKit2', () => {
+  it('migrates wide_screen_mode to width_mode in v2 output', () => {
+    const result = toCardKit2({
+      config: { wide_screen_mode: true, update_multi: true },
+      elements: [],
+    });
+    expect(result).toEqual({
+      schema: '2.0',
+      config: { width_mode: 'fill', update_multi: true },
+      body: { elements: [] },
+    });
+  });
+
+  it('keeps other config fields intact during migration', () => {
+    const result = toCardKit2({
+      config: {
+        wide_screen_mode: true,
+        update_multi: true,
+        locales: ['zh_cn', 'en_us'],
+        summary: { content: 'test' },
+      },
+      elements: [{ tag: 'markdown', content: 'hello' }],
+      header: { title: { tag: 'plain_text' as const, content: 'Header' } },
+    });
+    expect(result.config).toEqual({
+      width_mode: 'fill',
+      update_multi: true,
+      locales: ['zh_cn', 'en_us'],
+      summary: { content: 'test' },
+    });
+    expect(result.body).toEqual({ elements: [{ tag: 'markdown', content: 'hello' }] });
+    expect(result.header).toEqual({ title: { tag: 'plain_text', content: 'Header' } });
+  });
+
+  it('does not add width_mode when wide_screen_mode is not present', () => {
+    const result = toCardKit2({
+      config: { update_multi: true },
+      elements: [],
+    });
+    expect(result.config).toEqual({ update_multi: true });
+    expect('wide_screen_mode' in (result.config as Record<string, unknown>)).toBe(false);
+    expect('width_mode' in (result.config as Record<string, unknown>)).toBe(false);
+  });
+
+  it('does not add width_mode when wide_screen_mode is false', () => {
+    const result = toCardKit2({
+      config: { wide_screen_mode: false, update_multi: true } as any,
+      elements: [],
+    });
+    expect(result.config).toEqual({ update_multi: true });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #487: `toCardKit2` copies deprecated `wide_screen_mode: true` into CardKit v2 output, causing all cards to render at fixed width (~600px) instead of filling chat window.

## Changes

### 1. `toCardKit2` migration (src/card/builder.ts)
- When `wide_screen_mode === true`, translate to `width_mode: 'fill'` and delete the deprecated key
- Only migrates on `true` (not `false`, and not when absent)

### 2. `buildStreamingPreAnswerCard` (src/card/builder.ts)  
- This function emits CardKit v2 directly (bypassing `toCardKit2`), so `width_mode: 'fill'` is added inline

### 3. `FeishuCard` type (src/card/builder.ts)
- Added `width_mode?: 'fill' | 'compact'` to the config type

### 4. Unit tests (tests/builder-footer-runtime.test.ts)
- Migration: `wide_screen_mode: true` → `width_mode: 'fill'`
- Other config fields preserved during migration
- No spurious `width_mode` when `wide_screen_mode` is absent or `false`

## Design notes

Per [@evandance review comment](https://github.com/larksuite/openclaw-lark/issues/487#issuecomment-4421382792):
- Migration at `toCardKit2`, not in builders — the same builder output is also used by the IM fallback path which remains v1
- `buildStreamingPreAnswerCard` bypasses `toCardKit2` and emits schema 2.0 directly
- No `as any` — type extended cleanly

Closes #487