### PR TITLE
fix: harden Feishu streaming finalization

### DIFF
--- a/src/card/streaming-card-controller.ts
+++ b/src/card/streaming-card-controller.ts
@@ -66,6 +66,10 @@ import {
 import { UnavailableGuard } from './unavailable-guard';
 
 const log = larkLogger('card/streaming');
+const STALE_WATCHDOG_MS = Number(process.env.FEISHU_STREAMING_STALE_MS || process.env.LARK_STREAMING_STALE_MS || 5 * 60 * 1000);
+const EMPTY_FINAL_DIAGNOSTIC_TEXT =
+  '⚠️ 回复流程已结束，但没有收到可展示的最终内容。任务可能已完成但终态内容写回失败；请重试或检查会话日志。';
+
 
 interface TerminalCardTextImageResolver {
   resolveImages(text: string): string;
@@ -123,6 +127,9 @@ export class StreamingCardController {
   private cardCreationPromise: Promise<void> | null = null;
   private disposeShutdownHook: (() => void) | null = null;
   private readonly dispatchStartTime = Date.now();
+  private lastStreamingActivityAt = Date.now();
+  private staleWatchdogTimer: NodeJS.Timeout | null = null;
+
 
   // ---- Injected dependencies ----
   private readonly deps: StreamingCardDeps;
@@ -690,9 +697,11 @@ export class StreamingCardController {
         const isNoReplyLeak =
           !this.text.completedText && SILENT_REPLY_TOKEN.startsWith(this.text.accumulatedText.trim());
         const displayText =
-          this.text.completedText || (isNoReplyLeak ? '' : this.text.accumulatedText) || EMPTY_REPLY_FALLBACK_TEXT;
+          this.text.completedText ||
+          (isNoReplyLeak ? '' : this.text.accumulatedText) ||
+          EMPTY_FINAL_DIAGNOSTIC_TEXT;
         if (!this.text.completedText && !this.text.accumulatedText) {
-          log.warn('reply completed without visible text, using empty-reply fallback');
+          log.warn('reply completed without visible text, using explicit diagnostic fallback');
         }
 
         // 等待图片异步解析（最多 15s），避免终态卡片留占位符
@@ -765,6 +774,7 @@ export class StreamingCardController {
       accumulatedTextLen: this.text.accumulatedText.length,
     });
     this.dispatchFullyComplete = true;
+    this.markStreamingActivity('markFullyComplete');
   }
 
   async abortCard(): Promise<void> {
@@ -873,6 +883,7 @@ export class StreamingCardController {
 
           if (cId) {
             this.cardKit.cardKitCardId = cId;
+          this.markStreamingActivity('cardCreated');
             this.cardKit.originalCardKitCardId = cId;
             this.cardKit.cardKitSequence = 1;
             this.disposeShutdownHook = registerShutdownHook(`streaming-card:${cId}`, () => this.abortCard());
@@ -996,7 +1007,8 @@ export class StreamingCardController {
             seqBefore: prevSeq,
             seqAfter: this.cardKit.cardKitSequence,
           });
-          await streamCardContent({
+          this.markStreamingActivity('streamCardContent');
+      await streamCardContent({
             cfg: this.deps.cfg,
             cardId: this.cardKit.cardKitCardId,
             elementId: STREAMING_ELEMENT_ID,
@@ -1150,7 +1162,83 @@ export class StreamingCardController {
       accountId: this.deps.accountId,
     });
   }
+
+  private markStreamingActivity(reason: string): void {
+    this.lastStreamingActivityAt = Date.now();
+    log.debug('streaming activity', { reason });
+    this.armStaleWatchdog(reason);
+  }
+
+  private armStaleWatchdog(reason: string): void {
+    if (!STALE_WATCHDOG_MS || STALE_WATCHDOG_MS <= 0 || this.isTerminalPhase) return;
+    if (this.staleWatchdogTimer) clearTimeout(this.staleWatchdogTimer);
+    this.staleWatchdogTimer = setTimeout(() => {
+      void this.onStaleWatchdog().catch((err) => {
+        log.warn('streaming stale watchdog failed', { reason, error: String(err) });
+      });
+    }, STALE_WATCHDOG_MS);
+    this.staleWatchdogTimer.unref?.();
+  }
+
+  private async onStaleWatchdog(): Promise<void> {
+    if (this.isTerminalPhase) return;
+    const staleForMs = Date.now() - this.lastStreamingActivityAt;
+    if (staleForMs < STALE_WATCHDOG_MS - 100) {
+      this.armStaleWatchdog('staleWatchdog.race');
+      return;
+    }
+    log.warn('streaming card stale watchdog fired', {
+      staleForMs,
+      dispatchFullyComplete: this.dispatchFullyComplete,
+      phase: this.phase,
+    });
+    if (this.dispatchFullyComplete) {
+      await this.onIdle();
+      return;
+    }
+    const effectiveCardId = this.cardKit.cardKitCardId ?? this.cardKit.originalCardKitCardId;
+    if (!this.cardKit.cardMessageId || !effectiveCardId) {
+      this.armStaleWatchdog('staleWatchdog.noCard');
+      return;
+    }
+    const baseText = this.text.accumulatedText || this.text.completedText || '';
+    const minutes = Math.max(1, Math.round(staleForMs / 60000));
+    const watchdogNote = `\n\n---\n⚠️ 已超过 ${minutes} 分钟没有收到新的模型/工具/卡片更新事件。任务未被标记完成，可能仍在长时间等待，也可能已经卡在工具调用、模型返回或循环中；请不要把当前“三点进行中”视为健康信号。`;
+    const resolvedDisplayText = await this.imageResolver.resolveImagesAwait(`${baseText}${watchdogNote}`.trim(), 5000);
+    const display = this.computeToolUseDisplay();
+    const footerMetrics = this.needsFooterMetrics() ? await this.getFooterSessionMetrics() : undefined;
+    const diagnosticContent = prepareTerminalCardContent(
+      {
+        text: resolvedDisplayText,
+        reasoningText: this.reasoning.accumulatedReasoningText || undefined,
+      },
+      this.imageResolver,
+    );
+    const diagnosticCard = buildCardContent('streaming', {
+      text: diagnosticContent.text,
+      reasoningText: diagnosticContent.reasoningText,
+      reasoningElapsedMs: this.reasoning.reasoningElapsedMs || undefined,
+      toolUseSteps: display?.steps,
+      toolUseTitleSuffix: this.computeToolUseTitleSuffix(display),
+      toolUseElapsedMs: this.visibleToolUseElapsedMs,
+      showToolUse: this.deps.toolUseDisplay.showToolUse,
+      elapsedMs: this.elapsed(),
+      footer: this.deps.resolvedFooter,
+      footerMetrics,
+    });
+    this.cardKit.cardKitSequence += 1;
+    await updateCardKitCard({
+      cfg: this.deps.cfg,
+      cardId: effectiveCardId,
+      card: toCardKit2(diagnosticCard),
+      sequence: this.cardKit.cardKitSequence,
+      accountId: this.deps.accountId,
+    });
+    // This is a suspected-stall diagnostic, not completion. Keep the card/session open.
+    this.markStreamingActivity('staleWatchdog.diagnostic');
+  }
 }
+
 
 // ---------------------------------------------------------------------------
 // Error detail extraction helpers (replacing `any` casts)


### PR DESCRIPTION
## Summary

This PR hardens Feishu/Lark streaming-card finalization and suspected-stall handling.

It changes the streaming card lifecycle so that:

- an empty completed reply is no longer silently shown as a successful `Done.` card;
- a stale backend-activity watchdog can detect when no model/tool/card updates have arrived for a while;
- if dispatch is already complete, the watchdog routes through normal finalization/fallback;
- if dispatch is not complete, the watchdog writes a suspected-stall diagnostic into the card while keeping the streaming session open, so valid long tasks can still resume.

## Why this matters

Feishu streaming cards are the primary user-facing progress surface for long-running agent work. When that card keeps showing the normal animated “in progress” state after backend activity has stopped, users cannot tell the difference between:

1. a legitimate long task that is still making progress;
2. a tool call or model response that is waiting longer than expected;
3. a dispatch/finalization bug where the backend is done but the card never reached a terminal state;
4. a loop/deadlock/stuck state with no new backend activity.

The current failure mode is therefore not just cosmetic. It creates **false health**: the UI looks alive even when there may be no model/tool/card activity behind it.

That is operationally expensive for users running agents in Feishu groups:

- they may wait indefinitely because the card still looks healthy;
- they may resend or interrupt work unnecessarily because there is no diagnostic signal;
- group participants cannot tell whether the agent is still working, stuck, or already done;
- completion bugs can be masked by a misleading `Done.` fallback even when no real final content was produced.

## Intended behavior

Long tasks can legitimately run longer than five minutes. Duration alone should not be treated as failure.

This PR therefore does **not** force-close an unfinished task just because it is old. Instead, it distinguishes two cases:

### 1. Dispatch is complete

If dispatch is complete but the streaming card has not reached a clean terminal state, this is a finalization problem. The controller should route through normal finalization/fallback so the card stops presenting as still in progress.

### 2. Dispatch is not complete

If dispatch is not complete and there has been no backend model/tool/card activity for the watchdog interval, this is only a suspected-stall signal.

The card is updated with an explicit diagnostic, but the streaming session remains open. If real backend output resumes, the card can continue and finalize normally.

## User-facing value

This improves agent reliability in Feishu without disabling streaming mode:

- keeps streaming as the preferred display for group chats and long tasks;
- avoids misleading success text for empty final replies;
- exposes suspected-stall state instead of silently showing endless healthy progress;
- preserves legitimate long-running tasks by keeping the session open when dispatch is not complete;
- gives users a clear signal for when they should inspect task status instead of guessing.

## Validation

- `npm install --ignore-scripts --no-audit --no-fund --legacy-peer-deps`
- `git diff --check` PASS
- `npm run typecheck` was run. This patch leaves `src/card/streaming-card-controller.ts` clean. The remaining failure is an existing baseline issue in `src/messaging/outbound/actions.ts` capability typing (`cards` vs `presentation | delivery-pin`).
