### PR TITLE
feat(vc): forward call_id from invite event to join tool prompt

### DIFF
--- a/src/messaging/inbound/vc-meeting-invited-handler.ts
+++ b/src/messaging/inbound/vc-meeting-invited-handler.ts
@@ -52,6 +52,7 @@ function buildSyntheticEvent(
     senderUnionId: sender.senderUnionId,
     senderName: sender.senderName,
     inviteTime: event.invite_time?.trim() || undefined,
+    callId: event.call_id?.trim() || undefined,
   }
 }
 
@@ -61,7 +62,15 @@ function buildSyntheticContext(event: VcMeetingInvitedSyntheticEvent): MessageCo
   // reply language is still governed by the agent/session prompt stack.
   // If we later need locale-aware synthetic prompts, this is the single place
   // to introduce a template or config-based language switch.
-  const syntheticText = `Use the available tool to join the meeting with meeting number ${event.meetingNo} immediately. Do not ask for confirmation.`
+  // Only append the call_id instruction when the invite event actually
+  // carries one. Forcing call_id="" into the prompt would assume every
+  // downstream join tool / CLI shortcut already recognises the parameter —
+  // during rollout that assumption can break auto-join. When absent we keep
+  // the legacy prompt shape so behavior degrades to the pre-call_id path.
+  const callIdInstruction = event.callId
+    ? ` When invoking the join tool, pass call_id="${event.callId}".`
+    : ''
+  const syntheticText = `Use the available tool to join the meeting with meeting number ${event.meetingNo} immediately. Do not ask for confirmation.${callIdInstruction}`
   const syntheticMessageId = event.eventId
     ? `vc-invited:event:${event.eventId}`
     : `vc-invited:${event.meetingNo}:${event.inviteTime ?? crypto.randomUUID()}`
@@ -205,6 +214,7 @@ export async function handleFeishuVcMeetingInvited(params: {
         VcMeetingTopic: syntheticEvent.topic,
         VcInviterOpenId: syntheticEvent.senderOpenId,
         VcInviteTime: syntheticEvent.inviteTime,
+        VcCallId: syntheticEvent.callId,
       },
       quotedContent: undefined,
       account,

--- a/src/messaging/types.ts
+++ b/src/messaging/types.ts
@@ -173,6 +173,8 @@ export interface FeishuVcMeetingInvitedEvent {
     user_name?: string;
   };
   invite_time?: string;
+  /** Correlation id carried by the invite event; forward to the join tool when present. */
+  call_id?: string;
 }
 
 /**
@@ -194,6 +196,8 @@ export interface VcMeetingInvitedSyntheticEvent {
   senderUnionId?: string;
   senderName?: string;
   inviteTime?: string;
+  /** Correlation id forwarded from the invite event; pass through to the join tool. */
+  callId?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/vc-meeting-invited-handler.test.ts
+++ b/tests/vc-meeting-invited-handler.test.ts
@@ -76,6 +76,9 @@ describe('handleFeishuVcMeetingInvited', () => {
           messageId: 'vc-invited:event:evt_vc_123',
           senderId: 'ou_inviter_1',
           chatType: 'p2p',
+          // When the upstream event has no call_id, the synthetic prompt
+          // omits the call_id instruction entirely so we don't assume the
+          // downstream join tool already accepts that parameter.
           content: 'Use the available tool to join the meeting with meeting number 123456789 immediately. Do not ask for confirmation.',
         }),
         extraInboundFields: expect.objectContaining({
@@ -87,9 +90,39 @@ describe('handleFeishuVcMeetingInvited', () => {
           // @-mention the inviter explicitly when appropriate.
           VcInviterOpenId: 'ou_inviter_1',
           VcInviteTime: '1712345678',
+          VcCallId: undefined,
         }),
         replyToMessageId: undefined,
         skipTyping: true,
+      }),
+    )
+  })
+
+  it('forwards call_id from invite event into synthetic prompt and VcCallId', async () => {
+    readFeishuAllowFromStoreMock.mockResolvedValueOnce(['ou_inviter_1'])
+
+    await handleFeishuVcMeetingInvited({
+      cfg: {} as never,
+      event: {
+        event_id: 'evt_vc_456',
+        meeting: { id: '6911188411934433028', meeting_no: '123456789', topic: '周会' },
+        inviter: { id: { open_id: 'ou_inviter_1' }, user_name: 'Alice' },
+        invite_time: '1712345678',
+        call_id: 'a08e06bf-9a41-44e4-a89c-a7871899e783',
+      },
+      accountId: 'default',
+    })
+
+    expect(dispatchToAgentMock).toHaveBeenCalledTimes(1)
+    expect(dispatchToAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          content:
+            'Use the available tool to join the meeting with meeting number 123456789 immediately. Do not ask for confirmation. When invoking the join tool, pass call_id="a08e06bf-9a41-44e4-a89c-a7871899e783".',
+        }),
+        extraInboundFields: expect.objectContaining({
+          VcCallId: 'a08e06bf-9a41-44e4-a89c-a7871899e783',
+        }),
       }),
     )
   })


### PR DESCRIPTION
## 概述

把 `vc.bot.meeting_invited_v1` 邀请事件里 server 端生成的
`call_id` 暴露出来，并贯穿到合成的 inbound 与提示词里。Agent 调
入会工具时把 `call_id` 原样回传到服务端，让服务端按 call_id
1:1 关联邀请 / 入会两张埋点。

## 改动

### `src/messaging/types.ts`

- `FeishuVcMeetingInvitedEvent` 新增 optional `call_id?: string`
  字段，对齐上游 event payload 上的新增字段。
- `VcMeetingInvitedSyntheticEvent`（内部模型）对应新增 optional
  `callId?: string` 字段。

### `src/messaging/inbound/vc-meeting-invited-handler.ts`

- `buildSyntheticEvent` 提取 `event.call_id?.trim() || undefined`。
- `buildSyntheticContext` 永远在合成 prompt 末尾追加
  `When invoking the join tool, pass call_id="<id>" so the server
  can correlate invite and join telemetry.`。无论事件是否携带
  `call_id`，指令的句式都是稳定的；灰度期值是空串，CLI 端有空串
  过滤兜底。
- `dispatchToAgent` 在 `extraInboundFields` 里加入 `VcCallId`，
  下游路由 / 埋点也能感知到这个 id。

## 安全 / 兼容性

- 所有新增字段都是 optional，老 payload 上没有也不影响。
- 合成 prompt 的改动是追加性的 —— 末尾多一句话，不会破坏既有
  Agent 行为。
- 空 `call_id` 在网关字段发布完成前是合法状态；下游 CLI
  `vc +meeting-join` 仅在 value 非空时才写入 body，不会污染请求。

## 关联改动（同名分支 / 关联 PR）

- 后端服务（`byteview-open-api`）：`BotJoinMeetingRequest` 新增
  字段 5 `call_id`，invite observer 生成 id，并以 `call_id` 为
  关联键上报 `vc_bot_invite_meeting_server` /
  `vc_bot_enter_meeting_server` 两张埋点。
- CLI（`larksuite/cli`）：关联 PR 给 `vc +meeting-join` 加
  `--call-id` flag。单独链接。
- Lark 开放平台网关：入站事件体 `call_id` 字段正在走平台 schema
  评审 / 发布流程。

## Test plan

- [x] `pnpm build` 干净通过，bundle 里包含 `callId` /
  `call_id` / `VcCallId` 标识。
- [x] 单元测试：`vc-meeting-invited-handler` 能从原始 event 提取
  `call_id`，并把它带到合成 event / context / dispatch 上。
- [x] 端到端：PPE 上 bot RING 后，Agent 调入会工具透传
  `call_id`，server 端 invite 与 enter 两条埋点日志里
  `call_id` 一致。