### PR TITLE
fix: default respondToMentionAll to true

### DIFF
--- a/src/messaging/inbound/gate.ts
+++ b/src/messaging/inbound/gate.ts
@@ -41,7 +41,7 @@ import { sendPairingReply } from './gate-effects';
 /**
  * Resolve the effective `respondToMentionAll` setting.
  *
- * Precedence: per-group > default ("*") group > global account config > false.
+ * Precedence: per-group > default ("*") group > global account config > true (opt-out).
  */
 export function resolveRespondToMentionAll(params: {
   groupConfig?: { respondToMentionAll?: boolean };
@@ -52,7 +52,7 @@ export function resolveRespondToMentionAll(params: {
     params.groupConfig?.respondToMentionAll ??
     params.defaultConfig?.respondToMentionAll ??
     params.accountFeishuCfg?.respondToMentionAll ??
-    false
+    true
   );
 }
 


### PR DESCRIPTION
## Problem

When a group message contains `@all` / `@所有人` but does not explicitly mention the bot, the message is currently dropped by default because `respondToMentionAll` defaults to `false`.

This is counterintuitive — users who `@所有人` in a group reasonably expect the bot to respond, since they are addressing everyone including the bot.

## Change

Changed the default value of `respondToMentionAll` from `false` to `true` in `resolveRespondToMentionAll()`.

The existing mention gating logic (`requireMention && !mentionedBot`) already ensures that plain messages without any @mention are still dropped. This change only affects the `@all` edge case.

## Precedence (unchanged)

Per-group config > default ("*") group config > global account config > **true (new default)**

Users can still opt out by setting `respondToMentionAll: false` at any level.