### PR TITLE
fix: detect @all from content text when mentions array is empty

### DIFF
--- a/src/messaging/inbound/parse.ts
+++ b/src/messaging/inbound/parse.ts
@@ -83,6 +83,19 @@ export async function parseMessageEvent(
     mentionsByOpenId.set(info.openId, info);
   }
 
+  // Fallback: Feishu sometimes omits @all from the mentions array in group
+  // messages but still includes the @_all token in the content text.
+  // Detect it here so that downstream gate logic can honour
+  // respondToMentionAll.
+  if (!mentionAll) {
+    try {
+      const parsed = JSON.parse(event.message.content ?? '{}');
+      if (typeof parsed.text === 'string' && parsed.text.includes('@_all')) {
+        mentionAll = true;
+      }
+    } catch { /* non-JSON content, ignore */ }
+  }
+
   // 2. Convert content via registered converter
   const acctId = expandCtx?.accountId;
 


### PR DESCRIPTION
## Problem

When a user sends a group message with `@所有人` (mention all), Feishu sometimes omits the `@all` entry from the `mentions` array in the event payload. However, the `content` JSON still contains the `@_all` token in the `text` field:

```json
{
  "content": "{\"text\":\"@_all hello\"}",
  "message_type": "text"
  // no mentions field!
}
```

This causes `mentionAll` to remain `false`, and the message is rejected by the mention gate even when `respondToMentionAll` is enabled.

## Change

Added a fallback in `parseMessageEvent()`: after processing the `mentions` array, if `mentionAll` is still `false`, parse the `content` JSON and check for the `@_all` token in the `text` field.

## Why this is safe

- `@_all` is Feishu's internal structured marker — it won't appear in normal user-typed text
- The fallback only triggers when the mentions array didn't already detect @all (no double-processing)
- Wrapped in try-catch to handle non-JSON content gracefully

## Related

Complements the `respondToMentionAll` default change (#550) — that PR changes the default, this PR ensures the `mentionAll` flag is actually set when Feishu omits it from the mentions array.