### PR TITLE
feat: add forceGroupThread option to force thread replies in all groups

### DIFF
--- a/src/core/config-schema.ts
+++ b/src/core/config-schema.ts
@@ -196,6 +196,9 @@ export const FeishuAccountConfigSchema = z.object({
   dedup: DedupSchema,
   reactionNotifications: ReactionNotificationModeSchema,
   threadSession: z.boolean().optional(),
+  /** When true, force all group messages (including direct @mentions without
+   *  root_id) into threaded replies regardless of the group's chat mode. */
+  forceGroupThread: z.boolean().optional(),
   allowBots: AllowBotsSchema,
   uat: UATConfigSchema,
 });

--- a/src/messaging/inbound/dispatch.ts
+++ b/src/messaging/inbound/dispatch.ts
@@ -352,21 +352,30 @@ export async function dispatchToAgent(params: {
   // 1. Derive shared context (including route resolution + system event)
   const dc = buildDispatchContext(params);
 
-  // 1a. Thread detection fallback for topic groups.
-  //     In topic groups (chat_mode=topic), reply events may carry root_id
-  //     without thread_id.  When threadSession is enabled, use root_id as
-  //     a synthetic threadId so replies stay inside the topic instead of
-  //     creating a new top-level message.
-  if (!dc.isThread && dc.isGroup && dc.ctx.rootId && dc.account.config?.threadSession === true) {
-    const threadCapable = await isThreadCapableGroup({
-      cfg: dc.accountScopedCfg,
-      chatId: dc.ctx.chatId,
-      accountId: dc.account.accountId,
-    });
-    if (threadCapable) {
-      log.info(`inferred thread from root_id=${dc.ctx.rootId} in topic group ${dc.ctx.chatId}`);
+  // 1a. Thread detection for group messages.
+  //     - forceGroupThread = true: all group messages get threaded;
+  //       root_id is used when available, otherwise the message itself
+  //       serves as the thread anchor (Lark API auto-creates a new
+  //       thread when reply_in_thread=true with reply_to_message_id).
+  //     - threadSession = true (without forceGroupThread): only
+  //       thread-capable groups with a root_id get threaded.
+  if (!dc.isThread && dc.isGroup) {
+    if (dc.account.config?.forceGroupThread === true) {
+      const anchorId = dc.ctx.rootId || dc.ctx.messageId;
+      log.info(`forced thread in group ${dc.ctx.chatId} (anchor=${dc.ctx.rootId ? 'root_id' : 'messageId'})`);
       dc.isThread = true;
-      dc.ctx = { ...dc.ctx, threadId: dc.ctx.rootId };
+      dc.ctx = { ...dc.ctx, threadId: anchorId };
+    } else if (dc.account.config?.threadSession === true && dc.ctx.rootId) {
+      const threadCapable = await isThreadCapableGroup({
+        cfg: dc.accountScopedCfg,
+        chatId: dc.ctx.chatId,
+        accountId: dc.account.accountId,
+      });
+      if (threadCapable) {
+        log.info(`inferred thread from root_id=${dc.ctx.rootId} in topic group ${dc.ctx.chatId}`);
+        dc.isThread = true;
+        dc.ctx = { ...dc.ctx, threadId: dc.ctx.rootId };
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Add a new `forceGroupThread` config option that forces all @bot group messages into threaded replies, regardless of the group chat mode or whether the incoming message carries a `root_id`.

## Motivation

Currently, `threadSession: true` only enables threaded replies when:
1. The group is thread-capable (`chat_mode=topic` or `group_message_type=thread`)
2. The incoming message has a `root_id` (it is a reply to another message)

This means direct @mentions in regular chat-mode groups always appear in the main chat stream, making group conversations cluttered when a bot responds frequently.

## Changes

- **`src/core/config-schema.ts`**: Add `forceGroupThread: z.boolean().optional()` to `FeishuAccountConfigSchema`
- **`src/messaging/inbound/dispatch.ts`**: In `dispatchToAgent`, when `forceGroupThread=true`: skip the `isThreadCapableGroup` check and the `root_id` requirement. Use `root_id` when available, falling back to `messageId` as the thread anchor (Lark API auto-creates a new thread when `reply_in_thread=true` with `reply_to_message_id`).
- Existing `threadSession: true` behavior is **unchanged** — fully backward compatible.

## Usage

```json
{
  "channels": {
    "feishu": {
      "forceGroupThread": true
    }
  }
}
```

## Testing

Tested on Feishu with both chat-mode and topic-mode groups. All @bot messages correctly appear as threaded replies with streaming card support.