### PR TITLE
fix: fallback when accepted turns send no visible reply

### DIFF
--- a/src/card/reply-dispatcher-types.ts
+++ b/src/card/reply-dispatcher-types.ts
@@ -151,6 +151,8 @@ export interface FeishuReplyDispatcherResult {
   markDispatchIdle: () => void;
   markFullyComplete: () => void;
   abortCard: () => Promise<void>;
+  ensureNoVisibleReplyFallback: (reason: string) => Promise<boolean>;
+  getVisibleReplyState: () => { visibleReplySent: boolean; skippedFinalReason: string | null };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/card/reply-dispatcher.ts
+++ b/src/card/reply-dispatcher.ts
@@ -30,6 +30,9 @@ import { UnavailableGuard } from './unavailable-guard';
 
 const log = larkLogger('card/reply-dispatcher');
 
+export const NO_VISIBLE_REPLY_FALLBACK_TEXT =
+  '⚠️ This reply was interrupted before any visible content was delivered. Please retry, or send the message again if this keeps happening.';
+
 // Re-export the params type for backward compatibility with dispatch.ts
 export type { CreateFeishuReplyDispatcherParams } from './reply-dispatcher-types';
 
@@ -180,15 +183,50 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
 
   // ---- dispatchFullyComplete flag (static mode) ----
   let dispatchFullyComplete = false;
+  let visibleReplySent = false;
+  let skippedFinalReason: string | null = null;
+
+  const markVisibleReplySent = () => {
+    visibleReplySent = true;
+  };
+
+  const ensureNoVisibleReplyFallback = async (reason: string): Promise<boolean> => {
+    if (visibleReplySent) return false;
+    if (skippedFinalReason === 'silent') {
+      log.info('no-visible-reply fallback skipped for intentional silent final reply', { reason });
+      return false;
+    }
+
+    await sendMessageFeishu({
+      cfg,
+      to: chatId,
+      text: NO_VISIBLE_REPLY_FALLBACK_TEXT,
+      replyToMessageId,
+      replyInThread,
+      accountId,
+      threadId,
+    });
+    markVisibleReplySent();
+    log.warn('sent no-visible-reply fallback', { reason, skippedFinalReason });
+    return true;
+  };
 
   // ---- Build dispatcher ----
   const { dispatcher, replyOptions, markDispatchIdle } = core.channel.reply.createReplyDispatcherWithTyping({
     responsePrefix: prefixContext.responsePrefix,
     responsePrefixContextProvider: prefixContext.responsePrefixContextProvider,
+    silentReplyContext: {
+      cfg,
+      sessionKey,
+      surface: 'feishu',
+      conversationType: chatType === 'group' ? 'group' : 'direct',
+    },
     humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, agentId),
 
     onReplyStart: async () => {
       if (shouldSkip('onReplyStart')) return;
+      visibleReplySent = false;
+      skippedFinalReason = null;
       await typingCallbacks.onReplyStart?.();
     },
 
@@ -242,9 +280,11 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           if (controller.cardMessageId) {
             if (payload.isReasoning === true) {
               await controller.onReasoningStream({ ...payload, text: controllerText });
+              markVisibleReplySent();
               return;
             }
             await controller.onDeliver({ ...payload, text: controllerText });
+            markVisibleReplySent();
             return;
           }
           // Card creation failed — fall through to static delivery
@@ -275,6 +315,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                   accountId,
                   threadId,
                 });
+                markVisibleReplySent();
               } catch (fallbackErr) {
                 if (staticGuard?.terminate('deliver.textFallback', fallbackErr)) return;
                 throw fallbackErr;
@@ -290,6 +331,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                 replyInThread,
                 accountId,
               });
+              markVisibleReplySent();
             } catch (err) {
               if (staticGuard?.terminate('deliver.cardChunk', err)) return;
               // 卡片表格数超出飞书限制 — 降级为纯文本
@@ -306,6 +348,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                     accountId,
                     threadId,
                   });
+                  markVisibleReplySent();
                 } catch (fallbackErr) {
                   if (staticGuard?.terminate('deliver.textFallback', fallbackErr)) return;
                   throw fallbackErr;
@@ -333,6 +376,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                 accountId,
                 threadId,
               });
+              markVisibleReplySent();
             } catch (err) {
               if (staticGuard?.terminate('deliver.textChunk', err)) return;
               throw err;
@@ -356,6 +400,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             replyToMessageId,
             replyInThread,
           });
+          markVisibleReplySent();
         } catch (mediaErr) {
           if (staticGuard?.terminate('deliver.media', mediaErr)) return;
           log.error('deliver: static media send failed', {
@@ -398,9 +443,14 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
 
       if (controller) {
         await controller.onIdle();
+        markVisibleReplySent();
       }
 
       typingCallbacks.onIdle?.();
+    },
+
+    onSkip: (_payload: ReplyPayload, info: { kind?: string; reason?: string }) => {
+      if (info.kind === 'final') skippedFinalReason = info.reason ?? null;
     },
 
     onCleanup: async () => {
@@ -439,6 +489,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       controller?.markFullyComplete();
     },
     abortCard,
+    ensureNoVisibleReplyFallback,
+    getVisibleReplyState: () => ({ visibleReplySent, skippedFinalReason }),
   };
 }
 

--- a/src/messaging/inbound/dispatch.ts
+++ b/src/messaging/inbound/dispatch.ts
@@ -252,7 +252,7 @@ async function dispatchNormalMessage(
     clearToolUseTraceRun(effectiveSessionKey);
   }
 
-  const { dispatcher, replyOptions, markDispatchIdle, markFullyComplete, abortCard } = createFeishuReplyDispatcher({
+  const { dispatcher, replyOptions, markDispatchIdle, markFullyComplete, abortCard, ensureNoVisibleReplyFallback } = createFeishuReplyDispatcher({
     cfg: dc.accountScopedCfg,
     agentId: dc.route.agentId,
     chatId: dc.ctx.chatId,
@@ -308,6 +308,10 @@ async function dispatchNormalMessage(
         historyKey,
         limit: historyLimit,
       });
+    }
+
+    if (counts.final === 0) {
+      await ensureNoVisibleReplyFallback('dispatch-complete-zero-final');
     }
 
     dc.log(`feishu[${dc.account.accountId}]: dispatch complete (queuedFinal=${queuedFinal}, replies=${counts.final})`);

--- a/tests/no-visible-reply-fallback.test.ts
+++ b/tests/no-visible-reply-fallback.test.ts
@@ -1,0 +1,260 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { dispatchReplyFromConfigMock, createReplyDispatcherHooks } = vi.hoisted(() => ({
+  dispatchReplyFromConfigMock: vi.fn(),
+  createReplyDispatcherHooks: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock('../src/core/lark-client', () => ({
+  LarkClient: {
+    runtime: {
+      channel: {
+        text: {
+          resolveTextChunkLimit: () => 4000,
+          resolveChunkMode: () => 'paragraph',
+          resolveMarkdownTableMode: () => 'plain',
+          convertMarkdownTables: (text: string) => text,
+          chunkTextWithMode: (text: string) => (text ? [text] : []),
+        },
+        reply: {
+          createReplyDispatcherWithTyping: (hooks: Record<string, unknown>) => {
+            createReplyDispatcherHooks.push(hooks);
+            return {
+              dispatcher: {
+                waitForIdle: vi.fn().mockResolvedValue(undefined),
+                getQueuedCounts: () => ({ tool: 0, block: 0, final: 0 }),
+                markComplete: vi.fn(),
+              },
+              replyOptions: {},
+              markDispatchIdle: vi.fn(),
+            };
+          },
+          resolveHumanDelayConfig: () => null,
+          dispatchReplyFromConfig: dispatchReplyFromConfigMock,
+        },
+      },
+    },
+  },
+}));
+
+vi.mock('../src/core/accounts', () => ({
+  createAccountScopedConfig: vi.fn((cfg) => cfg),
+  getLarkAccount: () => ({ accountId: 'default', config: { streaming: false } }),
+}));
+vi.mock('../src/core/footer-config', () => ({ resolveFooterConfig: () => null }));
+vi.mock('../src/core/lark-logger', () => ({
+  larkLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+vi.mock('../src/messaging/outbound/send', () => ({
+  sendMessageFeishu: vi.fn().mockResolvedValue({ messageId: 'om_sent' }),
+  sendMarkdownCardFeishu: vi.fn().mockResolvedValue({ messageId: 'om_card' }),
+  buildI18nMarkdownCard: vi.fn(),
+  sendCardFeishu: vi.fn(),
+}));
+vi.mock('../src/messaging/outbound/deliver', () => ({ sendMediaLark: vi.fn() }));
+vi.mock('../src/messaging/outbound/typing', () => ({
+  addTypingIndicator: vi.fn().mockResolvedValue(null),
+  removeTypingIndicator: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../src/card/card-error', () => ({ isCardTableLimitError: () => false }));
+vi.mock('../src/card/reply-mode', () => ({
+  resolveReplyMode: () => 'static',
+  expandAutoMode: () => 'static',
+  shouldUseCard: () => false,
+}));
+vi.mock('../src/card/unavailable-guard', () => ({
+  UnavailableGuard: class {
+    shouldSkip() {
+      return false;
+    }
+    terminate() {
+      return false;
+    }
+    get isTerminated() {
+      return false;
+    }
+  },
+}));
+vi.mock('openclaw/plugin-sdk/channel-runtime', () => ({
+  createReplyPrefixContext: () => ({
+    responsePrefix: '',
+    responsePrefixContextProvider: () => null,
+    onModelSelected: vi.fn(),
+  }),
+  createTypingCallbacks: () => ({ onReplyStart: vi.fn(), onIdle: vi.fn(), onCleanup: vi.fn() }),
+}));
+vi.mock('openclaw/plugin-sdk/channel-feedback', () => ({ logTypingFailure: vi.fn() }));
+vi.mock('../src/card/tool-use-config', () => ({
+  resolveToolUseDisplayConfig: () => ({
+    mode: 'off',
+    showToolUse: false,
+    showToolResultDetails: false,
+    showFullPaths: false,
+  }),
+}));
+vi.mock('../src/card/tool-use-trace-store', () => ({ startToolUseTraceRun: vi.fn(), clearToolUseTraceRun: vi.fn() }));
+vi.mock('../src/channel/chat-queue', () => ({
+  buildQueueKey: () => 'queue-key',
+  registerActiveDispatcher: vi.fn(),
+  unregisterActiveDispatcher: vi.fn(),
+  threadScopedKey: () => 'thread-key',
+}));
+vi.mock('../src/messaging/inbound/dispatch-context', () => ({
+  buildDispatchContext: vi.fn((params) => params.__dc),
+  resolveThreadSessionKey: vi.fn(),
+}));
+vi.mock('../src/messaging/inbound/dispatch-builders', () => ({
+  buildMessageBody: vi.fn(() => 'message-body'),
+  buildEnvelopeWithHistory: vi.fn(() => ({ combinedBody: 'combined-body', historyKey: undefined })),
+  buildBodyForAgent: vi.fn(() => 'body-for-agent'),
+  buildInboundPayload: vi.fn(() => ({ kind: 'ctx-payload' })),
+}));
+vi.mock('../src/messaging/inbound/dispatch-commands', () => ({
+  dispatchPermissionNotification: vi.fn(),
+  dispatchSystemCommand: vi.fn(),
+}));
+vi.mock('../src/core/chat-info-cache', () => ({ isThreadCapableGroup: vi.fn(), injectLarkClient: vi.fn() }));
+vi.mock('../src/core/targets', () => ({ encodeFeishuRouteTarget: vi.fn() }));
+vi.mock('../src/commands/doctor', () => ({ runFeishuDoctorI18n: vi.fn() }));
+vi.mock('../src/commands/auth', () => ({ runFeishuAuthI18n: vi.fn() }));
+vi.mock('../src/commands/index', () => ({ getFeishuHelpI18n: vi.fn(), runFeishuStartI18n: vi.fn() }));
+vi.mock('../src/messaging/inbound/mention', () => ({ mentionedBot: vi.fn(() => false) }));
+vi.mock('../src/messaging/inbound/gate', () => ({ resolveRespondToMentionAll: vi.fn(() => false) }));
+vi.mock('../src/channel/abort-detect', () => ({ isLikelyAbortText: vi.fn(() => false) }));
+vi.mock('../src/core/lark-ticket', () => ({ ticketElapsed: () => 1 }));
+
+import { createFeishuReplyDispatcher, NO_VISIBLE_REPLY_FALLBACK_TEXT } from '../src/card/reply-dispatcher';
+import { dispatchToAgent } from '../src/messaging/inbound/dispatch';
+import { sendMessageFeishu } from '../src/messaging/outbound/send';
+
+const toolUseDisplay = { mode: 'off' as const, showToolUse: false, showToolResultDetails: false, showFullPaths: false };
+
+function baseDispatcherParams() {
+  return {
+    cfg: {} as never,
+    agentId: 'main',
+    sessionKey: 'agent:main:feishu:dm:user-1',
+    chatId: 'chat-1',
+    accountId: 'default',
+    chatType: 'p2p' as const,
+    replyToMessageId: 'om_msg_1',
+    replyInThread: false,
+    skipTyping: true,
+    toolUseDisplay,
+  };
+}
+
+function createDispatchContext() {
+  return {
+    ctx: {
+      chatId: 'chat-1',
+      messageId: 'om_msg_1',
+      senderId: 'ou_sender_1',
+      senderName: 'Alice',
+      content: 'hello',
+      chatType: 'p2p',
+      mentions: [],
+      resources: [],
+      contentType: 'text',
+      mentionAll: false,
+      rawMessage: {},
+      rawSender: {},
+    },
+    accountScopedCfg: {},
+    account: { accountId: 'default', enabled: true, brand: 'feishu', config: {} },
+    runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    log: vi.fn(),
+    error: vi.fn(),
+    core: {
+      channel: {
+        commands: { isControlCommandMessage: vi.fn(() => false) },
+        reply: { dispatchReplyFromConfig: dispatchReplyFromConfigMock },
+      },
+    },
+    isGroup: false,
+    isThread: false,
+    feishuFrom: 'feishu:ou_sender_1',
+    feishuTo: 'user:ou_sender_1',
+    envelopeFrom: 'ou_sender_1',
+    envelopeOptions: {},
+    route: { sessionKey: 'session-1', agentId: 'default', channel: 'feishu', accountId: 'default' },
+    threadSessionKey: undefined,
+    commandAuthorized: true,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  createReplyDispatcherHooks.length = 0;
+  dispatchReplyFromConfigMock.mockResolvedValue({ queuedFinal: false, counts: { final: 0 } });
+  (sendMessageFeishu as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ messageId: 'om_sent' });
+});
+
+describe('no-visible-reply fallback', () => {
+  it('sends a fallback when dispatch completes with no final replies and no visible output', async () => {
+    const dc = createDispatchContext();
+
+    await dispatchToAgent({
+      ctx: { ...dc.ctx, __dc: dc } as never,
+      mediaPayload: {},
+      account: dc.account as never,
+      accountScopedCfg: {} as never,
+      historyLimit: 0,
+    });
+
+    expect(sendMessageFeishu).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'chat-1',
+        text: NO_VISIBLE_REPLY_FALLBACK_TEXT,
+        replyToMessageId: 'om_msg_1',
+        accountId: 'default',
+      }),
+    );
+  });
+
+  it('does not fallback for an intentional silent final reply', async () => {
+    const result = createFeishuReplyDispatcher(baseDispatcherParams());
+    const hooks = createReplyDispatcherHooks.at(-1) as {
+      onReplyStart: () => Promise<void>;
+      onSkip: (payload: unknown, info: { kind: string; reason: string }) => void;
+    };
+
+    await hooks.onReplyStart();
+    hooks.onSkip({}, { kind: 'final', reason: 'silent' });
+
+    const sent = await result.ensureNoVisibleReplyFallback('dispatch-complete-zero-final');
+
+    expect(sent).toBe(false);
+    expect(sendMessageFeishu).not.toHaveBeenCalled();
+    expect(result.getVisibleReplyState()).toEqual({ visibleReplySent: false, skippedFinalReason: 'silent' });
+  });
+
+  it('does not duplicate fallback after visible static delivery', async () => {
+    const result = createFeishuReplyDispatcher(baseDispatcherParams());
+    const hooks = createReplyDispatcherHooks.at(-1) as {
+      deliver: (payload: { text: string }, info: { kind: string }) => Promise<void>;
+    };
+
+    await hooks.deliver({ text: 'visible answer' }, { kind: 'final' });
+    const sent = await result.ensureNoVisibleReplyFallback('dispatch-complete-zero-final');
+
+    expect(sent).toBe(false);
+    expect(sendMessageFeishu).toHaveBeenCalledTimes(1);
+    expect(sendMessageFeishu).toHaveBeenCalledWith(expect.objectContaining({ text: 'visible answer' }));
+  });
+
+  it('resets visible/silent state on each reply start', async () => {
+    const result = createFeishuReplyDispatcher(baseDispatcherParams());
+    const hooks = createReplyDispatcherHooks.at(-1) as {
+      onReplyStart: () => Promise<void>;
+      onSkip: (payload: unknown, info: { kind: string; reason: string }) => void;
+    };
+
+    await hooks.onReplyStart();
+    hooks.onSkip({}, { kind: 'final', reason: 'silent' });
+    expect(result.getVisibleReplyState().skippedFinalReason).toBe('silent');
+
+    await hooks.onReplyStart();
+    expect(result.getVisibleReplyState()).toEqual({ visibleReplySent: false, skippedFinalReason: null });
+  });
+});


### PR DESCRIPTION
## Summary

Fix Lark/Feishu accepted turns that complete without any user-visible reply.

This adds dispatcher-level visible-output tracking and sends a clear fallback when a normal inbound dispatch completes with `counts.final === 0` and no visible text/card/media output was delivered. Intentional silent final replies (`NO_REPLY`) are preserved via the SDK `onSkip(reason: "silent")` signal.

## Real behavior proof

- **Behavior or issue addressed**: In a live Feishu setup, accepted inbound turns could reach dispatch completion with `replies=0` after streaming/card terminalization problems, leaving the user with typing/status activity but no visible answer.
- **Real environment tested**: Live OpenClaw gateway on VPS host `iv-yegrn5k9vky6d72c8f3t`, installed package `@larksuite/openclaw-lark 2026.5.20`, Feishu account `default`.
- **Observed failure before fix**: Runtime logs showed Feishu messages being received and dispatched, then completing as `dispatch complete (queuedFinal=false, replies=0)`. In the same incident window, streaming card terminalization logged `phase transition rejected (from=idle, to=completed, source=onIdle)`, followed by no visible user reply.
- **Evidence after local hotfix**: The live runtime hotfix equivalent to this PR was loaded via gateway restart, and subsequent live Feishu logs reached the no-visible-reply fallback path instead of staying silent:

```text
2026-05-28T19:26:20+08:00 gateway tool: restart requested (reason=Load narrowed Feishu no-reply fallback hotfix: skip fallback for intentional silent final replies via onSkip reason tracking.)
2026-05-28T19:32:05+08:00 feishu[default][msg:om_x100b6eb62b75acacc4a0c55586a37f3]: reply completed without visible text, using empty-reply fallback
```

- **What this PR validates in code**:
  - no visible output + zero final replies sends fallback;
  - intentional silent final replies do not fallback;
  - already-visible static delivery does not receive duplicate fallback;
  - visible/silent state resets per reply start.

## Validation

- `git diff --check` PASS
- `pnpm exec tsc --noEmit --pretty false` attempted locally, but dependency hydration was incomplete on the VPS; it failed on missing `@types/node` after `pnpm install --frozen-lockfile` was terminated by slow registry/resource constraints. Full validation is left to upstream CI.
