### PR TITLE
feat(feishu): bot-at-bot mention support (M1)

### DIFF
--- a/src/card/reply-mode.ts
+++ b/src/card/reply-mode.ts
@@ -76,17 +76,20 @@ export function expandAutoMode(params: {
  * markdown tables).
  */
 export function shouldUseCard(text: string): boolean {
-  // Table limit takes priority -- even with code blocks, too many tables will fail
+  // Markdown tables NO LONGER force a card. Feishu messages render markdown
+  // tables natively, and wrapping a reply in a card breaks bot-at-bot @
+  // delivery (cards have limited @ support). Only fenced code blocks still
+  // benefit from card rendering.
+  //
+  // The table-count guard is kept as a safety valve: when a reply also
+  // contains an excessive number of markdown tables, skip the card entirely
+  // rather than risk a card-render failure.
   const tableMatches = findMarkdownTablesOutsideCodeBlocks(text);
   if (tableMatches.length > FEISHU_CARD_TABLE_LIMIT) {
     return false;
   }
   // Fenced code blocks
   if (/```[\s\S]*?```/.test(text)) {
-    return true;
-  }
-  // Markdown tables (header + separator rows separated by pipes)
-  if (tableMatches.length > 0) {
     return true;
   }
   return false;

--- a/src/channel/abort-detect.ts
+++ b/src/channel/abort-detect.ts
@@ -103,6 +103,67 @@ export function isLikelyAbortText(text: string): boolean {
   return isAbortTrigger(trimmed);
 }
 
+// ---------------------------------------------------------------------------
+// Conversation stop-intent (broader than the exact abort triggers)
+// ---------------------------------------------------------------------------
+
+/**
+ * Conversational "please stop / interrupt this exchange" phrases.
+ *
+ * Deliberately SEPARATE from {@link ABORT_TRIGGERS} (which is synced word-for-
+ * word with OpenClaw core and matched by exact equality, e.g. `/stop`). These
+ * are matched by substring so natural phrasings like "中断对话" or "stop
+ * talking" are caught. The list is intentionally distinctive to avoid false
+ * positives — a false positive only means we skip the deterministic peer-@
+ * backstop for that turn (the model can still @ on its own), which is mild.
+ */
+const STOP_INTENT_PHRASES = [
+  // zh
+  '中断',
+  '中止',
+  '停止',
+  '停下',
+  '停一下',
+  '暂停',
+  '别聊了',
+  '别说了',
+  '别回复',
+  '不要回复',
+  '结束对话',
+  '结束讨论',
+  '闭嘴',
+  // en
+  'stop talking',
+  'stop chatting',
+  'stop the conversation',
+  'stop this conversation',
+  'end the conversation',
+  'end conversation',
+  'shut up',
+  'be quiet',
+  'cut it out',
+  'knock it off',
+  'wrap it up',
+];
+
+/**
+ * Whether an inbound message expresses intent to stop / interrupt the ongoing
+ * (bot-to-bot) exchange. Superset of {@link isLikelyAbortText} plus the
+ * conversational phrases above.
+ *
+ * Used to suppress the deterministic peer-@ backstop: when a human asks the
+ * bots to stop, the acknowledgement must NOT @ the peer bot, or the forced @
+ * would re-wake it and defeat the interruption.
+ */
+export function isConversationStopIntent(text: string): boolean {
+  if (!text) return false;
+  // Drop bot mention placeholders so "@Bot 中断对话" → "中断对话".
+  const normalized = text.replace(/@_user_\d+/g, '').trim().toLowerCase();
+  if (!normalized) return false;
+  if (isLikelyAbortText(normalized)) return true;
+  return STOP_INTENT_PHRASES.some((p) => normalized.includes(p));
+}
+
 /**
  * Extract the raw text payload from a Feishu message event.
  *

--- a/src/channel/abort-detect.ts
+++ b/src/channel/abort-detect.ts
@@ -118,32 +118,54 @@ export function isLikelyAbortText(text: string): boolean {
  * backstop for that turn (the model can still @ on its own), which is mild.
  */
 const STOP_INTENT_PHRASES = [
-  // zh
+  // zh — stop / terminate / pause
   '中断',
   '中止',
+  '终止',
   '停止',
   '停下',
   '停一下',
   '暂停',
-  '别聊了',
+  '打住',
+  '停手',
+  '收手',
+  // zh — "don't keep going / replying"
+  '别聊',
   '别说了',
   '别回复',
+  '别继续',
+  '别再聊',
+  '别再说',
+  '别吵',
+  '别争',
   '不要回复',
+  '不要继续',
+  '不用回复',
+  '不用继续',
+  // zh — "wrap up / be quiet"
   '结束对话',
   '结束讨论',
+  '结束辩论',
+  '到此为止',
   '闭嘴',
   // en
   'stop talking',
   'stop chatting',
+  'stop debating',
+  'stop the debate',
   'stop the conversation',
   'stop this conversation',
+  'stop responding',
+  'stop replying',
   'end the conversation',
   'end conversation',
+  'end the debate',
   'shut up',
   'be quiet',
   'cut it out',
   'knock it off',
   'wrap it up',
+  'stand down',
 ];
 
 /**
@@ -151,9 +173,12 @@ const STOP_INTENT_PHRASES = [
  * (bot-to-bot) exchange. Superset of {@link isLikelyAbortText} plus the
  * conversational phrases above.
  *
- * Used to suppress the deterministic peer-@ backstop: when a human asks the
- * bots to stop, the acknowledgement must NOT @ the peer bot, or the forced @
- * would re-wake it and defeat the interruption.
+ * Two consumers: (1) suppress the deterministic peer-@ backstop so a stop
+ * acknowledgement doesn't re-wake the peer bot; (2) mute an active bot loop so
+ * the in-flight ping-pong drains instead of being re-armed. Substring match —
+ * keep the list distinctive (no bare "停"/"stop") to limit false positives;
+ * the worst case is a missed forced-@ or a self-healing mute (any normal
+ * message lifts it).
  */
 export function isConversationStopIntent(text: string): boolean {
   if (!text) return false;

--- a/src/core/config-schema.ts
+++ b/src/core/config-schema.ts
@@ -148,6 +148,9 @@ export const FeishuGroupSchema = z.object({
   allowFrom: AllowFromSchema,
   systemPrompt: z.string().optional(),
   allowBots: AllowBotsSchema,
+  // When true, bot-to-bot replies are allowed to stay inside a thread/topic
+  // instead of being forced to the main chat (relaxes the #32980 guard).
+  replyInThread: z.boolean().optional(),
 });
 
 // ---------------------------------------------------------------------------
@@ -197,6 +200,9 @@ export const FeishuAccountConfigSchema = z.object({
   reactionNotifications: ReactionNotificationModeSchema,
   threadSession: z.boolean().optional(),
   allowBots: AllowBotsSchema,
+  // Account-level default for letting bot-to-bot replies stay in a thread
+  // (per-group `replyInThread` overrides this).
+  replyInThread: z.boolean().optional(),
   uat: UATConfigSchema,
 });
 

--- a/src/messaging/converters/content-converter-helpers.ts
+++ b/src/messaging/converters/content-converter-helpers.ts
@@ -61,8 +61,13 @@ export function buildConvertContextFromItem(
 /**
  * Resolve mention placeholders in text.
  *
- * - Bot mentions: remove the placeholder key and any preceding `@botName`
- *   entirely (with trailing whitespace).
+ * - Bot self-mention + stripBotMentions: leading-only strip. When the
+ *   self-mention sits at the very start of the message, drop it (the
+ *   `WasMentioned` envelope field already tells the agent "this message
+ *   was addressed to you", so the anchor is redundant). When it appears
+ *   mid-text, render it as plain `@Name` so the surrounding context still
+ *   reads naturally without leaving an inline anchor the LLM might echo
+ *   back into its reply.
  * - Non-bot mentions: replace the placeholder key with readable `@name`.
  */
 export function resolveMentions(text: string, ctx: ConvertContext): string {
@@ -71,8 +76,11 @@ export function resolveMentions(text: string, ctx: ConvertContext): string {
   let result = text;
   for (const [key, info] of ctx.mentions) {
     if (info.isBot && ctx.stripBotMentions) {
-      result = result.replace(new RegExp(`@${escapeRegExp(info.name)}\\s*`, 'g'), '').trim();
-      result = result.replace(new RegExp(escapeRegExp(key) + '\\s*', 'g'), '').trim();
+      result = result.replace(new RegExp(escapeRegExp(key), 'g'), `@${info.name}`);
+      const leadingPattern = new RegExp(
+        `^\\s*@${escapeRegExp(info.name)}[\\s,，:：]*`,
+      );
+      result = result.replace(leadingPattern, '').trimStart();
     } else {
       result = result.replace(new RegExp(escapeRegExp(key), 'g'), `@${info.name}`);
     }

--- a/src/messaging/inbound/bot-content.ts
+++ b/src/messaging/inbound/bot-content.ts
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Reply-routing decisions for the Feishu dispatch path.
+ *
+ * In bot-to-bot group scenarios, Feishu will pull thread-style replies into
+ * a hidden "topic view" that group members cannot see (#32980). The peer bot
+ * keeps receiving messages but humans in the chat see nothing — a silent
+ * failure mode that turns bot↔bot chat into a black hole.
+ *
+ * This module centralizes the three signals that decide where a reply lands:
+ *   1. isGroup            — DMs never have the topic-view trap
+ *   2. senderIsBot        — only bot→bot triggers it
+ *   3. dc.isThread        — inbound was a thread reply (also inferred from
+ *                            root_id in topic groups when threadSession=true)
+ *
+ * Output: a routing object consumed by every outbound call site (main
+ * dispatcher + i18n command card + i18n command text fallback), so the
+ * three call sites never drift out of sync again.
+ */
+
+import { isThreadCapableGroup } from '../../core/chat-info-cache';
+import { larkLogger } from '../../core/lark-logger';
+import type { MentionInfo } from '../types';
+import type { DispatchContext } from './dispatch-context';
+
+const log = larkLogger('inbound/bot-content');
+
+/** The peer a reply must explicitly @-mention so it actually reaches them. */
+export interface BotPeerTarget {
+  peerOpenId: string;
+  peerName: string;
+}
+
+/**
+ * Decide which peer (if any) an outbound reply must be guaranteed to
+ * @-mention, so the deterministic `ensureMention` backstop can wake them up.
+ *
+ * Deliberately INDEPENDENT of `suppressForBotPeer` (which only governs
+ * thread-vs-main routing): the addressee must be resolvable even on a
+ * human-orchestrated kickoff, where the triggering sender is a person but the
+ * conversation is meant to continue between bots.
+ *
+ *   1. Bot sender  → @ the sender back, continuing the exchange.
+ *   2. Otherwise (e.g. a human kicking off a bot debate) → if the inbound
+ *      message @-mentions exactly ONE party other than ourselves, treat that
+ *      party as the designated peer. Zero / multiple non-self mentions are
+ *      ambiguous, so we add no forced @ (avoids spamming unrelated members).
+ *
+ * Group-only: bot-at-bot @ delivery semantics don't apply to DMs.
+ */
+export function resolveBotPeerForMention(params: {
+  isGroup: boolean;
+  senderIsBot?: boolean;
+  senderId?: string;
+  senderName?: string;
+  mentions: MentionInfo[];
+  botOpenId?: string;
+}): BotPeerTarget | undefined {
+  if (!params.isGroup) return undefined;
+
+  // 1. Bot sender → keep the ping-pong going by @-ing them back.
+  if (params.senderIsBot && params.senderId) {
+    return { peerOpenId: params.senderId, peerName: params.senderName ?? params.senderId };
+  }
+
+  // 2. Human-orchestrated kickoff → the single non-self @-mentioned party.
+  const seen = new Set<string>();
+  const others: MentionInfo[] = [];
+  for (const m of params.mentions) {
+    if (!m.openId || m.isBot || m.openId === params.botOpenId) continue;
+    if (seen.has(m.openId)) continue;
+    seen.add(m.openId);
+    others.push(m);
+  }
+  if (others.length === 1) {
+    return { peerOpenId: others[0].openId, peerName: others[0].name || others[0].openId };
+  }
+  return undefined;
+}
+
+export interface FeishuReplyRouting {
+  /** Whether to send the reply as a thread-scoped message. */
+  replyInThread: boolean;
+  /** Effective thread_id when replying in-thread; undefined otherwise. */
+  threadId: string | undefined;
+  /** True when the peer is a bot in a group chat: suppress thread-mode reply
+   *  so the message lands in the main chat (avoiding the hidden topic view,
+   *  #32980). Consumers may also use this signal for additional bot-peer-
+   *  specific behavior (e.g. ensureMention in outbound-mention). */
+  suppressForBotPeer: boolean;
+}
+
+/**
+ * Resolve reply routing for the current dispatch, performing two tasks:
+ *
+ *  1. **Topic-group thread inference (may mutate `dc`).** In topic groups
+ *     (chat_mode=topic), reply events may carry `root_id` without
+ *     `thread_id`. When `threadSession` is enabled and the chat is
+ *     thread-capable, treat `root_id` as a synthetic `threadId` so replies
+ *     stay inside the topic instead of creating a new top-level message.
+ *     This step mutates `dc.isThread` and `dc.ctx.threadId` so subsequent
+ *     code (session-key resolution, sentinel scoping, history scoping)
+ *     observes the same routing decision.
+ *
+ *  2. **Reply routing decision (pure).** Computes `replyInThread` and
+ *     `suppressForBotPeer` from the post-inference state. In bot→bot group
+ *     chats `replyInThread` is forced to `false` regardless of the inbound
+ *     shape, preventing the topic-view trap.
+ */
+export async function resolveFeishuReplyRouting(
+  dc: DispatchContext,
+  opts: { replyInThreadConfig?: boolean } = {},
+): Promise<FeishuReplyRouting> {
+  // Step 1: topic-group thread inference (async + side effects on dc)
+  if (
+    !dc.isThread &&
+    dc.isGroup &&
+    dc.ctx.rootId &&
+    dc.account.config?.threadSession === true
+  ) {
+    const threadCapable = await isThreadCapableGroup({
+      cfg: dc.accountScopedCfg,
+      chatId: dc.ctx.chatId,
+      accountId: dc.account.accountId,
+    });
+    if (threadCapable) {
+      log.info(
+        `inferred thread from root_id=${dc.ctx.rootId} in topic group ${dc.ctx.chatId}`,
+      );
+      dc.isThread = true;
+      dc.ctx = { ...dc.ctx, threadId: dc.ctx.rootId };
+    }
+  }
+
+  // Step 2: bot-peer suppression decision (pure read of dc state).
+  //
+  // We force a bot→bot reply out of the thread only when it would otherwise
+  // snowball an *auto-detected* threadReply into a hidden topic view (#32980).
+  // Two escape hatches keep parity with openclaw core (PR #89783):
+  //   - isTopicSession: a deliberate topic session (threadSession enabled +
+  //     inbound is in a thread) is human-visible by design — keep it threaded.
+  //   - replyInThread config: operators can opt in per-group/account.
+  const isTopicSession = dc.isThread && dc.account.config?.threadSession === true;
+  const configReplyInThread = opts.replyInThreadConfig === true;
+  const suppressForBotPeer =
+    dc.isGroup && !!dc.ctx.senderIsBot && !isTopicSession && !configReplyInThread;
+  const replyInThread = !suppressForBotPeer && dc.isThread;
+  const threadId = replyInThread ? dc.ctx.threadId : undefined;
+
+  return { replyInThread, threadId, suppressForBotPeer };
+}

--- a/src/messaging/inbound/bot-loop-guard.ts
+++ b/src/messaging/inbound/bot-loop-guard.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Cross-bot loop guard for bot-at-bot (ping-pong) conversations.
+ *
+ * Background: when two different bots @-mention each other in a group, each
+ * reply wakes the other, which replies again — an endless debate. The
+ * existing self-echo filter only drops a bot's *own* echo; it does nothing
+ * for A↔B loops. This module adds a deterministic hard brake: count the
+ * consecutive turns whose sender is a bot per (chat, thread), and stop
+ * auto-replying once the count exceeds a cap. Any human turn resets the
+ * counter, so a new human-driven exchange starts fresh.
+ *
+ * State is process-local and best-effort (each bot process keeps its own
+ * counter for the peer's messages it receives). Idle conversations decay so
+ * a long-quiet chat doesn't carry a stale count into a new exchange.
+ */
+
+/** Max consecutive bot-originated turns before auto-reply is suppressed. */
+export const MAX_CONSECUTIVE_BOT_TURNS = 10;
+
+/** Idle window after which a conversation's counter is considered stale. */
+export const BOT_LOOP_IDLE_RESET_MS = 10 * 60 * 1000; // 10 min
+
+interface LoopState {
+  count: number;
+  updatedAt: number;
+}
+
+// `${chatId}:${threadId ?? ''}` -> consecutive bot-turn state
+const states = new Map<string, LoopState>();
+
+function loopKey(chatId: string, threadId?: string): string {
+  return `${chatId}:${threadId ?? ''}`;
+}
+
+export interface BotTurnVerdict {
+  /** False once the consecutive bot-turn count exceeds the cap. */
+  allowed: boolean;
+  /** The current consecutive bot-turn count after this turn. */
+  count: number;
+  /** The configured cap, for logging. */
+  limit: number;
+}
+
+/**
+ * Record one bot-originated turn for the given conversation and decide
+ * whether the bot should still auto-reply.
+ *
+ * Increments the consecutive-bot-turn counter (resetting first if the
+ * conversation has been idle past the decay window), then returns
+ * `allowed: false` once the count exceeds {@link MAX_CONSECUTIVE_BOT_TURNS}.
+ */
+export function noteBotTurnAndCheck(
+  chatId: string,
+  threadId?: string,
+  now: number = Date.now(),
+): BotTurnVerdict {
+  const key = loopKey(chatId, threadId);
+  const prev = states.get(key);
+  const fresh = prev && now - prev.updatedAt <= BOT_LOOP_IDLE_RESET_MS;
+  const count = (fresh ? prev!.count : 0) + 1;
+  states.set(key, { count, updatedAt: now });
+  return {
+    allowed: count <= MAX_CONSECUTIVE_BOT_TURNS,
+    count,
+    limit: MAX_CONSECUTIVE_BOT_TURNS,
+  };
+}
+
+/**
+ * Reset the consecutive bot-turn counter for a conversation. Called on every
+ * human turn so a human stepping in always re-arms the debate budget.
+ */
+export function resetBotLoop(chatId: string, threadId?: string): void {
+  states.delete(loopKey(chatId, threadId));
+}
+
+/** Clear all loop state. Intended for tests. */
+export function resetAllBotLoops(): void {
+  states.clear();
+}

--- a/src/messaging/inbound/bot-loop-guard.ts
+++ b/src/messaging/inbound/bot-loop-guard.ts
@@ -31,8 +31,26 @@ interface LoopState {
 // `${chatId}:${threadId ?? ''}` -> consecutive bot-turn state
 const states = new Map<string, LoopState>();
 
+// Timestamp of the last stale-entry sweep, to bound sweep frequency.
+let lastSweepAt = 0;
+
 function loopKey(chatId: string, threadId?: string): string {
   return `${chatId}:${threadId ?? ''}`;
+}
+
+/**
+ * Evict entries idle past the decay window. Called opportunistically from
+ * noteBotTurnAndCheck (at most once per idle window) so the Map can't grow
+ * unbounded for bot-only chats that never see a human turn to reset them.
+ * Dropping a stale entry is equivalent to leaving it: the next access would
+ * reset its count to 1 via the freshness check anyway.
+ */
+function sweepStale(now: number): void {
+  if (now - lastSweepAt < BOT_LOOP_IDLE_RESET_MS) return;
+  lastSweepAt = now;
+  for (const [key, state] of states) {
+    if (now - state.updatedAt > BOT_LOOP_IDLE_RESET_MS) states.delete(key);
+  }
 }
 
 export interface BotTurnVerdict {
@@ -57,6 +75,7 @@ export function noteBotTurnAndCheck(
   threadId?: string,
   now: number = Date.now(),
 ): BotTurnVerdict {
+  sweepStale(now);
   const key = loopKey(chatId, threadId);
   const prev = states.get(key);
   const fresh = prev && now - prev.updatedAt <= BOT_LOOP_IDLE_RESET_MS;
@@ -80,4 +99,10 @@ export function resetBotLoop(chatId: string, threadId?: string): void {
 /** Clear all loop state. Intended for tests. */
 export function resetAllBotLoops(): void {
   states.clear();
+  lastSweepAt = 0;
+}
+
+/** Number of tracked conversations. Intended for tests. */
+export function botLoopStateSize(): number {
+  return states.size;
 }

--- a/src/messaging/inbound/dispatch-builders.ts
+++ b/src/messaging/inbound/dispatch-builders.ts
@@ -39,7 +39,16 @@ export function buildMentionAnnotation(
   ctx: MessageContext,
   sentinels?: SentinelEntry[],
 ): string | undefined {
+  // When this bot itself was @-mentioned, tell the agent explicitly. The
+  // leading self-mention is stripped from the body, so without this the
+  // agent has no signal that it was the addressee and may mis-attribute
+  // instructions to another mentioned party.
+  const selfMention = ctx.mentions.find((m) => m.isBot);
   const sections = [
+    selfMention
+      ? `You (${selfMention.name}, open_id: ${selfMention.openId}) were directly @mentioned in this message; ` +
+        `the message body is addressed to you.`
+      : undefined,
     formatMentionList(nonBotMentions(ctx)),
     formatSentinelFeedback(sentinels),
   ].filter((s): s is string => !!s);
@@ -188,6 +197,61 @@ export function buildInboundPayload(
     OriginatingChannel: 'feishu' as const,
     OriginatingTo: opts.originatingTo ?? dc.feishuTo,
   });
+}
+
+// ---------------------------------------------------------------------------
+// Bot-at-Bot identity & guidance
+// ---------------------------------------------------------------------------
+
+/**
+ * Structured identity signals injected into the agent envelope so the LLM
+ * can tell "who is talking to me" apart — in particular whether the sender
+ * is a bot, and what the bot's own open_id is.
+ *
+ * BotOpenId is omitted when unknown (e.g. startup race before the bot info
+ * probe completes) to avoid surfacing an empty identity to the agent.
+ */
+export function buildFeishuIdentityFields(
+  ctx: MessageContext,
+  botOpenId?: string,
+): Record<string, unknown> {
+  return {
+    SenderIsBot: ctx.senderIsBot ?? false,
+    ...(botOpenId ? { BotOpenId: botOpenId } : {}),
+  };
+}
+
+/** Static guidance about Feishu's bot-at-bot @ semantics and loop hygiene. */
+const FEISHU_BOT_AT_BOT_GUIDANCE =
+  'On Feishu, another bot only receives a message when you explicitly @-mention it; ' +
+  'a plain message or a reply without an @ will NOT reach another bot. ' +
+  'When you need another bot to continue the work, @-mention it. ' +
+  'When no further action is needed, or you are asked to stop, do not reply — ' +
+  'this avoids endless bot-to-bot loops.';
+
+/**
+ * Build the effective group system prompt for a Feishu group chat.
+ *
+ * Always prepends bot-at-bot guidance (self-identity + @ semantics + loop
+ * hygiene) so the agent knows which open_id is itself, how Feishu @-delivery
+ * works, and when to stop; then appends any operator-configured group
+ * systemPrompt. Returns `undefined` only when there is nothing to inject.
+ */
+export function buildFeishuGroupSystemPrompt(
+  configured: string | undefined,
+  botOpenId?: string,
+): string | undefined {
+  const parts: string[] = [];
+  if (botOpenId) {
+    parts.push(`Your own Feishu open_id is "${botOpenId}"; any @-mention of this open_id refers to you.`);
+  }
+  parts.push(FEISHU_BOT_AT_BOT_GUIDANCE);
+  const trimmedConfigured = configured?.trim();
+  if (trimmedConfigured) {
+    parts.push(trimmedConfigured);
+  }
+  const merged = parts.join('\n\n').trim();
+  return merged || undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/messaging/inbound/dispatch.ts
+++ b/src/messaging/inbound/dispatch.ts
@@ -30,7 +30,7 @@ import {
 } from '../../channel/chat-queue';
 import { resolveToolUseDisplayConfig } from '../../card/tool-use-config';
 import { clearToolUseTraceRun, startToolUseTraceRun } from '../../card/tool-use-trace-store';
-import { isLikelyAbortText } from '../../channel/abort-detect';
+import { isConversationStopIntent, isLikelyAbortText } from '../../channel/abort-detect';
 import { runWithBotPeerContext } from '../outbound/bot-peer-context';
 import { isCommentTarget } from '../../core/comment-target';
 import { SYNTHETIC_VC_CHAT_ID, isSyntheticTarget } from '../../core/synthetic-target';
@@ -578,14 +578,20 @@ export async function dispatchToAgent(params: {
     // System commands intentionally skip history cleanup — command handlers
     // don't consume history context, so entries are preserved for the next
     // normal message.
-    const botPeer = resolveBotPeerForMention({
-      isGroup: dc.isGroup,
-      senderIsBot: dc.ctx.senderIsBot,
-      senderId: dc.ctx.senderId,
-      senderName: dc.ctx.senderName ?? undefined,
-      mentions: dc.ctx.mentions,
-      botOpenId: params.botOpenId,
-    });
+    // A human asking the bots to stop ("中断对话", "stop talking", …) must NOT
+    // get a forced peer-@: the deterministic ensureMention backstop would
+    // re-wake the peer bot and defeat the interruption. Skip peer resolution
+    // on stop-intent; the kickoff/continue path ("你们辩论") is unaffected.
+    const botPeer = isConversationStopIntent(dc.ctx.content ?? '')
+      ? undefined
+      : resolveBotPeerForMention({
+          isGroup: dc.isGroup,
+          senderIsBot: dc.ctx.senderIsBot,
+          senderId: dc.ctx.senderId,
+          senderName: dc.ctx.senderName ?? undefined,
+          mentions: dc.ctx.mentions,
+          botOpenId: params.botOpenId,
+        });
     await dispatchNormalMessage(
       dc,
       ctxPayload,

--- a/src/messaging/inbound/dispatch.ts
+++ b/src/messaging/inbound/dispatch.ts
@@ -31,7 +31,7 @@ import {
 import { resolveToolUseDisplayConfig } from '../../card/tool-use-config';
 import { clearToolUseTraceRun, startToolUseTraceRun } from '../../card/tool-use-trace-store';
 import { isLikelyAbortText } from '../../channel/abort-detect';
-import { isThreadCapableGroup } from '../../core/chat-info-cache';
+import { runWithBotPeerContext } from '../outbound/bot-peer-context';
 import { isCommentTarget } from '../../core/comment-target';
 import { SYNTHETIC_VC_CHAT_ID, isSyntheticTarget } from '../../core/synthetic-target';
 import { encodeFeishuRouteTarget } from '../../core/targets';
@@ -41,10 +41,18 @@ import { runFeishuDoctorI18n } from '../../commands/doctor';
 import { runFeishuAuthI18n } from '../../commands/auth';
 import { getFeishuHelpI18n, runFeishuStartI18n } from '../../commands/index';
 import { buildI18nMarkdownCard, sendCardFeishu, sendMessageFeishu } from '../outbound/send';
+import {
+  type BotPeerTarget,
+  type FeishuReplyRouting,
+  resolveBotPeerForMention,
+  resolveFeishuReplyRouting,
+} from './bot-content';
 import { dispatchPermissionNotification, dispatchSystemCommand } from './dispatch-commands';
 import {
   buildBodyForAgent,
   buildEnvelopeWithHistory,
+  buildFeishuGroupSystemPrompt,
+  buildFeishuIdentityFields,
   buildInboundPayload,
   buildMessageBody,
 } from './dispatch-builders';
@@ -205,12 +213,14 @@ async function dispatchSyntheticMessage(
 async function dispatchNormalMessage(
   dc: DispatchContext,
   ctxPayload: ReturnType<typeof LarkClient.runtime.channel.reply.finalizeInboundContext>,
+  routing: FeishuReplyRouting,
   chatHistories: Map<string, HistoryEntry[]> | undefined,
   historyKey: string | undefined,
   historyLimit: number,
   replyToMessageId?: string,
   skillFilter?: string[],
   skipTyping?: boolean,
+  botPeer?: BotPeerTarget,
 ): Promise<void> {
   // Synthetic targets (e.g. VC meeting-invited) have no real IM peer to
   // deliver replies to. Route them through the buffered block dispatcher
@@ -261,8 +271,8 @@ async function dispatchNormalMessage(
     accountId: dc.account.accountId,
     chatType: dc.ctx.chatType,
     skipTyping,
-    replyInThread: dc.isThread,
-    threadId: dc.isThread ? dc.ctx.threadId : undefined,
+    replyInThread: routing.replyInThread,
+    threadId: routing.threadId,
     toolUseDisplay,
   });
 
@@ -278,17 +288,27 @@ async function dispatchNormalMessage(
   dc.log(`feishu[${dc.account.accountId}]: dispatching to agent (session=${effectiveSessionKey})`);
   log.info(`dispatching to agent (session=${effectiveSessionKey})`);
 
+  // Attach the resolved bot-peer (if any) so the outbound `ensureMention`
+  // backstop can guarantee an @ even when the LLM forgets. Resolved by the
+  // caller (dispatchToAgent) and decoupled from thread routing. Undefined →
+  // pure no-op.
+  const withBotPeer = botPeer
+    ? <T>(fn: () => Promise<T>): Promise<T> => runWithBotPeerContext(botPeer, fn)
+    : <T>(fn: () => Promise<T>): Promise<T> => fn();
+
   try {
-    const { queuedFinal, counts } = await dc.core.channel.reply.dispatchReplyFromConfig({
-      ctx: ctxPayload,
-      cfg: dc.accountScopedCfg,
-      dispatcher,
-      replyOptions: {
-        ...replyOptions,
-        abortSignal: abortController.signal,
-        ...(skillFilter ? { skillFilter } : {}),
-      },
-    });
+    const { queuedFinal, counts } = await withBotPeer(() =>
+      dc.core.channel.reply.dispatchReplyFromConfig({
+        ctx: ctxPayload,
+        cfg: dc.accountScopedCfg,
+        dispatcher,
+        replyOptions: {
+          ...replyOptions,
+          abortSignal: abortController.signal,
+          ...(skillFilter ? { skillFilter } : {}),
+        },
+      }),
+    );
 
     // Wait for all enqueued deliver() calls in the SDK's sendChain to
     // complete before marking the dispatch as done.  Without this,
@@ -296,7 +316,10 @@ async function dispatchNormalMessage(
     // still pending in the Promise chain, causing markFullyComplete() to
     // block it and leaving completedText incomplete — which in turn makes
     // the streaming card's final update show truncated content.
-    await dispatcher.waitForIdle();
+    //
+    // Run under withBotPeer too so any deliveries flushed during waitForIdle
+    // still see the peer context.
+    await withBotPeer(() => dispatcher.waitForIdle());
 
     markFullyComplete();
     markDispatchIdle();
@@ -348,27 +371,20 @@ export async function dispatchToAgent(params: {
   defaultGroupConfig?: FeishuGroupConfig;
   /** When true, the reply dispatcher skips typing indicators. */
   skipTyping?: boolean;
+  /** The receiving bot's own open_id, used for self-identity injection. */
+  botOpenId?: string;
 }): Promise<void> {
   // 1. Derive shared context (including route resolution + system event)
   const dc = buildDispatchContext(params);
 
-  // 1a. Thread detection fallback for topic groups.
-  //     In topic groups (chat_mode=topic), reply events may carry root_id
-  //     without thread_id.  When threadSession is enabled, use root_id as
-  //     a synthetic threadId so replies stay inside the topic instead of
-  //     creating a new top-level message.
-  if (!dc.isThread && dc.isGroup && dc.ctx.rootId && dc.account.config?.threadSession === true) {
-    const threadCapable = await isThreadCapableGroup({
-      cfg: dc.accountScopedCfg,
-      chatId: dc.ctx.chatId,
-      accountId: dc.account.accountId,
-    });
-    if (threadCapable) {
-      log.info(`inferred thread from root_id=${dc.ctx.rootId} in topic group ${dc.ctx.chatId}`);
-      dc.isThread = true;
-      dc.ctx = { ...dc.ctx, threadId: dc.ctx.rootId };
-    }
-  }
+  // 1a. Reply routing: handles topic-group thread inference (may mutate dc)
+  //     and bot-peer suppression for bot→bot group scenarios (#32980).
+  //     See src/messaging/inbound/bot-content.ts for the full rationale.
+  const replyInThreadConfig =
+    params.groupConfig?.replyInThread ??
+    params.defaultGroupConfig?.replyInThread ??
+    dc.account.config?.replyInThread;
+  const routing = await resolveFeishuReplyRouting(dc, { replyInThreadConfig });
 
   // 1b. Resolve thread session isolation (async: may query group info API)
   if (dc.isThread && dc.ctx.threadId) {
@@ -431,8 +447,14 @@ export async function dispatchToAgent(params: {
 
   // 8. Build inbound context payload
   const isBareNewOrReset = /^\/(?:new|reset)\s*$/i.test((params.ctx.content ?? '').trim());
-  const groupSystemPrompt = dc.isGroup
+  const configuredGroupPrompt = dc.isGroup
     ? params.groupConfig?.systemPrompt?.trim() || params.defaultGroupConfig?.systemPrompt?.trim() || undefined
+    : undefined;
+  // In group chats, always inject bot-at-bot guidance (self open_id + @
+  // delivery rules + loop hygiene), merged with any operator-configured
+  // group prompt. Complements the deterministic ensureMention safety net.
+  const groupSystemPrompt = dc.isGroup
+    ? buildFeishuGroupSystemPrompt(configuredGroupPrompt, params.botOpenId)
     : undefined;
   const originatingTo =
     isBareNewOrReset && dc.isThread
@@ -464,6 +486,7 @@ export async function dispatchToAgent(params: {
     extraFields: {
       ...params.mediaPayload,
       ...(params.extraInboundFields ?? {}),
+      ...buildFeishuIdentityFields(params.ctx, params.botOpenId),
       ...(groupSystemPrompt ? { GroupSystemPrompt: groupSystemPrompt } : {}),
       ...(dc.ctx.threadId ? { MessageThreadId: dc.ctx.threadId } : {}),
     },
@@ -514,7 +537,7 @@ export async function dispatchToAgent(params: {
         card,
         replyToMessageId: params.replyToMessageId ?? dc.ctx.messageId,
         accountId: dc.account.accountId,
-        replyInThread: dc.isThread,
+        replyInThread: routing.replyInThread,
       });
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
@@ -525,7 +548,7 @@ export async function dispatchToAgent(params: {
         text: `${i18nCommandName} failed: ${errMsg}`,
         replyToMessageId: params.replyToMessageId ?? dc.ctx.messageId,
         accountId: dc.account.accountId,
-        replyInThread: dc.isThread,
+        replyInThread: routing.replyInThread,
       });
     }
     return;
@@ -555,15 +578,25 @@ export async function dispatchToAgent(params: {
     // System commands intentionally skip history cleanup — command handlers
     // don't consume history context, so entries are preserved for the next
     // normal message.
+    const botPeer = resolveBotPeerForMention({
+      isGroup: dc.isGroup,
+      senderIsBot: dc.ctx.senderIsBot,
+      senderId: dc.ctx.senderId,
+      senderName: dc.ctx.senderName ?? undefined,
+      mentions: dc.ctx.mentions,
+      botOpenId: params.botOpenId,
+    });
     await dispatchNormalMessage(
       dc,
       ctxPayload,
+      routing,
       params.chatHistories,
       historyKey,
       params.historyLimit,
       params.replyToMessageId,
       skillFilter,
       params.skipTyping,
+      botPeer,
     );
   }
 }

--- a/src/messaging/inbound/handler.ts
+++ b/src/messaging/inbound/handler.ts
@@ -149,7 +149,7 @@ export async function handleFeishuMessage(params: {
   // fresh human-driven exchange always starts clean (counter checked below,
   // after the gate, only for bot senders).
   if (!ctx.senderIsBot) {
-    resetBotLoop(ctx.chatId, ctx.threadId);
+    resetBotLoop(ctx.chatId, ctx.threadId ?? ctx.rootId);
   }
 
   log(`feishu[${account.accountId}]: received message from ${ctx.senderId} in ${ctx.chatId} (${ctx.chatType})`);
@@ -255,7 +255,12 @@ export async function handleFeishuMessage(params: {
   // above. Checked after the gate so only messages we would actually act on
   // are counted.
   if (ctx.senderIsBot) {
-    const verdict = noteBotTurnAndCheck(ctx.chatId, ctx.threadId);
+    // Use root_id when thread_id is absent: in topic groups, reply events
+    // often carry only root_id (thread_id is inferred later in dispatch), and
+    // the queue/dispatch key uses the same fallback. Without it, all topics in
+    // a chat share one chat-level counter and one topic's cutoff suppresses
+    // the others.
+    const verdict = noteBotTurnAndCheck(ctx.chatId, ctx.threadId ?? ctx.rootId);
     if (!verdict.allowed) {
       log(
         `feishu[${account.accountId}]: bot-loop guard tripped ` +

--- a/src/messaging/inbound/handler.ts
+++ b/src/messaging/inbound/handler.ts
@@ -272,20 +272,26 @@ export async function handleFeishuMessage(params: {
       // loop. A human message resets the counter and re-arms auto-reply.
       //
       // Deliver it where the debate actually is: reply to the triggering
-      // message. Only thread the notice when the inbound is genuinely in a
-      // Feishu thread (real thread_id) AND this account runs deliberate topic
-      // sessions — mirroring resolveFeishuReplyRouting, which keeps bot↔bot
-      // replies threaded only in that case and otherwise forces them flat
-      // (#32980). Crucially we must NOT treat root_id as a thread here: a plain
-      // bot↔bot quote-reply chain in a normal group carries root_id but no
-      // thread_id, and reply_in_thread=true on such a message makes Feishu mint
-      // a brand-new topic for just the notice — pulling it into a thread the
-      // debate itself was never in.
+      // message. Thread the notice only when the bot↔bot reply body would also
+      // be threaded — i.e. mirror resolveFeishuReplyRouting's effective
+      // replyInThread for a bot turn: a real thread_id is present AND threading
+      // is opted in (threadSession or replyInThread). Crucially we must NOT
+      // treat root_id as a thread here: a plain bot↔bot quote-reply chain in a
+      // normal group carries root_id but no thread_id, and reply_in_thread=true
+      // on such a message makes Feishu mint a brand-new topic for just the
+      // notice — pulling it into a thread the debate itself was never in.
       if (verdict.count === verdict.limit + 1) {
         try {
           // Localized via i18nTexts so the viewer's Feishu client renders the
           // notice in its own language (same mechanism as /help, /doctor).
-          const inThread = Boolean(ctx.threadId) && account.config?.threadSession === true;
+          // replyInThread precedence matches dispatch (group > default > account).
+          const replyInThreadCfg =
+            groupConfig?.replyInThread ??
+            defaultGroupConfig?.replyInThread ??
+            account.config?.replyInThread;
+          const inThread =
+            Boolean(ctx.threadId) &&
+            (account.config?.threadSession === true || replyInThreadCfg === true);
           await sendMessageFeishu({
             cfg: accountScopedCfg,
             to: ctx.chatId,

--- a/src/messaging/inbound/handler.ts
+++ b/src/messaging/inbound/handler.ts
@@ -272,15 +272,20 @@ export async function handleFeishuMessage(params: {
       // loop. A human message resets the counter and re-arms auto-reply.
       //
       // Deliver it where the debate actually is: reply to the triggering
-      // message and thread it when that message came from a thread, so a
-      // topic-scoped debate gets the notice inside the topic (not the main
-      // chat). When the debate is in the main chat the inbound carries no
-      // thread, so the notice lands in the main chat too.
+      // message. Only thread the notice when the inbound is genuinely in a
+      // Feishu thread (real thread_id) AND this account runs deliberate topic
+      // sessions — mirroring resolveFeishuReplyRouting, which keeps bot↔bot
+      // replies threaded only in that case and otherwise forces them flat
+      // (#32980). Crucially we must NOT treat root_id as a thread here: a plain
+      // bot↔bot quote-reply chain in a normal group carries root_id but no
+      // thread_id, and reply_in_thread=true on such a message makes Feishu mint
+      // a brand-new topic for just the notice — pulling it into a thread the
+      // debate itself was never in.
       if (verdict.count === verdict.limit + 1) {
         try {
           // Localized via i18nTexts so the viewer's Feishu client renders the
           // notice in its own language (same mechanism as /help, /doctor).
-          const inThread = Boolean(ctx.threadId ?? ctx.rootId);
+          const inThread = Boolean(ctx.threadId) && account.config?.threadSession === true;
           await sendMessageFeishu({
             cfg: accountScopedCfg,
             to: ctx.chatId,
@@ -292,7 +297,7 @@ export async function handleFeishuMessage(params: {
             accountId: account.accountId,
             replyToMessageId: replyToMessageId ?? ctx.messageId,
             replyInThread: inThread,
-            threadId: ctx.threadId ?? ctx.rootId,
+            threadId: inThread ? ctx.threadId : undefined,
           });
         } catch (err) {
           log(`feishu[${account.accountId}]: failed to send loop-guard notice: ${String(err)}`);

--- a/src/messaging/inbound/handler.ts
+++ b/src/messaging/inbound/handler.ts
@@ -30,6 +30,7 @@ import { LarkClient } from '../../core/lark-client';
 import { larkLogger } from '../../core/lark-logger';
 import { ticketElapsed } from '../../core/lark-ticket';
 import { threadScopedKey } from '../../channel/chat-queue';
+import { sendMessageFeishu } from '../outbound/send';
 import { parseMessageEvent } from './parse';
 import {
   prefetchUserNames,
@@ -42,6 +43,8 @@ import { type GateResult, checkMessageGate, readFeishuAllowFromStore } from './g
 import { injectInboundHandler } from './handler-registry';
 import { dispatchToAgent } from './dispatch';
 import { resolveFeishuGroupConfig, splitLegacyGroupAllowFrom } from './policy';
+import { recordMention, recordSender } from './mention-registry';
+import { noteBotTurnAndCheck, resetBotLoop } from './bot-loop-guard';
 
 const logger = larkLogger('inbound/handler');
 
@@ -97,13 +100,28 @@ export async function handleFeishuMessage(params: {
     accountId: account.accountId,
   });
 
+  // Self-echo hard filter — drop messages authored by this very bot before
+  // enrichment, gating, or dispatch. Mirrors the channel-layer filter in
+  // event-handlers.ts so alternate entrypoints into handleFeishuMessage
+  // (synthetic messages, replays, tests) don't bypass it. Skipped when
+  // botOpenId is not yet populated (startup race before bot probe resolves);
+  // the channel-layer filter and downstream bot-sender gate act as fallback.
+  if (botOpenId && ctx.senderId && ctx.senderId === botOpenId) {
+    log(`feishu[${account.accountId}]: drop self-echo message ${ctx.messageId}`);
+    return;
+  }
+
   // 3. Early reject: skip empty-text messages with no media resources.
   //    OpenClaw 2026.4.29 adds a core-side guard for this (##74634), but
   //    rejecting here avoids wasting cycles on enrichment, gate, and
   //    dispatch for messages that would be silently dropped at the deliver
   //    callback anyway.
-  if (!ctx.content.trim() && ctx.resources.length === 0) {
-    log(`feishu[${account.accountId}]: empty message ${ctx.messageId} (no text, no media), skipping`);
+  //    A "bare @" (only a mention, no text/media) is a valid ping in
+  //    bot-at-bot flows — treat it as an intentional wake-up rather than an
+  //    empty message. Only drop messages that carry no text, no media, AND
+  //    no mention at all.
+  if (!ctx.content.trim() && ctx.resources.length === 0 && ctx.mentions.length === 0 && !ctx.mentionAll) {
+    log(`feishu[${account.accountId}]: empty message ${ctx.messageId} (no text, no media, no mention), skipping`);
     return;
   }
 
@@ -114,6 +132,25 @@ export async function handleFeishuMessage(params: {
     log,
   });
   ctx = enrichedCtx;
+
+  // Feed the per-chat name→openId registry that the outbound layer uses to
+  // turn "@Name" in LLM output into a real <at user_id="ou_xxx"> element.
+  // Both the sender and any @-target observed here are valuable signal —
+  // recording them now (before the gate) means we keep learning names even
+  // for messages the gate rejects.
+  if (ctx.senderId && ctx.senderName) {
+    recordSender(ctx.chatId, ctx.senderId, ctx.senderName);
+  }
+  for (const m of ctx.mentions) {
+    if (m.openId && m.name) recordMention(ctx.chatId, m.openId, m.name);
+  }
+
+  // Bot-loop guard: a human turn re-arms the consecutive bot-turn budget so a
+  // fresh human-driven exchange always starts clean (counter checked below,
+  // after the gate, only for bot senders).
+  if (!ctx.senderIsBot) {
+    resetBotLoop(ctx.chatId, ctx.threadId);
+  }
 
   log(`feishu[${account.accountId}]: received message from ${ctx.senderId} in ${ctx.chatId} (${ctx.chatType})`);
   logger.info(`received from ${ctx.senderId} in ${ctx.chatId} (${ctx.chatType})`);
@@ -213,6 +250,53 @@ export async function handleFeishuMessage(params: {
     resolveCommandAuthorizedFromAuthorizers: core.channel.commands.resolveCommandAuthorizedFromAuthorizers,
   });
 
+  // Bot-loop guard: cap consecutive bot↔bot turns so a runaway debate stops
+  // itself. Only bot senders count; a human turn already reset the counter
+  // above. Checked after the gate so only messages we would actually act on
+  // are counted.
+  if (ctx.senderIsBot) {
+    const verdict = noteBotTurnAndCheck(ctx.chatId, ctx.threadId);
+    if (!verdict.allowed) {
+      log(
+        `feishu[${account.accountId}]: bot-loop guard tripped ` +
+          `(${verdict.count}/${verdict.limit} consecutive bot turns) in ${ctx.chatId}, suppressing reply`,
+      );
+      // Surface the cutoff to humans ONCE, on the first over-cap turn, so the
+      // conversation doesn't just go silent. Plain text with no @ — so it
+      // neither wakes the peer bot (allowBots='mentions') nor extends the
+      // loop. A human message resets the counter and re-arms auto-reply.
+      //
+      // Deliver it where the debate actually is: reply to the triggering
+      // message and thread it when that message came from a thread, so a
+      // topic-scoped debate gets the notice inside the topic (not the main
+      // chat). When the debate is in the main chat the inbound carries no
+      // thread, so the notice lands in the main chat too.
+      if (verdict.count === verdict.limit + 1) {
+        try {
+          // Localized via i18nTexts so the viewer's Feishu client renders the
+          // notice in its own language (same mechanism as /help, /doctor).
+          const inThread = Boolean(ctx.threadId ?? ctx.rootId);
+          await sendMessageFeishu({
+            cfg: accountScopedCfg,
+            to: ctx.chatId,
+            text: `⏸️ 已达连续 ${verdict.limit} 轮自动对话上限，已暂停自动回复。需要继续请在群里发一条消息。`,
+            i18nTexts: {
+              zh_cn: `⏸️ 已达连续 ${verdict.limit} 轮自动对话上限，已暂停自动回复。需要继续请在群里发一条消息。`,
+              en_us: `⏸️ Reached the limit of ${verdict.limit} consecutive automated turns; auto-replies are paused. Send a message in the chat to continue.`,
+            },
+            accountId: account.accountId,
+            replyToMessageId: replyToMessageId ?? ctx.messageId,
+            replyInThread: inThread,
+            threadId: ctx.threadId ?? ctx.rootId,
+          });
+        } catch (err) {
+          log(`feishu[${account.accountId}]: failed to send loop-guard notice: ${String(err)}`);
+        }
+      }
+      return;
+    }
+  }
+
   // 9. Dispatch to agent
   // groupConfig and defaultGroupConfig are already resolved above.
 
@@ -232,6 +316,7 @@ export async function handleFeishuMessage(params: {
       groupConfig,
       defaultGroupConfig,
       skipTyping,
+      botOpenId,
     });
   } catch (err) {
     error(`feishu[${account.accountId}]: failed to dispatch message: ${String(err)}`);

--- a/src/messaging/inbound/mention-registry.ts
+++ b/src/messaging/inbound/mention-registry.ts
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Per-chat name → openId registry.
+ *
+ * Backs `normalizeOutboundMentions` / `ensureMention` on the outbound side:
+ * when the LLM writes "@Alice" in a reply, the outbound layer needs to look
+ * up which `ou_xxx` "Alice" maps to in this specific chat to produce a real
+ * Feishu `<at user_id="ou_xxx">` element that actually triggers delivery.
+ *
+ * Two ingestion paths feed the registry:
+ *   1. `recordSender(chatId, openId, name)` — every inbound message's sender
+ *   2. `recordMention(chatId, openId, name)` — every @-target in inbound text
+ *
+ * Entries decay with TTL so stale display names (renames, departed members)
+ * don't pollute future lookups indefinitely. The registry is process-local;
+ * it's a best-effort cache, not a source of truth, and a cache miss simply
+ * means the outbound mention falls back to plain "@Name" text (which Feishu
+ * won't deliver as a notification — that's a graceful degradation, not a
+ * functional failure).
+ */
+
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+
+interface Entry {
+  openId: string;
+  name: string;
+  recordedAt: number;
+}
+
+// chatId -> lowercased name -> Entry
+const registry = new Map<string, Map<string, Entry>>();
+
+function normalizeName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+function getChatMap(chatId: string): Map<string, Entry> {
+  let chatMap = registry.get(chatId);
+  if (!chatMap) {
+    chatMap = new Map();
+    registry.set(chatId, chatMap);
+  }
+  return chatMap;
+}
+
+function recordEntry(chatId: string, openId: string, name: string): void {
+  if (!chatId || !openId || !name) return;
+  const key = normalizeName(name);
+  if (!key) return;
+  getChatMap(chatId).set(key, { openId, name, recordedAt: Date.now() });
+}
+
+/**
+ * Record an @-mention target observed in inbound text.
+ *
+ * The name passed here should be the human-readable display name as parsed
+ * out of the Feishu mention element, not the raw `@user_xxx` placeholder.
+ */
+export function recordMention(chatId: string, openId: string, name: string): void {
+  recordEntry(chatId, openId, name);
+}
+
+/**
+ * Record the sender of an inbound message.
+ *
+ * Even when the sender is never @-mentioned, recording lets the outbound
+ * layer @ them back by name. In bot↔bot flows this is the only way the
+ * receiving bot learns the peer bot's name → openId mapping.
+ */
+export function recordSender(chatId: string, openId: string, name: string): void {
+  recordEntry(chatId, openId, name);
+}
+
+/**
+ * Look up the openId for a name in a given chat. Returns `undefined` when
+ * the name has never been seen, or when the entry has aged out past TTL.
+ *
+ * Caller may pass either the raw mention spelling ("alice", "Alice", "
+ *  Alice ") — name comparison is case-insensitive and ignores surrounding
+ * whitespace.
+ */
+export function lookupByName(
+  chatId: string,
+  name: string,
+  opts: { ttlMs?: number } = {},
+): string | undefined {
+  const chatMap = registry.get(chatId);
+  if (!chatMap) return undefined;
+  const entry = chatMap.get(normalizeName(name));
+  if (!entry) return undefined;
+  const ttl = opts.ttlMs ?? DEFAULT_TTL_MS;
+  if (Date.now() - entry.recordedAt > ttl) {
+    chatMap.delete(normalizeName(name));
+    return undefined;
+  }
+  return entry.openId;
+}
+
+/**
+ * Reset the registry. Intended for tests; production code should rely on
+ * TTL expiry instead.
+ */
+export function resetMentionRegistry(): void {
+  registry.clear();
+}
+
+/**
+ * Drop all entries older than `ttlMs` across every chat. Optional helper
+ * for callers that want a deterministic cleanup tick — `lookupByName`
+ * already does lazy eviction on read.
+ */
+export function purgeStaleEntries(ttlMs: number = DEFAULT_TTL_MS): void {
+  const cutoff = Date.now() - ttlMs;
+  for (const [chatId, chatMap] of registry) {
+    for (const [key, entry] of chatMap) {
+      if (entry.recordedAt < cutoff) chatMap.delete(key);
+    }
+    if (chatMap.size === 0) registry.delete(chatId);
+  }
+}

--- a/src/messaging/outbound/bot-peer-context.ts
+++ b/src/messaging/outbound/bot-peer-context.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * AsyncLocalStorage-backed channel for telling the outbound adapter that
+ * the current dispatch is replying to a bot peer in a group chat.
+ *
+ * Why ALS instead of an extra adapter parameter: the outbound adapter is
+ * channel-agnostic (Slack / Telegram / Feishu share the same shape) and
+ * the SDK owns the call site between dispatch and our outbound. Adding a
+ * Feishu-specific "peer-is-bot" parameter would pollute that interface.
+ * ALS lets the dispatch layer attach context once and have it flow through
+ * the SDK's async chain to the outbound adapter without any other layer
+ * needing to know.
+ *
+ * Lifetime: scoped to a single `runWithBotPeerContext(...)` call. When that
+ * promise settles, the store is gone. No manual cleanup required.
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+export interface BotPeerContext {
+  /** The peer bot's open_id — what `ensureMention` will inject. */
+  peerOpenId: string;
+  /** Display name for the rendered `<at>` element. */
+  peerName: string;
+  /**
+   * Mutable de-dup flag: set once the peer @ has appeared on an outbound
+   * chunk (model-written or injected) so multi-chunk replies don't prepend
+   * the @ to every chunk. Scoped to the single dispatch via the store.
+   */
+  mentioned?: boolean;
+}
+
+const storage = new AsyncLocalStorage<BotPeerContext>();
+
+/**
+ * Run `fn` with the given bot-peer context attached to the async chain.
+ * The outbound adapter's `currentBotPeerContext()` inside `fn` (and any
+ * promises it spawns) will see this store.
+ */
+export function runWithBotPeerContext<T>(
+  ctx: BotPeerContext,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return storage.run(ctx, fn);
+}
+
+/**
+ * Read the active bot-peer context, or `undefined` if none is set.
+ * Outbound code uses this to decide whether to wrap the reply text with
+ * `ensureMention` so the peer bot actually receives a Feishu notification.
+ */
+export function currentBotPeerContext(): BotPeerContext | undefined {
+  return storage.getStore();
+}

--- a/src/messaging/outbound/outbound-mention.ts
+++ b/src/messaging/outbound/outbound-mention.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Outbound mention normalization + bot-peer @-mention enforcement.
+ *
+ * Why this exists: in Feishu groups, a bot only receives a message when
+ * something explicitly @-mentions its open_id with a structured `<at>`
+ * element. LLM outputs come in many "natural" @-shapes (markdown, angle
+ * brackets, template syntax) but none of them satisfy the delivery rule —
+ * only `<at user_id="ou_xxx">Name</at>` does. This module:
+ *
+ *   1. `normalizeOutboundMentions` — rewrites the six common LLM shapes
+ *      into the standard `<at>` element when the name resolves via the
+ *      per-chat mention-registry. Unknown names are left as plain text
+ *      (a recipient who's never spoken in this chat can't be @-mentioned).
+ *
+ *   2. `ensureMention` — in bot→bot group scenarios, the agent reply must
+ *      include an explicit @ of the peer bot or the peer never receives
+ *      it. When the LLM forgets to add one, prepend it as a safety net.
+ *
+ * Both are idempotent: existing standard `<at>` elements are preserved,
+ * and `ensureMention` is a no-op when the peer is already mentioned.
+ */
+
+import { lookupByName } from '../inbound/mention-registry';
+
+const STANDARD_AT_RE = /<at\s+user_id="[^"]*">[^<]*<\/at>/g;
+
+// LLM-produced mention shapes (in priority order — first match wins).
+// Each pattern captures the display name; the runner consults the registry
+// for an openId before rewriting, and leaves the original text untouched
+// when the name doesn't resolve.
+//
+// Plain `@Name` is intentionally last because the more decorated variants
+// embed an `@` and we want them to claim ownership of their match first.
+const VARIANT_PATTERNS: { re: RegExp; group: number }[] = [
+  { re: /@\[([^\]\n]+)\]/g, group: 1 },        // @[Name]
+  { re: /@<([^>\n]+)>/g, group: 1 },           // @<Name>
+  { re: /<@([^>\n]+)>/g, group: 1 },           // <@Name>
+  { re: /<at>\s*([^<\n]+?)\s*<\/at>/g, group: 1 }, // <at>Name</at>
+  { re: /\{\{\s*([^}\n]+?)\s*\}\}/g, group: 1 },   // {{Name}}
+  // Plain @Name — single token, ASCII/CJK/digit/underscore. Won't match
+  // mid-word (preceded by a word char), so email addresses are safe.
+  { re: /(^|[^\w@])@([A-Za-z0-9_一-鿿][\w.一-鿿-]{0,30})/g, group: 2 },
+];
+
+/**
+ * Rewrite LLM-emitted mention shapes into the standard `<at user_id="…">`
+ * element used by Feishu for guaranteed delivery. Unknown names — those
+ * whose display name isn't in the per-chat registry — are left intact as
+ * plain text so the agent's wording survives even when delivery cannot
+ * fire.
+ */
+export function normalizeOutboundMentions(text: string, chatId: string): string {
+  if (!text || !chatId) return text;
+
+  // Step 1: mask out already-standard <at> elements so the variant patterns
+  //         below never re-match them.
+  const protectedTokens: string[] = [];
+  let masked = text.replace(STANDARD_AT_RE, (m) => {
+    const idx = protectedTokens.push(m) - 1;
+    return `\x00P${idx}\x00`;
+  });
+
+  // Step 2: apply variant patterns in declared priority.
+  for (const { re, group } of VARIANT_PATTERNS) {
+    masked = masked.replace(re, (...args: unknown[]) => {
+      const match = args[0] as string;
+      const groups = args.slice(1, args.length - 2) as string[];
+      const name = (groups[group - 1] ?? '').trim();
+      if (!name) return match;
+      const openId = lookupByName(chatId, name);
+      if (!openId) return match;
+      const standardAt = `<at user_id="${openId}">${name}</at>`;
+      // For the plain-@Name pattern we captured a leading word boundary in
+      // group 1 — preserve it. Other patterns matched the @-shape exactly.
+      if (group === 2) {
+        const leading = groups[0] ?? '';
+        return `${leading}${standardAt}`;
+      }
+      return standardAt;
+    });
+  }
+
+  // Step 3: restore protected tokens. The \x00 sentinels are intentional
+  // private-use markers that never appear in real Feishu text.
+  // eslint-disable-next-line no-control-regex
+  return masked.replace(/\x00P(\d+)\x00/g, (_, idx) => protectedTokens[Number(idx)]);
+}
+
+/**
+ * Ensure the reply explicitly @-mentions the given peer.
+ *
+ * Designed for bot↔bot group flows: when the peer is another bot, Feishu
+ * won't deliver the message unless an `<at user_id="ou_peer">` element is
+ * present somewhere in the text. If the LLM already mentioned the peer,
+ * no-op; otherwise, prepend a standard `<at>` so the peer wakes up.
+ */
+export function ensureMention(
+  text: string,
+  peerOpenId: string,
+  peerName: string,
+): string {
+  if (!peerOpenId) return text;
+  // Already-mentioned check — match any existing <at user_id="ou_peer">
+  // element regardless of the rendered name to preserve idempotency.
+  const escaped = peerOpenId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const existingRe = new RegExp(`<at\\s+user_id="${escaped}">[^<]*<\\/at>`);
+  if (existingRe.test(text)) return text;
+
+  const standardAt = `<at user_id="${peerOpenId}">${peerName || peerOpenId}</at>`;
+  if (!text || !text.trim()) return standardAt;
+  return `${standardAt} ${text}`;
+}

--- a/src/messaging/outbound/outbound.ts
+++ b/src/messaging/outbound/outbound.ts
@@ -20,6 +20,22 @@ import { isCommentTarget } from '../../core/comment-target';
 import { isSyntheticTarget } from '../../core/synthetic-target';
 import type { FeishuSendResult } from '../types';
 import { sendCardLark, sendCommentReplyLark, sendMediaLark, sendTextLark } from './deliver';
+import { ensureMention, normalizeOutboundMentions } from './outbound-mention';
+import { currentBotPeerContext } from './bot-peer-context';
+
+/**
+ * Apply the outbound mention safety net for the current send:
+ *  - rewrite LLM-emitted @-shapes into Feishu's standard <at> element
+ *  - when the dispatch layer marked the current reply as bot→bot in a
+ *    group (via `runWithBotPeerContext`), guarantee the peer bot is
+ *    explicitly @-mentioned so Feishu delivers the message at all.
+ */
+function applyOutboundMentions(text: string, chatId: string): string {
+  const normalized = normalizeOutboundMentions(text, chatId);
+  const peer = currentBotPeerContext();
+  if (!peer) return normalized;
+  return ensureMention(normalized, peer.peerOpenId, peer.peerName);
+}
 
 const log = larkLogger('outbound/outbound');
 
@@ -187,7 +203,8 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     }
 
     const ctx = resolveFeishuSendContext({ cfg, to, accountId, replyToId, threadId });
-    const result = await sendTextLark({ ...ctx, to: ctx.to, text });
+    const finalText = applyOutboundMentions(text, ctx.to);
+    const result = await sendTextLark({ ...ctx, to: ctx.to, text: finalText });
     return { channel: 'feishu', ...result };
   },
 
@@ -212,12 +229,13 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     }
 
     const ctx = resolveFeishuSendContext({ cfg, to, accountId, replyToId, threadId });
+    const normalizedCaption = text ? applyOutboundMentions(text, ctx.to) : text;
 
     // Feishu media messages do not support inline captions — send text first.
     // Capture the result so the no-mediaUrl path can return it without re-sending.
     let captionResult: { messageId: string; chatId: string; warning?: string } | undefined;
-    if (text?.trim()) {
-      captionResult = await sendTextLark({ ...ctx, to: ctx.to, text });
+    if (normalizedCaption?.trim()) {
+      captionResult = await sendTextLark({ ...ctx, to: ctx.to, text: normalizedCaption });
     }
 
     // No mediaUrl — text-only flow.
@@ -228,7 +246,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         return { channel: 'feishu', ...captionResult };
       }
       // No caption text — send empty/raw text to satisfy the contract.
-      const result = await sendTextLark({ ...ctx, to: ctx.to, text: text ?? '' });
+      const result = await sendTextLark({ ...ctx, to: ctx.to, text: normalizedCaption ?? '' });
       return { channel: 'feishu', ...result };
     }
 

--- a/src/messaging/outbound/outbound.ts
+++ b/src/messaging/outbound/outbound.ts
@@ -33,8 +33,16 @@ import { currentBotPeerContext } from './bot-peer-context';
 function applyOutboundMentions(text: string, chatId: string): string {
   const normalized = normalizeOutboundMentions(text, chatId);
   const peer = currentBotPeerContext();
-  if (!peer) return normalized;
-  return ensureMention(normalized, peer.peerOpenId, peer.peerName);
+  // De-dupe the peer @ across chunks: once it has appeared on one chunk
+  // (model-written or injected), later chunks of the same dispatch skip it.
+  // Mirrors normalizeFeishuOutboundText in send.ts so both outbound paths
+  // behave the same and a long multi-chunk reply doesn't @ the peer repeatedly.
+  if (!peer || peer.mentioned) return normalized;
+  const out = ensureMention(normalized, peer.peerOpenId, peer.peerName);
+  if (out.includes(`user_id="${peer.peerOpenId}"`)) {
+    peer.mentioned = true;
+  }
+  return out;
 }
 
 const log = larkLogger('outbound/outbound');

--- a/src/messaging/outbound/send.ts
+++ b/src/messaging/outbound/send.ts
@@ -17,6 +17,8 @@ import { optimizeMarkdownStyle } from '../../card/markdown-style';
 import { buildMentionedCardContent, buildMentionedMessage } from '../inbound/mention';
 import { getSentinelStore } from '../inbound/sentinel-store';
 import { type NormalizeContext, type SentinelEntry, normalizeOutboundMentions } from './normalize-mentions';
+import { ensureMention } from './outbound-mention';
+import { currentBotPeerContext } from './bot-peer-context';
 
 const sendLog = larkLogger('outbound/send');
 
@@ -41,7 +43,22 @@ async function normalizeFeishuOutboundText(
       log: (...args) => sendLog.warn(args.map(String).join(' ')),
     };
     const r = await normalizeOutboundMentions(text, ctx);
-    return { text: r.normalizedText, sentinels: r.sentinels, resolvedAccountId: account.accountId };
+    let outText = r.normalizedText;
+    // Deterministic backstop on the real reply path: when this dispatch is
+    // replying to a designated bot peer (set via runWithBotPeerContext in the
+    // inbound dispatch), guarantee an @-mention so the peer actually receives
+    // the message even if the model didn't write one. No-op when no peer is
+    // in scope. De-duped across chunks: once the peer @ has appeared (whether
+    // the model wrote it or we injected it), later chunks of the same reply
+    // are left untouched so we don't @ on every chunk.
+    const peer = currentBotPeerContext();
+    if (peer && !peer.mentioned) {
+      outText = ensureMention(outText, peer.peerOpenId, peer.peerName);
+      if (outText.includes(`user_id="${peer.peerOpenId}"`)) {
+        peer.mentioned = true;
+      }
+    }
+    return { text: outText, sentinels: r.sentinels, resolvedAccountId: account.accountId };
   } catch (err) {
     sendLog.warn(`normalizeOutboundMentions failed, using raw text: ${String(err)}`);
     return { text, sentinels: [], resolvedAccountId: accountId };
@@ -482,14 +499,19 @@ export async function sendMarkdownCardFeishu(params: {
 }): Promise<FeishuSendResult> {
   const { cfg, to, text, replyToMessageId, mentions, accountId, replyInThread } = params;
 
-  let cardText = text;
+  // Normalize @-mentions and apply the bot-peer ensureMention backstop on the
+  // card path too (mirrors sendMessageFeishu), so a reply rendered as a card
+  // still reaches the designated peer bot.
+  const normalized = await normalizeFeishuOutboundText(cfg, to, text, accountId ?? undefined);
+
+  let cardText = normalized.text;
   if (mentions && mentions.length > 0) {
     cardText = buildMentionedCardContent(mentions, cardText);
   }
 
   const card = buildMarkdownCard(cardText);
 
-  return sendCardFeishu({
+  const result = await sendCardFeishu({
     cfg,
     to,
     card,
@@ -497,6 +519,8 @@ export async function sendMarkdownCardFeishu(params: {
     replyInThread,
     accountId,
   });
+  recordFeishuSendSentinels(normalized.resolvedAccountId, to, undefined, normalized.sentinels);
+  return result;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/bot-at-bot-identity.test.ts
+++ b/tests/bot-at-bot-identity.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for the restored bot-at-bot identity & guidance builders in
+ * dispatch-builders.ts:
+ *  - buildFeishuIdentityFields  → SenderIsBot / BotOpenId injection
+ *  - buildFeishuGroupSystemPrompt → self-identity + @ rule + loop hygiene
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  buildFeishuGroupSystemPrompt,
+  buildFeishuIdentityFields,
+} from '../src/messaging/inbound/dispatch-builders';
+import type { MessageContext } from '../src/messaging/types';
+
+function makeCtx(overrides: Partial<MessageContext> = {}): MessageContext {
+  return {
+    chatId: 'oc_chat',
+    messageId: 'om_test',
+    senderId: 'ou_sender',
+    chatType: 'group',
+    content: 'hi',
+    contentType: 'text',
+    resources: [],
+    mentions: [],
+    mentionAll: false,
+    ...overrides,
+  } as MessageContext;
+}
+
+describe('buildFeishuIdentityFields', () => {
+  it('marks SenderIsBot true and includes BotOpenId', () => {
+    const fields = buildFeishuIdentityFields(makeCtx({ senderIsBot: true }), 'ou_self');
+    expect(fields.SenderIsBot).toBe(true);
+    expect(fields.BotOpenId).toBe('ou_self');
+  });
+
+  it('defaults SenderIsBot to false when unset', () => {
+    const fields = buildFeishuIdentityFields(makeCtx({ senderIsBot: undefined }), 'ou_self');
+    expect(fields.SenderIsBot).toBe(false);
+  });
+
+  it('omits BotOpenId when the bot open_id is unknown', () => {
+    const fields = buildFeishuIdentityFields(makeCtx({ senderIsBot: false }), undefined);
+    expect(fields.SenderIsBot).toBe(false);
+    expect('BotOpenId' in fields).toBe(false);
+  });
+});
+
+describe('buildFeishuGroupSystemPrompt', () => {
+  it('injects self open_id, the @-delivery rule, and loop hygiene', () => {
+    const prompt = buildFeishuGroupSystemPrompt(undefined, 'ou_self') ?? '';
+    expect(prompt).toContain('ou_self');
+    expect(prompt).toMatch(/@-mention/i);
+    expect(prompt).toMatch(/loop/i);
+    expect(prompt).toMatch(/stop|do not reply/i);
+  });
+
+  it('appends the operator-configured group prompt after the guidance', () => {
+    const prompt = buildFeishuGroupSystemPrompt('Be concise.', 'ou_self') ?? '';
+    expect(prompt).toContain('Be concise.');
+    expect(prompt.indexOf('ou_self')).toBeLessThan(prompt.indexOf('Be concise.'));
+  });
+
+  it('still injects guidance with no configured prompt and no open_id', () => {
+    const prompt = buildFeishuGroupSystemPrompt(undefined, undefined);
+    expect(prompt).toBeTruthy();
+    expect(prompt).toMatch(/@-mention/i);
+  });
+});

--- a/tests/bot-loop-guard.test.ts
+++ b/tests/bot-loop-guard.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for the cross-bot loop guard (bot-loop-guard.ts).
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  MAX_CONSECUTIVE_BOT_TURNS,
+  BOT_LOOP_IDLE_RESET_MS,
+  noteBotTurnAndCheck,
+  resetBotLoop,
+  resetAllBotLoops,
+} from '../src/messaging/inbound/bot-loop-guard';
+
+beforeEach(() => resetAllBotLoops());
+
+describe('noteBotTurnAndCheck', () => {
+  it('allows turns up to the cap, then suppresses', () => {
+    let last = { allowed: true, count: 0, limit: 0 };
+    for (let i = 1; i <= MAX_CONSECUTIVE_BOT_TURNS; i++) {
+      last = noteBotTurnAndCheck('oc_a');
+      expect(last.allowed).toBe(true);
+      expect(last.count).toBe(i);
+    }
+    const over = noteBotTurnAndCheck('oc_a');
+    expect(over.allowed).toBe(false);
+    expect(over.count).toBe(MAX_CONSECUTIVE_BOT_TURNS + 1);
+  });
+
+  it('resets on a human turn (resetBotLoop)', () => {
+    for (let i = 0; i < MAX_CONSECUTIVE_BOT_TURNS + 2; i++) noteBotTurnAndCheck('oc_b');
+    resetBotLoop('oc_b');
+    const after = noteBotTurnAndCheck('oc_b');
+    expect(after.allowed).toBe(true);
+    expect(after.count).toBe(1);
+  });
+
+  it('decays after the idle window', () => {
+    const t0 = 1_000_000;
+    for (let i = 0; i < MAX_CONSECUTIVE_BOT_TURNS; i++) {
+      noteBotTurnAndCheck('oc_c', undefined, t0);
+    }
+    // Same instant, one more → over cap
+    expect(noteBotTurnAndCheck('oc_c', undefined, t0).allowed).toBe(false);
+    // Far in the future (idle) → counter decays, allowed again from 1
+    const later = t0 + BOT_LOOP_IDLE_RESET_MS + 1;
+    const fresh = noteBotTurnAndCheck('oc_c', undefined, later);
+    expect(fresh.allowed).toBe(true);
+    expect(fresh.count).toBe(1);
+  });
+
+  it('tracks chat and thread independently', () => {
+    for (let i = 0; i < MAX_CONSECUTIVE_BOT_TURNS + 1; i++) noteBotTurnAndCheck('oc_d');
+    // A different thread in the same chat has its own budget.
+    const other = noteBotTurnAndCheck('oc_d', 'thread_1');
+    expect(other.allowed).toBe(true);
+    expect(other.count).toBe(1);
+  });
+});

--- a/tests/bot-loop-guard.test.ts
+++ b/tests/bot-loop-guard.test.ts
@@ -9,6 +9,7 @@ import {
   noteBotTurnAndCheck,
   resetBotLoop,
   resetAllBotLoops,
+  botLoopStateSize,
 } from '../src/messaging/inbound/bot-loop-guard';
 
 beforeEach(() => resetAllBotLoops());
@@ -54,5 +55,18 @@ describe('noteBotTurnAndCheck', () => {
     const other = noteBotTurnAndCheck('oc_d', 'thread_1');
     expect(other.allowed).toBe(true);
     expect(other.count).toBe(1);
+  });
+
+  it('sweeps idle entries so the state map does not grow unbounded', () => {
+    const t0 = 5_000_000;
+    // Several bot-only conversations that never see a human reset.
+    noteBotTurnAndCheck('oc_1', undefined, t0);
+    noteBotTurnAndCheck('oc_2', undefined, t0);
+    noteBotTurnAndCheck('oc_3', undefined, t0);
+    expect(botLoopStateSize()).toBe(3);
+    // A new turn well past the idle window triggers a sweep of the stale ones.
+    const later = t0 + BOT_LOOP_IDLE_RESET_MS + 1;
+    noteBotTurnAndCheck('oc_new', undefined, later);
+    expect(botLoopStateSize()).toBe(1); // only oc_new survives
   });
 });

--- a/tests/bot-loop-key.test.ts
+++ b/tests/bot-loop-key.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Integration test: handleFeishuMessage keys the bot-loop guard by
+ * `threadId ?? rootId`. Topic-group reply events often carry only root_id
+ * (thread_id is inferred later in dispatch), so the guard must fall back to
+ * root_id to count per-topic — matching the dispatch/queue key — instead of
+ * merging all topics into one chat-level counter.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockParseMessageEvent = vi.fn();
+const mockResolveSenderInfo = vi.fn();
+const mockResolveMedia = vi.fn();
+const mockResolveQuotedContent = vi.fn();
+const noteBotTurnAndCheckMock = vi.fn((..._args: unknown[]) => ({ allowed: true, count: 1, limit: 10 }));
+const resetBotLoopMock = vi.fn();
+
+vi.mock('../src/messaging/inbound/parse', () => ({
+  parseMessageEvent: (...a: unknown[]) => mockParseMessageEvent(...a),
+}));
+vi.mock('../src/messaging/inbound/enrich', () => ({
+  resolveSenderInfo: (...a: unknown[]) => mockResolveSenderInfo(...a),
+  prefetchUserNames: vi.fn(),
+  resolveMedia: (...a: unknown[]) => mockResolveMedia(...a),
+  resolveQuotedContent: (...a: unknown[]) => mockResolveQuotedContent(...a),
+  substituteMediaPaths: vi.fn(),
+}));
+vi.mock('../src/messaging/inbound/gate', () => ({
+  checkMessageGate: vi.fn().mockResolvedValue({ allowed: true }),
+  readFeishuAllowFromStore: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('../src/messaging/inbound/handler-registry', () => ({ injectInboundHandler: vi.fn() }));
+vi.mock('../src/messaging/inbound/dispatch', () => ({ dispatchToAgent: vi.fn() }));
+vi.mock('../src/messaging/inbound/policy', () => ({
+  resolveFeishuGroupConfig: vi.fn(),
+  splitLegacyGroupAllowFrom: vi.fn().mockReturnValue({ senderAllowFrom: [] }),
+}));
+vi.mock('../src/messaging/inbound/bot-loop-guard', () => ({
+  noteBotTurnAndCheck: (...a: unknown[]) => noteBotTurnAndCheckMock(...a),
+  resetBotLoop: (...a: unknown[]) => resetBotLoopMock(...a),
+}));
+vi.mock('../src/core/accounts', () => ({
+  getLarkAccount: vi.fn().mockReturnValue({ accountId: 'test-account', config: {}, enabled: true, configured: true }),
+}));
+vi.mock('../src/core/lark-client', () => ({
+  LarkClient: {
+    runtime: { channel: { commands: { shouldComputeCommandAuthorized: false, resolveCommandAuthorizedFromAuthorizers: vi.fn() } } },
+  },
+}));
+vi.mock('../src/core/lark-logger', () => ({ larkLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }));
+vi.mock('../src/core/lark-ticket', () => ({ ticketElapsed: () => 1 }));
+vi.mock('../src/channel/chat-queue', () => ({
+  threadScopedKey: (chatId: string, threadId?: string) => `${chatId}:${threadId ?? ''}`,
+}));
+vi.mock('openclaw/plugin-sdk/reply-history', () => ({
+  DEFAULT_GROUP_HISTORY_LIMIT: 20,
+  recordPendingHistoryEntryIfEnabled: vi.fn(),
+}));
+vi.mock('openclaw/plugin-sdk/command-auth', () => ({
+  resolveSenderCommandAuthorization: vi.fn().mockResolvedValue({ commandAuthorized: false }),
+}));
+vi.mock('openclaw/plugin-sdk/allow-from', () => ({ isNormalizedSenderAllowed: vi.fn().mockReturnValue(false) }));
+
+import { handleFeishuMessage } from '../src/messaging/inbound/handler';
+
+// Topic-group ctx: root_id present, thread_id absent.
+function makeCtx(senderIsBot: boolean) {
+  return {
+    chatId: 'oc_topic',
+    messageId: 'om_msg',
+    senderId: senderIsBot ? 'ou_peer_bot' : 'ou_human',
+    senderName: senderIsBot ? 'PeerBot' : 'Human',
+    chatType: 'group' as const,
+    content: 'hi',
+    contentType: 'text',
+    resources: [],
+    mentions: [],
+    mentionAll: false,
+    senderIsBot,
+    threadId: undefined,
+    rootId: 'om_root',
+  };
+}
+
+const cfg = { channels: { feishu: {} } } as never;
+const event = { sender: { sender_id: { open_id: 'x' } }, message: { message_id: 'om_msg', chat_id: 'oc_topic' } };
+
+describe('handleFeishuMessage — bot-loop guard keys by threadId ?? rootId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResolveMedia.mockResolvedValue({ mediaList: [], payload: undefined });
+    mockResolveQuotedContent.mockResolvedValue(undefined);
+  });
+
+  it('a bot turn with only root_id counts under root_id (not chat-level)', async () => {
+    const ctx = makeCtx(true);
+    mockParseMessageEvent.mockResolvedValue(ctx);
+    mockResolveSenderInfo.mockResolvedValue({ ctx, permissionError: undefined });
+
+    await handleFeishuMessage({ cfg, event: event as never, botOpenId: 'ou_self' });
+
+    expect(noteBotTurnAndCheckMock).toHaveBeenCalledWith('oc_topic', 'om_root');
+  });
+
+  it('a human turn with only root_id resets under root_id', async () => {
+    const ctx = makeCtx(false);
+    mockParseMessageEvent.mockResolvedValue(ctx);
+    mockResolveSenderInfo.mockResolvedValue({ ctx, permissionError: undefined });
+
+    await handleFeishuMessage({ cfg, event: event as never, botOpenId: 'ou_self' });
+
+    expect(resetBotLoopMock).toHaveBeenCalledWith('oc_topic', 'om_root');
+  });
+});

--- a/tests/bot-peer-mention.test.ts
+++ b/tests/bot-peer-mention.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Tests for resolveBotPeerForMention — picking the peer that an outbound
+ * reply must @-mention (the ensureMention backstop), decoupled from thread
+ * routing. Covers the human-orchestrated debate kickoff.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { resolveBotPeerForMention } from '../src/messaging/inbound/bot-content';
+import type { MentionInfo } from '../src/messaging/types';
+
+function m(openId: string, name: string, isBot = false): MentionInfo {
+  return { key: `@_${openId}`, openId, name, isBot };
+}
+
+const SELF = 'ou_self';
+
+describe('resolveBotPeerForMention', () => {
+  it('bot sender in a group → @ the sender back', () => {
+    const peer = resolveBotPeerForMention({
+      isGroup: true,
+      senderIsBot: true,
+      senderId: 'ou_peer_bot',
+      senderName: 'PeerBot',
+      mentions: [],
+      botOpenId: SELF,
+    });
+    expect(peer).toEqual({ peerOpenId: 'ou_peer_bot', peerName: 'PeerBot' });
+  });
+
+  it('human kickoff @-mentioning self + one opponent → @ the opponent', () => {
+    // Mirrors "you two debate, @ZJ start": human @s the opponent (twice) and self.
+    const peer = resolveBotPeerForMention({
+      isGroup: true,
+      senderIsBot: false,
+      senderId: 'ou_human',
+      senderName: 'Human',
+      mentions: [m('ou_opponent', '云端Openclaw'), m('ou_opponent', '云端Openclaw'), m(SELF, 'ZJ', true)],
+      botOpenId: SELF,
+    });
+    expect(peer).toEqual({ peerOpenId: 'ou_opponent', peerName: '云端Openclaw' });
+  });
+
+  it('human sender, no non-self mention → no forced peer', () => {
+    const peer = resolveBotPeerForMention({
+      isGroup: true,
+      senderIsBot: false,
+      senderId: 'ou_human',
+      mentions: [m(SELF, 'ZJ', true)],
+      botOpenId: SELF,
+    });
+    expect(peer).toBeUndefined();
+  });
+
+  it('human sender, multiple distinct non-self mentions → ambiguous, no forced peer', () => {
+    const peer = resolveBotPeerForMention({
+      isGroup: true,
+      senderIsBot: false,
+      senderId: 'ou_human',
+      mentions: [m('ou_a', 'A'), m('ou_b', 'B')],
+      botOpenId: SELF,
+    });
+    expect(peer).toBeUndefined();
+  });
+
+  it('DM → never forces a peer', () => {
+    const peer = resolveBotPeerForMention({
+      isGroup: false,
+      senderIsBot: true,
+      senderId: 'ou_peer_bot',
+      mentions: [m('ou_opponent', 'Opp')],
+      botOpenId: SELF,
+    });
+    expect(peer).toBeUndefined();
+  });
+
+  it('excludes self even when botOpenId is the only signal', () => {
+    const peer = resolveBotPeerForMention({
+      isGroup: true,
+      senderIsBot: false,
+      senderId: 'ou_human',
+      mentions: [m(SELF, 'ZJ', false), m('ou_opponent', 'Opp')],
+      botOpenId: SELF,
+    });
+    expect(peer).toEqual({ peerOpenId: 'ou_opponent', peerName: 'Opp' });
+  });
+});

--- a/tests/card-review-followup.test.ts
+++ b/tests/card-review-followup.test.ts
@@ -85,6 +85,16 @@ describe('shouldUseCard', () => {
     const text = buildCodeBlockWithTables(4);
     expect(shouldUseCard(text)).toBe(true);
   });
+
+  it('does NOT force a card for plain markdown tables (rendered natively)', () => {
+    const text = [buildTable('a'), buildTable('b')].join('\n\n');
+    expect(shouldUseCard(text)).toBe(false);
+  });
+
+  it('still uses a card when a fenced code block is present', () => {
+    const text = ['Here is code:', '```ts\nconst x = 1;\n```'].join('\n\n');
+    expect(shouldUseCard(text)).toBe(true);
+  });
 });
 
 describe('sanitizeTextForCard', () => {

--- a/tests/conversation-stop-intent.test.ts
+++ b/tests/conversation-stop-intent.test.ts
@@ -22,10 +22,25 @@ describe('isConversationStopIntent', () => {
     expect(isConversationStopIntent('请暂停')).toBe(true);
   });
 
+  it('matches the broader zh stop vocabulary (终止 / 打住 / 别继续 / …)', () => {
+    expect(isConversationStopIntent('终止')).toBe(true);
+    expect(isConversationStopIntent('@_user_1 @_user_2 终止辩论')).toBe(true);
+    expect(isConversationStopIntent('打住')).toBe(true);
+    expect(isConversationStopIntent('你们别继续了')).toBe(true);
+    expect(isConversationStopIntent('别再聊了')).toBe(true);
+    expect(isConversationStopIntent('不要继续了')).toBe(true);
+    expect(isConversationStopIntent('到此为止吧')).toBe(true);
+    expect(isConversationStopIntent('都别吵了')).toBe(true);
+    expect(isConversationStopIntent('结束辩论')).toBe(true);
+  });
+
   it('matches English conversational stops', () => {
     expect(isConversationStopIntent('stop talking')).toBe(true);
     expect(isConversationStopIntent('@_user_1 please stop the conversation')).toBe(true);
     expect(isConversationStopIntent('OK you two, knock it off')).toBe(true);
+    expect(isConversationStopIntent('stop debating please')).toBe(true);
+    expect(isConversationStopIntent('alright, stand down')).toBe(true);
+    expect(isConversationStopIntent('stop responding to each other')).toBe(true);
   });
 
   it('still matches the exact abort triggers (superset of isLikelyAbortText)', () => {
@@ -38,6 +53,9 @@ describe('isConversationStopIntent', () => {
     expect(isConversationStopIntent('你们分别充当正反方辩手，辩论下无斑马线的路口是否要礼让行人')).toBe(false);
     expect(isConversationStopIntent('@_user_1 @_user_2 讨论下今天杭州的天气')).toBe(false);
     expect(isConversationStopIntent('继续')).toBe(false);
+    expect(isConversationStopIntent('请继续辩论')).toBe(false); // continue, not stop
+    expect(isConversationStopIntent('我们停车场见面吧')).toBe(false); // "停车" must not match (no bare 停)
+    expect(isConversationStopIntent('讨论继续进行')).toBe(false);
     expect(isConversationStopIntent('收到！测试成功')).toBe(false);
     expect(isConversationStopIntent('')).toBe(false);
     expect(isConversationStopIntent('   ')).toBe(false);

--- a/tests/conversation-stop-intent.test.ts
+++ b/tests/conversation-stop-intent.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Tests for isConversationStopIntent — the predicate that suppresses the
+ * deterministic peer-@ backstop when a human asks the bots to stop. A false
+ * negative re-wakes the peer bot and defeats the interruption (the "@对手"
+ * loop seen when a user sends "中断对话"); a false positive only skips a
+ * forced @ for that turn.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isConversationStopIntent } from '../src/channel/abort-detect';
+
+describe('isConversationStopIntent', () => {
+  it('matches the conversational stop phrases that defeated the interruption', () => {
+    expect(isConversationStopIntent('中断对话')).toBe(true);
+    expect(isConversationStopIntent('@_user_1 @_user_2 中断对话')).toBe(true); // with mention placeholders
+    expect(isConversationStopIntent('你们先停一下')).toBe(true);
+    expect(isConversationStopIntent('别聊了')).toBe(true);
+    expect(isConversationStopIntent('结束对话吧')).toBe(true);
+    expect(isConversationStopIntent('请暂停')).toBe(true);
+  });
+
+  it('matches English conversational stops', () => {
+    expect(isConversationStopIntent('stop talking')).toBe(true);
+    expect(isConversationStopIntent('@_user_1 please stop the conversation')).toBe(true);
+    expect(isConversationStopIntent('OK you two, knock it off')).toBe(true);
+  });
+
+  it('still matches the exact abort triggers (superset of isLikelyAbortText)', () => {
+    expect(isConversationStopIntent('停止')).toBe(true);
+    expect(isConversationStopIntent('stop')).toBe(true);
+    expect(isConversationStopIntent('/stop')).toBe(true);
+  });
+
+  it('does NOT fire on a debate kickoff or normal chatter', () => {
+    expect(isConversationStopIntent('你们分别充当正反方辩手，辩论下无斑马线的路口是否要礼让行人')).toBe(false);
+    expect(isConversationStopIntent('@_user_1 @_user_2 讨论下今天杭州的天气')).toBe(false);
+    expect(isConversationStopIntent('继续')).toBe(false);
+    expect(isConversationStopIntent('收到！测试成功')).toBe(false);
+    expect(isConversationStopIntent('')).toBe(false);
+    expect(isConversationStopIntent('   ')).toBe(false);
+  });
+});

--- a/tests/dispatch-tool-use-init.test.ts
+++ b/tests/dispatch-tool-use-init.test.ts
@@ -101,6 +101,7 @@ vi.mock('../src/messaging/inbound/gate', () => ({
 
 vi.mock('../src/channel/abort-detect', () => ({
   isLikelyAbortText: vi.fn(() => false),
+  isConversationStopIntent: vi.fn(() => false),
 }));
 
 vi.mock('../src/core/lark-logger', () => ({

--- a/tests/dispatch-tool-use-init.test.ts
+++ b/tests/dispatch-tool-use-init.test.ts
@@ -34,6 +34,8 @@ vi.mock('../src/messaging/inbound/dispatch-builders', () => ({
   buildEnvelopeWithHistory: buildEnvelopeWithHistoryMock,
   buildBodyForAgent: buildBodyForAgentMock,
   buildInboundPayload: buildInboundPayloadMock,
+  buildFeishuIdentityFields: vi.fn(() => ({})),
+  buildFeishuGroupSystemPrompt: vi.fn(() => undefined),
 }));
 
 vi.mock('../src/card/tool-use-config', () => ({

--- a/tests/empty-message-guard.test.ts
+++ b/tests/empty-message-guard.test.ts
@@ -212,4 +212,38 @@ describe('handleFeishuMessage — empty message guard', () => {
 
     expect(mockResolveSenderInfo).toHaveBeenCalled();
   });
+
+  it('allows a bare @-mention (no text, no media) as a valid ping', async () => {
+    const ctx = {
+      ...makeCtx('', []),
+      mentions: [{ openId: 'ou_bot', name: 'Bot', isBot: true }],
+    };
+    mockParseMessageEvent.mockResolvedValue(ctx);
+    mockResolveSenderInfo.mockResolvedValue({ ctx, permissionError: undefined });
+    mockResolveMedia.mockResolvedValue({ mediaList: [], payload: undefined });
+    mockResolveQuotedContent.mockResolvedValue(undefined);
+
+    await handleFeishuMessage({
+      cfg: { channels: { feishu: {} } } as never,
+      event: makeEvent(''),
+    });
+
+    // A pure @ must NOT be dropped as an empty message.
+    expect(mockResolveSenderInfo).toHaveBeenCalled();
+  });
+
+  it('allows an @all with no text as a valid ping', async () => {
+    const ctx = { ...makeCtx('', []), mentionAll: true };
+    mockParseMessageEvent.mockResolvedValue(ctx);
+    mockResolveSenderInfo.mockResolvedValue({ ctx, permissionError: undefined });
+    mockResolveMedia.mockResolvedValue({ mediaList: [], payload: undefined });
+    mockResolveQuotedContent.mockResolvedValue(undefined);
+
+    await handleFeishuMessage({
+      cfg: { channels: { feishu: {} } } as never,
+      event: makeEvent(''),
+    });
+
+    expect(mockResolveSenderInfo).toHaveBeenCalled();
+  });
 });

--- a/tests/feishu-reply-routing.test.ts
+++ b/tests/feishu-reply-routing.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Unit tests for resolveFeishuReplyRouting:
+ *  - bot-peer suppression in groups (the bot→bot topic-view trap, #32980)
+ *  - topic-group thread inference from root_id (threadSession=true)
+ *  - default replyInThread = dc.isThread for non-bot peers
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { isThreadCapableGroupMock } = vi.hoisted(() => ({
+  isThreadCapableGroupMock: vi.fn(),
+}));
+
+vi.mock('../src/core/chat-info-cache', () => ({
+  isThreadCapableGroup: isThreadCapableGroupMock,
+  injectLarkClient: vi.fn(),
+}));
+
+vi.mock('../src/core/lark-logger', () => ({
+  larkLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+import { resolveFeishuReplyRouting } from '../src/messaging/inbound/bot-content';
+
+function makeDc(overrides: {
+  isGroup?: boolean;
+  isThread?: boolean;
+  senderIsBot?: boolean;
+  rootId?: string;
+  threadId?: string;
+  threadSession?: boolean;
+}) {
+  return {
+    isGroup: overrides.isGroup ?? false,
+    isThread: overrides.isThread ?? false,
+    ctx: {
+      chatId: 'oc_test',
+      senderIsBot: overrides.senderIsBot ?? false,
+      rootId: overrides.rootId,
+      threadId: overrides.threadId,
+    },
+    account: {
+      accountId: 'default',
+      config: { threadSession: overrides.threadSession },
+    },
+    accountScopedCfg: {},
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+beforeEach(() => {
+  isThreadCapableGroupMock.mockReset();
+});
+
+describe('resolveFeishuReplyRouting — bot-peer suppression', () => {
+  it('bot peer in group + inbound thread → suppress thread, route to main chat', async () => {
+    const dc = makeDc({ isGroup: true, isThread: true, senderIsBot: true, threadId: 'thr_1' });
+    const routing = await resolveFeishuReplyRouting(dc);
+    expect(routing.suppressForBotPeer).toBe(true);
+    expect(routing.replyInThread).toBe(false);
+    expect(routing.threadId).toBeUndefined();
+  });
+
+  it('bot peer in DM → no suppression (DMs never have the topic-view trap)', async () => {
+    const dc = makeDc({ isGroup: false, isThread: false, senderIsBot: true });
+    const routing = await resolveFeishuReplyRouting(dc);
+    expect(routing.suppressForBotPeer).toBe(false);
+    expect(routing.replyInThread).toBe(false);
+  });
+
+  it('human peer in group + inbound thread → preserves original threading', async () => {
+    const dc = makeDc({ isGroup: true, isThread: true, senderIsBot: false, threadId: 'thr_2' });
+    const routing = await resolveFeishuReplyRouting(dc);
+    expect(routing.suppressForBotPeer).toBe(false);
+    expect(routing.replyInThread).toBe(true);
+    expect(routing.threadId).toBe('thr_2');
+  });
+
+  it('human peer in group + flat message → no thread', async () => {
+    const dc = makeDc({ isGroup: true, isThread: false, senderIsBot: false });
+    const routing = await resolveFeishuReplyRouting(dc);
+    expect(routing.replyInThread).toBe(false);
+    expect(routing.threadId).toBeUndefined();
+  });
+});
+
+describe('resolveFeishuReplyRouting — topic-group thread inference', () => {
+  it('isGroup + rootId + threadSession=true + threadCapable → infer thread and mutate dc', async () => {
+    isThreadCapableGroupMock.mockResolvedValueOnce(true);
+    const dc = makeDc({
+      isGroup: true,
+      isThread: false,
+      rootId: 'om_root_1',
+      threadSession: true,
+    });
+    const routing = await resolveFeishuReplyRouting(dc);
+    expect(dc.isThread).toBe(true);
+    expect(dc.ctx.threadId).toBe('om_root_1');
+    expect(routing.replyInThread).toBe(true);
+    expect(routing.threadId).toBe('om_root_1');
+  });
+
+  it('threadCapable=false → no inference', async () => {
+    isThreadCapableGroupMock.mockResolvedValueOnce(false);
+    const dc = makeDc({
+      isGroup: true,
+      isThread: false,
+      rootId: 'om_root_2',
+      threadSession: true,
+    });
+    const routing = await resolveFeishuReplyRouting(dc);
+    expect(dc.isThread).toBe(false);
+    expect(routing.replyInThread).toBe(false);
+  });
+
+  it('threadSession not enabled → skip inference (no API call)', async () => {
+    const dc = makeDc({
+      isGroup: true,
+      isThread: false,
+      rootId: 'om_root_3',
+      threadSession: false,
+    });
+    const routing = await resolveFeishuReplyRouting(dc);
+    expect(isThreadCapableGroupMock).not.toHaveBeenCalled();
+    expect(dc.isThread).toBe(false);
+    expect(routing.replyInThread).toBe(false);
+  });
+
+  it('inferred thread + bot peer with threadSession on → topic session, stays threaded', async () => {
+    // Aligns with openclaw core PR #89783: a deliberate topic session
+    // (threadSession enabled) is human-visible, so bot↔bot replies are NOT
+    // forced out of the thread.
+    isThreadCapableGroupMock.mockResolvedValueOnce(true);
+    const dc = makeDc({
+      isGroup: true,
+      isThread: false,
+      senderIsBot: true,
+      rootId: 'om_root_4',
+      threadSession: true,
+    });
+    const routing = await resolveFeishuReplyRouting(dc);
+    expect(dc.isThread).toBe(true);
+    expect(routing.suppressForBotPeer).toBe(false);
+    expect(routing.replyInThread).toBe(true);
+    expect(routing.threadId).toBe('om_root_4');
+  });
+});
+
+describe('resolveFeishuReplyRouting — topic/config escape hatches (#89783 parity)', () => {
+  it('bot peer in a real topic session (threadSession on + in thread) → not suppressed', async () => {
+    const dc = makeDc({
+      isGroup: true,
+      isThread: true,
+      senderIsBot: true,
+      threadId: 'thr_topic',
+      threadSession: true,
+    });
+    const routing = await resolveFeishuReplyRouting(dc);
+    expect(routing.suppressForBotPeer).toBe(false);
+    expect(routing.replyInThread).toBe(true);
+    expect(routing.threadId).toBe('thr_topic');
+  });
+
+  it('bot peer + replyInThread config → not suppressed even without threadSession', async () => {
+    const dc = makeDc({ isGroup: true, isThread: true, senderIsBot: true, threadId: 'thr_cfg' });
+    const routing = await resolveFeishuReplyRouting(dc, { replyInThreadConfig: true });
+    expect(routing.suppressForBotPeer).toBe(false);
+    expect(routing.replyInThread).toBe(true);
+    expect(routing.threadId).toBe('thr_cfg');
+  });
+
+  it('bot peer in thread WITHOUT threadSession or config → still suppressed (#32980 guard)', async () => {
+    const dc = makeDc({ isGroup: true, isThread: true, senderIsBot: true, threadId: 'thr_x' });
+    const routing = await resolveFeishuReplyRouting(dc);
+    expect(routing.suppressForBotPeer).toBe(true);
+    expect(routing.replyInThread).toBe(false);
+    expect(routing.threadId).toBeUndefined();
+  });
+});

--- a/tests/handler-self-filter.test.ts
+++ b/tests/handler-self-filter.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Integration test: handleFeishuMessage drops self-echo messages.
+ *
+ * Mirrors the channel-layer filter in event-handlers.ts so that synthetic
+ * messages, replays, or alternate entrypoints into handleFeishuMessage
+ * cannot trigger bot-to-bot self loops once include_bot scope is enabled.
+ */
+
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { handleFeishuMessage } from '../src/messaging/inbound/handler';
+import { setLarkRuntime } from '../src/core/runtime-store';
+
+beforeAll(() => {
+  setLarkRuntime({
+    channel: {
+      groups: {
+        resolveGroupPolicy: () => ({ allowed: true, allowlistEnabled: false }),
+        resolveRequireMention: () => true,
+      },
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+});
+
+function makeBotEvent(senderOpenId: string, messageId = 'om_test') {
+  return {
+    sender: {
+      sender_id: { open_id: senderOpenId },
+      sender_type: 'bot' as const,
+    },
+    message: {
+      message_id: messageId,
+      chat_id: 'oc_test',
+      chat_type: 'group' as const,
+      message_type: 'text',
+      content: JSON.stringify({ text: 'hi' }),
+      create_time: String(Date.now()),
+    },
+  };
+}
+
+const cfg = {
+  channels: {
+    feishu: {
+      appId: 'cli_x',
+      appSecret: 'secret',
+      allowBots: false as const,
+      accounts: {
+        acct1: { appId: 'cli_x', appSecret: 'secret', allowBots: false as const },
+      },
+    },
+  },
+} as never;
+
+describe('handleFeishuMessage self-echo filter', () => {
+  it('drops the message when senderOpenId === botOpenId', async () => {
+    const logs: string[] = [];
+    const log = (...args: unknown[]) => {
+      logs.push(args.map(String).join(' '));
+    };
+
+    await handleFeishuMessage({
+      cfg,
+      event: makeBotEvent('ou_self', 'om_echo'),
+      botOpenId: 'ou_self',
+      accountId: 'acct1',
+      runtime: { log, error: vi.fn(), exit: vi.fn() } as never,
+    });
+
+    expect(
+      logs.some((l) => l.includes('drop self-echo') && l.includes('om_echo')),
+    ).toBe(true);
+  });
+
+  it('does not filter when botOpenId is not yet populated (startup race)', async () => {
+    const logs: string[] = [];
+    const log = (...args: unknown[]) => {
+      logs.push(args.map(String).join(' '));
+    };
+
+    await handleFeishuMessage({
+      cfg,
+      event: makeBotEvent('ou_other_bot', 'om_user_msg'),
+      botOpenId: undefined,
+      accountId: 'acct1',
+      runtime: { log, error: vi.fn(), exit: vi.fn() } as never,
+    });
+
+    expect(logs.some((l) => l.includes('drop self-echo'))).toBe(false);
+  });
+
+  it('does not filter when sender differs from bot', async () => {
+    const logs: string[] = [];
+    const log = (...args: unknown[]) => {
+      logs.push(args.map(String).join(' '));
+    };
+
+    await handleFeishuMessage({
+      cfg,
+      event: makeBotEvent('ou_other_bot', 'om_other_msg'),
+      botOpenId: 'ou_self',
+      accountId: 'acct1',
+      runtime: { log, error: vi.fn(), exit: vi.fn() } as never,
+    });
+
+    expect(logs.some((l) => l.includes('drop self-echo'))).toBe(false);
+  });
+});

--- a/tests/loop-guard-notice-routing.test.ts
+++ b/tests/loop-guard-notice-routing.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Integration test: the loop-guard cutoff notice must NOT manufacture a Feishu
+ * thread. In a normal group a bot↔bot quote-reply chain carries root_id but no
+ * thread_id; sending the notice with reply_in_thread=true on such a message
+ * mints a brand-new topic for just the notice (pulling it into a thread the
+ * debate was never in). The notice should thread ONLY when the inbound is in a
+ * real thread (thread_id) AND the account runs deliberate topic sessions —
+ * mirroring resolveFeishuReplyRouting.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockParseMessageEvent = vi.fn();
+const mockResolveSenderInfo = vi.fn();
+const mockResolveMedia = vi.fn();
+const mockResolveQuotedContent = vi.fn();
+// Tripped: count is over the cap, on the exact "limit + 1" turn that surfaces
+// the notice once.
+const noteBotTurnAndCheckMock = vi.fn((..._args: unknown[]) => ({ allowed: false, count: 11, limit: 10 }));
+const resetBotLoopMock = vi.fn();
+const sendMessageFeishuMock = vi.fn(async (..._args: unknown[]) => undefined);
+
+// Mutable account config so each test can toggle threadSession.
+let accountConfig: Record<string, unknown> = {};
+
+vi.mock('../src/messaging/inbound/parse', () => ({
+  parseMessageEvent: (...a: unknown[]) => mockParseMessageEvent(...a),
+}));
+vi.mock('../src/messaging/inbound/enrich', () => ({
+  resolveSenderInfo: (...a: unknown[]) => mockResolveSenderInfo(...a),
+  prefetchUserNames: vi.fn(),
+  resolveMedia: (...a: unknown[]) => mockResolveMedia(...a),
+  resolveQuotedContent: (...a: unknown[]) => mockResolveQuotedContent(...a),
+  substituteMediaPaths: vi.fn(),
+}));
+vi.mock('../src/messaging/inbound/gate', () => ({
+  checkMessageGate: vi.fn().mockResolvedValue({ allowed: true }),
+  readFeishuAllowFromStore: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('../src/messaging/inbound/handler-registry', () => ({ injectInboundHandler: vi.fn() }));
+vi.mock('../src/messaging/inbound/dispatch', () => ({ dispatchToAgent: vi.fn() }));
+vi.mock('../src/messaging/inbound/policy', () => ({
+  resolveFeishuGroupConfig: vi.fn(),
+  splitLegacyGroupAllowFrom: vi.fn().mockReturnValue({ senderAllowFrom: [] }),
+}));
+vi.mock('../src/messaging/inbound/bot-loop-guard', () => ({
+  noteBotTurnAndCheck: (...a: unknown[]) => noteBotTurnAndCheckMock(...a),
+  resetBotLoop: (...a: unknown[]) => resetBotLoopMock(...a),
+}));
+vi.mock('../src/messaging/outbound/send', () => ({
+  sendMessageFeishu: (...a: unknown[]) => sendMessageFeishuMock(...a),
+}));
+vi.mock('../src/core/accounts', () => ({
+  getLarkAccount: vi.fn(() => ({ accountId: 'test-account', config: accountConfig, enabled: true, configured: true })),
+}));
+vi.mock('../src/core/lark-client', () => ({
+  LarkClient: {
+    runtime: { channel: { commands: { shouldComputeCommandAuthorized: false, resolveCommandAuthorizedFromAuthorizers: vi.fn() } } },
+  },
+}));
+vi.mock('../src/core/lark-logger', () => ({ larkLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }));
+vi.mock('../src/core/lark-ticket', () => ({ ticketElapsed: () => 1 }));
+vi.mock('../src/channel/chat-queue', () => ({
+  threadScopedKey: (chatId: string, threadId?: string) => `${chatId}:${threadId ?? ''}`,
+}));
+vi.mock('openclaw/plugin-sdk/reply-history', () => ({
+  DEFAULT_GROUP_HISTORY_LIMIT: 20,
+  recordPendingHistoryEntryIfEnabled: vi.fn(),
+}));
+vi.mock('openclaw/plugin-sdk/command-auth', () => ({
+  resolveSenderCommandAuthorization: vi.fn().mockResolvedValue({ commandAuthorized: false }),
+}));
+vi.mock('openclaw/plugin-sdk/allow-from', () => ({ isNormalizedSenderAllowed: vi.fn().mockReturnValue(false) }));
+
+import { handleFeishuMessage } from '../src/messaging/inbound/handler';
+
+function makeCtx(over: { threadId?: string; rootId?: string }) {
+  return {
+    chatId: 'oc_topic',
+    messageId: 'om_trigger',
+    senderId: 'ou_peer_bot',
+    senderName: 'PeerBot',
+    chatType: 'group' as const,
+    content: 'hi',
+    contentType: 'text',
+    resources: [],
+    mentions: [],
+    mentionAll: false,
+    senderIsBot: true,
+    threadId: over.threadId,
+    rootId: over.rootId,
+  };
+}
+
+const cfg = { channels: { feishu: {} } } as never;
+const event = { sender: { sender_id: { open_id: 'x' } }, message: { message_id: 'om_trigger', chat_id: 'oc_topic' } };
+
+async function runWith(ctx: ReturnType<typeof makeCtx>) {
+  mockParseMessageEvent.mockResolvedValue(ctx);
+  mockResolveSenderInfo.mockResolvedValue({ ctx, permissionError: undefined });
+  await handleFeishuMessage({ cfg, event: event as never, botOpenId: 'ou_self' });
+}
+
+describe('loop-guard cutoff notice routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    accountConfig = {};
+    mockResolveMedia.mockResolvedValue({ mediaList: [], payload: undefined });
+    mockResolveQuotedContent.mockResolvedValue(undefined);
+  });
+
+  it('does NOT thread the notice for a root_id-only quote-reply chain (no real thread)', async () => {
+    accountConfig = {}; // threadSession unset
+    await runWith(makeCtx({ threadId: undefined, rootId: 'om_root' }));
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    const arg = sendMessageFeishuMock.mock.calls[0][0] as { replyInThread: boolean; threadId: string | undefined };
+    expect(arg.replyInThread).toBe(false); // would-be-thread root_id must NOT force a thread
+    expect(arg.threadId).toBeUndefined();
+  });
+
+  it('does NOT thread when in a real thread but threadSession is off', async () => {
+    accountConfig = {}; // threadSession unset
+    await runWith(makeCtx({ threadId: 'omt_real', rootId: undefined }));
+
+    const arg = sendMessageFeishuMock.mock.calls[0][0] as { replyInThread: boolean; threadId: string | undefined };
+    expect(arg.replyInThread).toBe(false);
+    expect(arg.threadId).toBeUndefined();
+  });
+
+  it('DOES thread when in a real thread AND threadSession is on (deliberate topic session)', async () => {
+    accountConfig = { threadSession: true };
+    await runWith(makeCtx({ threadId: 'omt_real', rootId: undefined }));
+
+    const arg = sendMessageFeishuMock.mock.calls[0][0] as { replyInThread: boolean; threadId: string | undefined };
+    expect(arg.replyInThread).toBe(true);
+    expect(arg.threadId).toBe('omt_real');
+  });
+});

--- a/tests/loop-guard-notice-routing.test.ts
+++ b/tests/loop-guard-notice-routing.test.ts
@@ -139,4 +139,22 @@ describe('loop-guard cutoff notice routing', () => {
     expect(arg.replyInThread).toBe(true);
     expect(arg.threadId).toBe('omt_real');
   });
+
+  it('DOES thread when in a real thread AND replyInThread is on (follows the body routing)', async () => {
+    accountConfig = { replyInThread: true }; // threadSession off, replyInThread on
+    await runWith(makeCtx({ threadId: 'omt_real', rootId: undefined }));
+
+    const arg = sendMessageFeishuMock.mock.calls[0][0] as { replyInThread: boolean; threadId: string | undefined };
+    expect(arg.replyInThread).toBe(true);
+    expect(arg.threadId).toBe('omt_real');
+  });
+
+  it('does NOT thread for a root_id-only chain even with replyInThread on (no real thread)', async () => {
+    accountConfig = { replyInThread: true };
+    await runWith(makeCtx({ threadId: undefined, rootId: 'om_root' }));
+
+    const arg = sendMessageFeishuMock.mock.calls[0][0] as { replyInThread: boolean; threadId: string | undefined };
+    expect(arg.replyInThread).toBe(false); // replyInThread relaxes thread suppression; it never mints a thread
+    expect(arg.threadId).toBeUndefined();
+  });
 });

--- a/tests/mention-registry.test.ts
+++ b/tests/mention-registry.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Unit tests for the per-chat name→openId registry.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  lookupByName,
+  purgeStaleEntries,
+  recordMention,
+  recordSender,
+  resetMentionRegistry,
+} from '../src/messaging/inbound/mention-registry';
+
+beforeEach(() => {
+  resetMentionRegistry();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('mention-registry', () => {
+  it('records and looks up by exact name', () => {
+    recordMention('oc_chat', 'ou_alice', 'Alice');
+    expect(lookupByName('oc_chat', 'Alice')).toBe('ou_alice');
+  });
+
+  it('lookup is case-insensitive and ignores surrounding whitespace', () => {
+    recordSender('oc_chat', 'ou_bob', 'Bob');
+    expect(lookupByName('oc_chat', 'BOB')).toBe('ou_bob');
+    expect(lookupByName('oc_chat', '  bob  ')).toBe('ou_bob');
+  });
+
+  it('scopes per chatId', () => {
+    recordMention('oc_chat_a', 'ou_alice_a', 'Alice');
+    recordMention('oc_chat_b', 'ou_alice_b', 'Alice');
+    expect(lookupByName('oc_chat_a', 'Alice')).toBe('ou_alice_a');
+    expect(lookupByName('oc_chat_b', 'Alice')).toBe('ou_alice_b');
+  });
+
+  it('returns undefined for unknown name', () => {
+    recordMention('oc_chat', 'ou_alice', 'Alice');
+    expect(lookupByName('oc_chat', 'Charlie')).toBeUndefined();
+  });
+
+  it('returns undefined for unknown chat', () => {
+    recordMention('oc_chat_a', 'ou_alice', 'Alice');
+    expect(lookupByName('oc_other', 'Alice')).toBeUndefined();
+  });
+
+  it('newer record overwrites older entry for the same name', () => {
+    recordMention('oc_chat', 'ou_old', 'Dana');
+    recordMention('oc_chat', 'ou_new', 'Dana');
+    expect(lookupByName('oc_chat', 'Dana')).toBe('ou_new');
+  });
+
+  it('ignores empty/falsy inputs', () => {
+    recordMention('', 'ou_x', 'X');
+    recordMention('oc_chat', '', 'X');
+    recordMention('oc_chat', 'ou_x', '');
+    expect(lookupByName('oc_chat', 'X')).toBeUndefined();
+  });
+
+  it('TTL eviction on read', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    recordMention('oc_chat', 'ou_eve', 'Eve');
+    expect(lookupByName('oc_chat', 'Eve', { ttlMs: 1000 })).toBe('ou_eve');
+    vi.setSystemTime(new Date('2026-01-01T00:00:02Z'));
+    expect(lookupByName('oc_chat', 'Eve', { ttlMs: 1000 })).toBeUndefined();
+  });
+
+  it('purgeStaleEntries drops aged entries and empties chats', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    recordMention('oc_chat', 'ou_eve', 'Eve');
+    vi.setSystemTime(new Date('2026-01-01T00:00:05Z'));
+    purgeStaleEntries(1000);
+    expect(lookupByName('oc_chat', 'Eve')).toBeUndefined();
+  });
+});

--- a/tests/outbound-ensure-mention-integration.test.ts
+++ b/tests/outbound-ensure-mention-integration.test.ts
@@ -121,6 +121,26 @@ describe('sendText + ensureMention via AsyncLocalStorage', () => {
     expect(matches.length).toBe(1);
   });
 
+  it('does not re-@ the peer on later sends in the same dispatch (cross-chunk de-dup)', async () => {
+    await runWithBotPeerContext(
+      { peerOpenId: 'ou_peer_bot', peerName: 'PeerBot' },
+      async () => {
+        // Two sends within one dispatch (e.g. a reply split into chunks).
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await feishuOutbound.sendText!({ cfg: {} as any, to: CHAT, text: '第一段', accountId: 'acct1' });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await feishuOutbound.sendText!({ cfg: {} as any, to: CHAT, text: '第二段', accountId: 'acct1' });
+      },
+    );
+
+    expect(sendTextLarkMock).toHaveBeenCalledTimes(2);
+    const first = sendTextLarkMock.mock.calls[0][0].text;
+    const second = sendTextLarkMock.mock.calls[1][0].text;
+    expect(first).toContain('<at user_id="ou_peer_bot">PeerBot</at>'); // first chunk @s the peer
+    expect(second).not.toContain('<at user_id="ou_peer_bot">'); // later chunk does not repeat it
+    expect(second).toContain('第二段');
+  });
+
   it('composes with normalize: LLM writes "@PeerBot", normalize rewrites, ensureMention then no-ops', async () => {
     recordMention(CHAT, 'ou_peer_bot', 'PeerBot');
     await runWithBotPeerContext(

--- a/tests/outbound-ensure-mention-integration.test.ts
+++ b/tests/outbound-ensure-mention-integration.test.ts
@@ -83,7 +83,9 @@ describe('sendText + ensureMention via AsyncLocalStorage', () => {
 
     expect(sendTextLarkMock).toHaveBeenCalledTimes(1);
     const sent = sendTextLarkMock.mock.calls[0][0].text;
-    expect(sent).toContain('<at user_id="ou_peer_bot">PeerBot</at>');
+    // Assert the @ is PREPENDED (position + exact format), not merely present,
+    // so a regression to tail-append or extra spacing is caught.
+    expect(sent.startsWith('<at user_id="ou_peer_bot">PeerBot</at> ')).toBe(true);
     expect(sent).toContain('好的，我去查');
   });
 

--- a/tests/outbound-ensure-mention-integration.test.ts
+++ b/tests/outbound-ensure-mention-integration.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Integration test: outbound `sendText` honors the bot-peer context that
+ * the dispatch layer attaches via `runWithBotPeerContext`. When set, the
+ * outbound layer injects an `<at user_id="ou_peer">` element so the peer
+ * bot receives the reply even if the LLM forgot to @-mention it.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sendTextLarkMock = vi.hoisted(() => vi.fn().mockResolvedValue({
+  messageId: 'om_sent',
+  chatId: 'oc_test',
+}));
+
+vi.mock('../src/messaging/outbound/deliver', () => ({
+  sendTextLark: sendTextLarkMock,
+  sendCardLark: vi.fn(),
+  sendCommentReplyLark: vi.fn(),
+  sendMediaLark: vi.fn(),
+}));
+
+vi.mock('../src/core/lark-client', () => ({
+  LarkClient: {
+    runtime: {
+      channel: {
+        text: { chunkMarkdownText: (s: string) => [s] },
+      },
+    },
+  },
+}));
+
+vi.mock('../src/core/lark-logger', () => ({
+  larkLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+vi.mock('../src/core/targets', () => ({
+  parseFeishuRouteTarget: (to: string) => ({ target: to }),
+}));
+
+vi.mock('../src/core/comment-target', () => ({
+  isCommentTarget: () => false,
+}));
+
+vi.mock('../src/core/synthetic-target', () => ({
+  isSyntheticTarget: () => false,
+}));
+
+import { feishuOutbound } from '../src/messaging/outbound/outbound';
+import { runWithBotPeerContext } from '../src/messaging/outbound/bot-peer-context';
+import {
+  recordMention,
+  resetMentionRegistry,
+} from '../src/messaging/inbound/mention-registry';
+
+const CHAT = 'oc_test';
+
+beforeEach(() => {
+  sendTextLarkMock.mockClear();
+  resetMentionRegistry();
+});
+
+afterEach(() => {
+  resetMentionRegistry();
+});
+
+describe('sendText + ensureMention via AsyncLocalStorage', () => {
+  it('injects an <at> element when bot-peer context is active and LLM forgot the @', async () => {
+    await runWithBotPeerContext(
+      { peerOpenId: 'ou_peer_bot', peerName: 'PeerBot' },
+      async () => {
+        await feishuOutbound.sendText!({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          cfg: {} as any,
+          to: CHAT,
+          text: '好的，我去查',
+          accountId: 'acct1',
+        });
+      },
+    );
+
+    expect(sendTextLarkMock).toHaveBeenCalledTimes(1);
+    const sent = sendTextLarkMock.mock.calls[0][0].text;
+    expect(sent).toContain('<at user_id="ou_peer_bot">PeerBot</at>');
+    expect(sent).toContain('好的，我去查');
+  });
+
+  it('does NOT touch text when no bot-peer context is set (human-peer path)', async () => {
+    await feishuOutbound.sendText!({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cfg: {} as any,
+      to: CHAT,
+      text: '普通回复',
+      accountId: 'acct1',
+    });
+
+    expect(sendTextLarkMock).toHaveBeenCalledTimes(1);
+    const sent = sendTextLarkMock.mock.calls[0][0].text;
+    expect(sent).toBe('普通回复');
+  });
+
+  it('is a no-op when the LLM already mentioned the peer correctly', async () => {
+    await runWithBotPeerContext(
+      { peerOpenId: 'ou_peer_bot', peerName: 'PeerBot' },
+      async () => {
+        await feishuOutbound.sendText!({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          cfg: {} as any,
+          to: CHAT,
+          text: '收到 <at user_id="ou_peer_bot">PeerBot</at>，我去查',
+          accountId: 'acct1',
+        });
+      },
+    );
+
+    const sent = sendTextLarkMock.mock.calls[0][0].text;
+    // Standard <at> element appears exactly once.
+    const matches = sent.match(/<at user_id="ou_peer_bot">/g) ?? [];
+    expect(matches.length).toBe(1);
+  });
+
+  it('composes with normalize: LLM writes "@PeerBot", normalize rewrites, ensureMention then no-ops', async () => {
+    recordMention(CHAT, 'ou_peer_bot', 'PeerBot');
+    await runWithBotPeerContext(
+      { peerOpenId: 'ou_peer_bot', peerName: 'PeerBot' },
+      async () => {
+        await feishuOutbound.sendText!({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          cfg: {} as any,
+          to: CHAT,
+          text: '@PeerBot 我去查',
+          accountId: 'acct1',
+        });
+      },
+    );
+
+    const sent = sendTextLarkMock.mock.calls[0][0].text;
+    const matches = sent.match(/<at user_id="ou_peer_bot">/g) ?? [];
+    expect(matches.length).toBe(1); // not duplicated
+    expect(sent).toContain('我去查');
+  });
+});

--- a/tests/outbound-mention.test.ts
+++ b/tests/outbound-mention.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Tests for outbound mention normalization + ensureMention safety net.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  ensureMention,
+  normalizeOutboundMentions,
+} from '../src/messaging/outbound/outbound-mention';
+import {
+  recordMention,
+  resetMentionRegistry,
+} from '../src/messaging/inbound/mention-registry';
+
+const CHAT = 'oc_test';
+
+beforeEach(() => {
+  resetMentionRegistry();
+  recordMention(CHAT, 'ou_alice', 'Alice');
+  recordMention(CHAT, 'ou_zhang', '张三');
+  recordMention(CHAT, 'ou_peer', 'PeerBot');
+});
+
+describe('normalizeOutboundMentions — six LLM variants', () => {
+  it('@Name → standard <at>', () => {
+    expect(normalizeOutboundMentions('hi @Alice', CHAT)).toBe(
+      'hi <at user_id="ou_alice">Alice</at>',
+    );
+  });
+
+  it('@[Name] → standard <at>', () => {
+    expect(normalizeOutboundMentions('hi @[Alice] there', CHAT)).toBe(
+      'hi <at user_id="ou_alice">Alice</at> there',
+    );
+  });
+
+  it('@<Name> → standard <at>', () => {
+    expect(normalizeOutboundMentions('hi @<Alice>', CHAT)).toBe(
+      'hi <at user_id="ou_alice">Alice</at>',
+    );
+  });
+
+  it('<@Name> → standard <at>', () => {
+    expect(normalizeOutboundMentions('hi <@Alice>!', CHAT)).toBe(
+      'hi <at user_id="ou_alice">Alice</at>!',
+    );
+  });
+
+  it('<at>Name</at> (no user_id) → standard <at>', () => {
+    expect(normalizeOutboundMentions('hi <at>Alice</at>', CHAT)).toBe(
+      'hi <at user_id="ou_alice">Alice</at>',
+    );
+  });
+
+  it('{{Name}} → standard <at>', () => {
+    expect(normalizeOutboundMentions('hi {{Alice}}', CHAT)).toBe(
+      'hi <at user_id="ou_alice">Alice</at>',
+    );
+  });
+
+  it('CJK name', () => {
+    expect(normalizeOutboundMentions('请 @张三 看看', CHAT)).toBe(
+      '请 <at user_id="ou_zhang">张三</at> 看看',
+    );
+  });
+});
+
+describe('normalizeOutboundMentions — boundary behavior', () => {
+  it('preserves an already-standard <at> element verbatim', () => {
+    const text = 'hi <at user_id="ou_alice">Alice</at> there';
+    expect(normalizeOutboundMentions(text, CHAT)).toBe(text);
+  });
+
+  it('does not double-rewrite a mention that points to the same user', () => {
+    const text = '<at user_id="ou_alice">Alice</at>';
+    expect(normalizeOutboundMentions(text, CHAT)).toBe(text);
+  });
+
+  it('leaves unknown names as plain text', () => {
+    expect(normalizeOutboundMentions('hi @Stranger', CHAT)).toBe('hi @Stranger');
+  });
+
+  it('does not touch @ inside email addresses', () => {
+    expect(normalizeOutboundMentions('contact me@example.com', CHAT)).toBe(
+      'contact me@example.com',
+    );
+  });
+
+  it('returns input unchanged when chatId is empty', () => {
+    expect(normalizeOutboundMentions('hi @Alice', '')).toBe('hi @Alice');
+  });
+
+  it('returns input unchanged when text is empty', () => {
+    expect(normalizeOutboundMentions('', CHAT)).toBe('');
+  });
+});
+
+describe('ensureMention — bot-peer safety net', () => {
+  it('prepends a standard <at> when peer is not already mentioned', () => {
+    const out = ensureMention('reply body', 'ou_peer', 'PeerBot');
+    expect(out).toBe('<at user_id="ou_peer">PeerBot</at> reply body');
+  });
+
+  it('no-op when peer is already mentioned via standard <at>', () => {
+    const input = 'hey <at user_id="ou_peer">PeerBot</at>, sounds good';
+    expect(ensureMention(input, 'ou_peer', 'PeerBot')).toBe(input);
+  });
+
+  it('no-op for empty peerOpenId (caller did not resolve the peer)', () => {
+    expect(ensureMention('reply body', '', 'PeerBot')).toBe('reply body');
+  });
+
+  it('falls back to openId when peerName is missing', () => {
+    expect(ensureMention('reply', 'ou_peer', '')).toBe(
+      '<at user_id="ou_peer">ou_peer</at> reply',
+    );
+  });
+
+  it('returns just the @ element when reply text is empty', () => {
+    expect(ensureMention('', 'ou_peer', 'PeerBot')).toBe(
+      '<at user_id="ou_peer">PeerBot</at>',
+    );
+  });
+});

--- a/tests/resolve-bot-name.test.ts
+++ b/tests/resolve-bot-name.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Behavior contract for resolveBotName.
+ *
+ * Aligned with upstream PR #89783's bot-name resolver design:
+ *   - calls /open-apis/bot/v3/bots/basic_batch (contact API can't see bots)
+ *   - shares the account-scoped LRU+TTL cache so repeated lookups stay cheap
+ *   - i18n-names fallback chain (zh_cn → en_us)
+ *   - best-effort on permission errors (don't surface as agent-visible)
+ *
+ * The local fork already implemented this functionality in
+ * src/messaging/inbound/user-name-cache.ts; this test pins the behavior so
+ * future refactors don't accidentally regress the bot-at-bot reception path.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearUserNameCache, getUserNameCache, resolveBotName } from '../src/messaging/inbound/user-name-cache';
+import type { LarkAccount } from '../src/core/types';
+
+const requestMock = vi.fn();
+
+vi.mock('../src/core/lark-client', () => ({
+  LarkClient: {
+    fromAccount: () => ({
+      sdk: { request: (...args: unknown[]) => requestMock(...args) },
+    }),
+  },
+}));
+
+const account = {
+  accountId: 'acct1',
+  appId: 'cli_test',
+  configured: true as const,
+  enabled: true,
+  brand: 'feishu' as const,
+  config: {},
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as unknown as LarkAccount;
+
+const noopLog = () => undefined;
+
+beforeEach(() => {
+  requestMock.mockReset();
+  clearUserNameCache(account.accountId);
+});
+
+afterEach(() => {
+  clearUserNameCache(account.accountId);
+});
+
+describe('resolveBotName', () => {
+  it('resolves a bot name via /open-apis/bot/v3/bots/basic_batch', async () => {
+    requestMock.mockResolvedValueOnce({
+      data: { bots: { ou_bot: { name: 'AlphaBot' } } },
+    });
+    const r = await resolveBotName({ account, openId: 'ou_bot', log: noopLog });
+    expect(r.name).toBe('AlphaBot');
+    expect(requestMock).toHaveBeenCalledWith({
+      method: 'GET',
+      url: '/open-apis/bot/v3/bots/basic_batch',
+      params: { bot_ids: ['ou_bot'] },
+    });
+  });
+
+  it('falls back to i18n_names.zh_cn when name field is empty', async () => {
+    requestMock.mockResolvedValueOnce({
+      data: { bots: { ou_bot: { name: '', i18n_names: { zh_cn: '阿尔法机器人', en_us: 'AlphaBot' } } } },
+    });
+    const r = await resolveBotName({ account, openId: 'ou_bot', log: noopLog });
+    expect(r.name).toBe('阿尔法机器人');
+  });
+
+  it('falls back to i18n_names.en_us when name and zh_cn are empty', async () => {
+    requestMock.mockResolvedValueOnce({
+      data: { bots: { ou_bot: { name: '', i18n_names: { en_us: 'AlphaBot' } } } },
+    });
+    const r = await resolveBotName({ account, openId: 'ou_bot', log: noopLog });
+    expect(r.name).toBe('AlphaBot');
+  });
+
+  it('serves a second call from cache without re-calling the API', async () => {
+    requestMock.mockResolvedValueOnce({
+      data: { bots: { ou_bot: { name: 'AlphaBot' } } },
+    });
+    await resolveBotName({ account, openId: 'ou_bot', log: noopLog });
+    await resolveBotName({ account, openId: 'ou_bot', log: noopLog });
+    expect(requestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches an empty name when the bot has no resolvable display name', async () => {
+    requestMock.mockResolvedValueOnce({ data: { bots: {} } });
+    const r = await resolveBotName({ account, openId: 'ou_bot', log: noopLog });
+    expect(r.name).toBeUndefined();
+    // Second call must not hit the API — empty-name caching prevents retry storms.
+    await resolveBotName({ account, openId: 'ou_bot', log: noopLog });
+    expect(requestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows permission errors and caches empty (no agent-visible failure)', async () => {
+    requestMock.mockRejectedValueOnce({
+      response: { data: { code: 99991663, msg: 'permission denied' } },
+    });
+    const r = await resolveBotName({ account, openId: 'ou_bot', log: noopLog });
+    expect(r.name).toBeUndefined();
+    expect(r.permissionError).toBeUndefined();
+    // Cached: no second API call.
+    await resolveBotName({ account, openId: 'ou_bot', log: noopLog });
+    expect(requestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows network errors and caches empty (graceful degradation)', async () => {
+    requestMock.mockRejectedValueOnce(new Error('network down'));
+    const r = await resolveBotName({ account, openId: 'ou_bot', log: noopLog });
+    expect(r.name).toBeUndefined();
+  });
+
+  it('returns empty when account is not configured', async () => {
+    const r = await resolveBotName({
+      account: { ...account, configured: false },
+      openId: 'ou_bot',
+      log: noopLog,
+    });
+    expect(r.name).toBeUndefined();
+    expect(requestMock).not.toHaveBeenCalled();
+  });
+
+  it('shares the account-scoped cache with user-name lookups', async () => {
+    requestMock.mockResolvedValueOnce({
+      data: { bots: { ou_bot: { name: 'AlphaBot' } } },
+    });
+    await resolveBotName({ account, openId: 'ou_bot', log: noopLog });
+    const cache = getUserNameCache(account.accountId);
+    expect(cache.get('ou_bot')).toBe('AlphaBot');
+  });
+});

--- a/tests/resolve-mentions-leading-strip.test.ts
+++ b/tests/resolve-mentions-leading-strip.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ *
+ * Tests for the leading-only self-mention strip in resolveMentions.
+ *
+ * The previous implementation injected a "@你(本机器人)" anchor in place of
+ * every self-mention; this test pins the new behavior:
+ *  - Leading self-mention → dropped entirely
+ *  - Mid-text self-mention → rendered as "@Name" (no anchor, no strip)
+ */
+
+import { describe, expect, it } from 'vitest';
+import { resolveMentions } from '../src/messaging/converters/content-converter-helpers';
+import type { ConvertContext } from '../src/messaging/converters/types';
+import type { MentionInfo } from '../src/messaging/types';
+
+function makeCtx(bot: MentionInfo, otherKey: MentionInfo[] = []): ConvertContext {
+  const mentions = new Map<string, MentionInfo>();
+  mentions.set(bot.key, bot);
+  for (const m of otherKey) mentions.set(m.key, m);
+  return {
+    mentions,
+    mentionsByOpenId: new Map(),
+    messageId: 'om_test',
+    stripBotMentions: true,
+  };
+}
+
+const SELF: MentionInfo = {
+  key: '@_bot_self',
+  openId: 'ou_self',
+  name: 'MyBot',
+  isBot: true,
+};
+
+describe('resolveMentions — leading-only strip for self-mention', () => {
+  it('drops the leading self-mention with placeholder key', () => {
+    const ctx = makeCtx(SELF);
+    expect(resolveMentions('@_bot_self  please summarize', ctx)).toBe('please summarize');
+  });
+
+  it('drops the leading self-mention written as @Name', () => {
+    const ctx = makeCtx(SELF);
+    expect(resolveMentions('@MyBot please summarize', ctx)).toBe('please summarize');
+  });
+
+  it('strips a leading colon/comma after the self-mention', () => {
+    const ctx = makeCtx(SELF);
+    expect(resolveMentions('@MyBot: do it', ctx)).toBe('do it');
+    expect(resolveMentions('@MyBot, do it', ctx)).toBe('do it');
+    expect(resolveMentions('@MyBot，请处理', ctx)).toBe('请处理');
+  });
+
+  it('preserves mid-text self-mention as plain @Name', () => {
+    const ctx = makeCtx(SELF);
+    const out = resolveMentions('hey @MyBot please take a look', ctx);
+    expect(out).toContain('@MyBot');
+    expect(out).not.toContain('@你(本机器人)');
+  });
+
+  it('leaves non-bot mentions rendered as @Name regardless of position', () => {
+    const human: MentionInfo = {
+      key: '@_user_1',
+      openId: 'ou_alice',
+      name: 'Alice',
+      isBot: false,
+    };
+    const ctx = makeCtx(SELF, [human]);
+    expect(resolveMentions('@_user_1 hi from @_bot_self', ctx)).toContain('@Alice');
+    expect(resolveMentions('@_user_1 hi from @_bot_self', ctx)).toContain('@MyBot');
+  });
+
+  it('does not strip the anchor when stripBotMentions is false', () => {
+    const ctx: ConvertContext = {
+      mentions: new Map([[SELF.key, SELF]]),
+      mentionsByOpenId: new Map(),
+      messageId: 'om_test',
+      stripBotMentions: false,
+    };
+    const out = resolveMentions('@_bot_self hi', ctx);
+    expect(out).toContain('@MyBot');
+  });
+});

--- a/tests/vc-synthetic-notify.test.ts
+++ b/tests/vc-synthetic-notify.test.ts
@@ -91,6 +91,8 @@ vi.mock('../src/messaging/inbound/dispatch-builders', () => ({
   buildEnvelopeWithHistory: vi.fn(() => ({ combinedBody: 'body', historyKey: undefined })),
   buildBodyForAgent: vi.fn(() => 'body-for-agent'),
   buildInboundPayload: vi.fn(() => ({ inbound: true })),
+  buildFeishuIdentityFields: vi.fn(() => ({})),
+  buildFeishuGroupSystemPrompt: vi.fn(() => undefined),
 }))
 
 import { dispatchToAgent } from '../src/messaging/inbound/dispatch'

--- a/tests/vc-synthetic-notify.test.ts
+++ b/tests/vc-synthetic-notify.test.ts
@@ -69,6 +69,7 @@ vi.mock('../src/card/tool-use-trace-store', () => ({
 
 vi.mock('../src/channel/abort-detect', () => ({
   isLikelyAbortText: vi.fn(() => false),
+  isConversationStopIntent: vi.fn(() => false),
 }))
 
 vi.mock('../src/messaging/outbound/deliver', () => ({


### PR DESCRIPTION
Enable bot-to-bot conversations in Feishu group chats:

- Inbound: mention registry resolves bot @-mentions, keeps the self-mention anchor so the addressed bot retains its instructions, and injects bot self-identity + @-delivery guidance
- Outbound: ensureMention guarantees the designated bot peer is @-mentioned on real reply send paths (text chunks and card replies), de-duplicated across chunks, with thread routing aligned to upstream #89783
- Loop guard: cross-bot loop detection cuts off runaway debates, surfaces a localized (zh_cn/en_us) cutoff notice to humans once, delivered in the chat where the debate happens