### PR TITLE
fix: add one-click contracts manifest repair CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,23 @@ Before you start, make sure you have the following:
 
 [How to Use the Official Lark/Feishu Plugin for OpenClaw](https://bytedance.larkoffice.com/docx/MFK7dDFLFoVlOGxWCv5cTXKmnMh)
 
+## Troubleshooting
+
+If gateway startup repeatedly logs:
+
+`plugin must declare contracts.tools before registering agent tools`
+
+you can re-apply the published manifest tool contract with:
+
+```bash
+openclaw-lark-fix-contracts
+```
+
+Optional flags:
+
+- `--no-restart`: patch manifest only, do not restart gateway
+- `--path <manifest-path>`: patch a specific `openclaw.plugin.json`
+
 ## Contributing
 
 Community contributions are welcome! If you find a bug or have feature suggestions, please submit an [Issue](https://github.com/larksuite/openclaw-larksuite/issues) or a [Pull Request](https://github.com/larksuite/openclaw-larksuite/pulls).

--- a/bin/openclaw-lark-fix-contracts.js
+++ b/bin/openclaw-lark-fix-contracts.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const sourceManifestPath = join(__dirname, '..', 'openclaw.plugin.json');
+const homeDir = process.env.USERPROFILE || process.env.HOME;
+const defaultTargetManifestPath = homeDir
+  ? join(homeDir, '.openclaw', 'extensions', 'openclaw-lark', 'openclaw.plugin.json')
+  : null;
+
+function fail(message, code = 1) {
+  console.error(`[openclaw-lark-fix-contracts] ${message}`);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const result = {
+    restart: true,
+    target: defaultTargetManifestPath,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+
+    if (arg === '--no-restart') {
+      result.restart = false;
+      continue;
+    }
+
+    if (arg === '--path') {
+      const value = argv[i + 1];
+      if (!value || value.startsWith('--')) {
+        fail('missing value for --path');
+      }
+      result.target = value;
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--help' || arg === '-h') {
+      console.log(`Usage:
+  openclaw-lark-fix-contracts [--path <manifest-path>] [--no-restart]
+
+Options:
+  --path <manifest-path>  Target openclaw.plugin.json to patch.
+  --no-restart            Do not run \`openclaw gateway restart\` after patching.
+`);
+      process.exit(0);
+    }
+
+    fail(`unknown argument: ${arg}`);
+  }
+
+  if (!result.target) {
+    fail('cannot resolve default target path; set HOME/USERPROFILE or pass --path');
+  }
+
+  return result;
+}
+
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch (err) {
+    fail(`failed to read JSON at ${path}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+function writeJson(path, value) {
+  try {
+    writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+  } catch (err) {
+    fail(`failed to write JSON at ${path}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+const args = parseArgs(process.argv.slice(2));
+const sourceManifest = readJson(sourceManifestPath);
+const contractsTools = sourceManifest?.contracts?.tools;
+
+if (!Array.isArray(contractsTools) || contractsTools.length === 0) {
+  fail(`source manifest has no contracts.tools: ${sourceManifestPath}`);
+}
+
+const targetManifest = readJson(args.target);
+targetManifest.contracts = targetManifest.contracts || {};
+targetManifest.contracts.tools = contractsTools;
+writeJson(args.target, targetManifest);
+
+console.log(`[openclaw-lark-fix-contracts] patched contracts.tools in: ${args.target}`);
+
+if (args.restart) {
+  const restart = spawnSync('openclaw', ['gateway', 'restart'], {
+    stdio: 'inherit',
+  });
+
+  if (restart.error) {
+    fail(`failed to restart gateway: ${restart.error.message}`);
+  }
+
+  if (typeof restart.status === 'number' && restart.status !== 0) {
+    fail(`gateway restart exited with code ${restart.status}`);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
   "bin": {
-    "openclaw-lark": "bin/openclaw-lark.js"
+    "openclaw-lark": "bin/openclaw-lark.js",
+    "openclaw-lark-fix-contracts": "bin/openclaw-lark-fix-contracts.js"
   },
   "files": [
     "bin/",


### PR DESCRIPTION
﻿## Summary

This PR adds a one-command recovery path for environments that still hit:

`plugin must declare contracts.tools before registering agent tools`

Even though `openclaw.plugin.json` in this repository already declares `contracts.tools`, some users may still be on older published artifacts or partially-upgraded local plugin installs.

## Changes

- Add new CLI binary: `openclaw-lark-fix-contracts`
  - Reads `contracts.tools` from the package's own `openclaw.plugin.json`
  - Patches target local plugin manifest (default: `~/.openclaw/extensions/openclaw-lark/openclaw.plugin.json`)
  - Restarts gateway by default (`openclaw gateway restart`)
  - Supports `--no-restart` and `--path <manifest-path>`
- Register the new binary in `package.json`.
- Add a troubleshooting section in `README.md` documenting how to run this repair command.

## Why

Issue #473 reports repeated startup warnings on current OpenClaw when local/plugin artifacts are missing `contracts.tools` metadata. This PR provides an immediate and repeatable self-heal path for affected users without requiring manual JSON editing.

Refs: #473

## Validation

- `node bin/openclaw-lark-fix-contracts.js --help`
- Verified git diff contains only:
  - `package.json`
  - `README.md`
  - `bin/openclaw-lark-fix-contracts.js`
