### PR TITLE
fix(feishu): start typing reaction before agent dispatch

### DIFF
--- a/src/card/reply-dispatcher-types.ts
+++ b/src/card/reply-dispatcher-types.ts
@@ -148,6 +148,7 @@ export interface CreateFeishuReplyDispatcherParams {
 export interface FeishuReplyDispatcherResult {
   dispatcher: ReplyDispatcher;
   replyOptions: Record<string, unknown>;
+  startTypingIndicator: () => void;
   markDispatchIdle: () => void;
   markFullyComplete: () => void;
   abortCard: () => Promise<void>;

--- a/src/card/reply-dispatcher.ts
+++ b/src/card/reply-dispatcher.ts
@@ -130,28 +130,42 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   // ---- Typing indicator (reaction-based) ----
   let typingState: TypingIndicatorState | null = null;
   let typingStopped = false;
+  let typingStartPromise: Promise<void> | null = null;
+
+  const startTypingReaction = async () => {
+    if (shouldSkip('typing.start.precheck')) return;
+    if (!replyToMessageId || typingStopped || params.skipTyping) return;
+    if (typingState?.reactionId) return;
+
+    typingState = await addTypingIndicator({
+      cfg,
+      messageId: replyToMessageId,
+      accountId,
+    });
+    if (shouldSkip('typing.start.postcheck')) return;
+
+    if (typingStopped && typingState) {
+      await removeTypingIndicator({ cfg, state: typingState, accountId });
+      typingState = null;
+      log.info('removed typing indicator (raced with stop)');
+      return;
+    }
+    log.info('added typing indicator reaction');
+  };
 
   const typingCallbacks = createTypingCallbacks({
     keepaliveIntervalMs: 0,
     start: async () => {
-      if (shouldSkip('typing.start.precheck')) return;
-      if (!replyToMessageId || typingStopped || params.skipTyping) return;
-      if (typingState?.reactionId) return;
-
-      typingState = await addTypingIndicator({
-        cfg,
-        messageId: replyToMessageId,
-        accountId,
-      });
-      if (shouldSkip('typing.start.postcheck')) return;
-
-      if (typingStopped && typingState) {
-        await removeTypingIndicator({ cfg, state: typingState, accountId });
-        typingState = null;
-        log.info('removed typing indicator (raced with stop)');
+      if (typingStartPromise) {
+        await typingStartPromise;
         return;
       }
-      log.info('added typing indicator reaction');
+      typingStartPromise = startTypingReaction();
+      try {
+        await typingStartPromise;
+      } finally {
+        typingStartPromise = null;
+      }
     },
     stop: async () => {
       typingStopped = true;
@@ -177,6 +191,13 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       });
     },
   });
+
+  const startTypingIndicator = () => {
+    if (shouldSkip('typing.eagerStart')) return;
+    if (!replyToMessageId || typingStopped || params.skipTyping) return;
+    log.info('typing indicator eager start requested');
+    void typingCallbacks.onReplyStart?.();
+  };
 
   // ---- dispatchFullyComplete flag (static mode) ----
   let dispatchFullyComplete = false;
@@ -433,6 +454,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           }
         : {}),
     },
+    startTypingIndicator,
     markDispatchIdle,
     markFullyComplete: () => {
       dispatchFullyComplete = true;

--- a/src/messaging/inbound/dispatch.ts
+++ b/src/messaging/inbound/dispatch.ts
@@ -262,19 +262,20 @@ async function dispatchNormalMessage(
     clearToolUseTraceRun(effectiveSessionKey);
   }
 
-  const { dispatcher, replyOptions, markDispatchIdle, markFullyComplete, abortCard } = createFeishuReplyDispatcher({
-    cfg: dc.accountScopedCfg,
-    agentId: dc.route.agentId,
-    chatId: dc.ctx.chatId,
-    sessionKey: effectiveSessionKey,
-    replyToMessageId: replyToMessageId ?? dc.ctx.messageId,
-    accountId: dc.account.accountId,
-    chatType: dc.ctx.chatType,
-    skipTyping,
-    replyInThread: routing.replyInThread,
-    threadId: routing.threadId,
-    toolUseDisplay,
-  });
+  const { dispatcher, replyOptions, startTypingIndicator, markDispatchIdle, markFullyComplete, abortCard } =
+    createFeishuReplyDispatcher({
+      cfg: dc.accountScopedCfg,
+      agentId: dc.route.agentId,
+      chatId: dc.ctx.chatId,
+      sessionKey: effectiveSessionKey,
+      replyToMessageId: replyToMessageId ?? dc.ctx.messageId,
+      accountId: dc.account.accountId,
+      chatType: dc.ctx.chatType,
+      skipTyping,
+      replyInThread: routing.replyInThread,
+      threadId: routing.threadId,
+      toolUseDisplay,
+    });
 
   // Create an AbortController so the abort fast-path can cancel the
   // underlying LLM request (not just the streaming card UI).
@@ -287,6 +288,7 @@ async function dispatchNormalMessage(
 
   dc.log(`feishu[${dc.account.accountId}]: dispatching to agent (session=${effectiveSessionKey})`);
   log.info(`dispatching to agent (session=${effectiveSessionKey})`);
+  startTypingIndicator();
 
   // Attach the resolved bot-peer (if any) so the outbound `ensureMention`
   // backstop can guarantee an @ even when the LLM forgets. Resolved by the

--- a/tests/dispatch-tool-use-init.test.ts
+++ b/tests/dispatch-tool-use-init.test.ts
@@ -11,6 +11,7 @@ const {
   clearToolUseTraceRunMock,
   createFeishuReplyDispatcherMock,
   dispatchReplyFromConfigMock,
+  startTypingIndicatorMock,
 } = vi.hoisted(() => ({
   buildDispatchContextMock: vi.fn(),
   buildMessageBodyMock: vi.fn(() => 'message-body'),
@@ -22,6 +23,7 @@ const {
   clearToolUseTraceRunMock: vi.fn(),
   createFeishuReplyDispatcherMock: vi.fn(),
   dispatchReplyFromConfigMock: vi.fn(),
+  startTypingIndicatorMock: vi.fn(),
 }));
 
 vi.mock('../src/messaging/inbound/dispatch-context', () => ({
@@ -185,6 +187,7 @@ beforeEach(() => {
   createFeishuReplyDispatcherMock.mockReturnValue({
     dispatcher: createDispatcher(),
     replyOptions: {},
+    startTypingIndicator: startTypingIndicatorMock,
     markDispatchIdle: vi.fn(),
     markFullyComplete: vi.fn(),
     abortCard: vi.fn(),
@@ -210,6 +213,33 @@ describe('dispatchToAgent tool_use trace initialization', () => {
     expect(startToolUseTraceRunMock).toHaveBeenCalledTimes(1);
     expect(startToolUseTraceRunMock).toHaveBeenCalledWith('session-1');
     expect(clearToolUseTraceRunMock).not.toHaveBeenCalled();
+  });
+
+  it('starts the typing indicator before dispatching the agent reply', async () => {
+    const order: string[] = [];
+    startTypingIndicatorMock.mockImplementationOnce(() => {
+      order.push('typing');
+    });
+    dispatchReplyFromConfigMock.mockImplementationOnce(async () => {
+      order.push('dispatch');
+      return {
+        queuedFinal: false,
+        counts: { final: 0 },
+      };
+    });
+
+    const dc = createDispatchContext();
+
+    await dispatchToAgent({
+      ctx: dc.ctx as never,
+      mediaPayload: {},
+      account: dc.account as never,
+      accountScopedCfg: {} as never,
+      historyLimit: 0,
+    });
+
+    expect(startTypingIndicatorMock).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(['typing', 'dispatch']);
   });
 
   it('clears the trace run without initializing it when tool_use is disabled', async () => {


### PR DESCRIPTION
## Summary
- start the Feishu typing reaction as soon as normal inbound messages are dispatched to the agent
- keep the existing onReplyStart typing path and add an in-flight guard so eager start and core reply start do not create duplicate reactions
- add coverage that verifies typing starts before dispatchReplyFromConfig runs

## Verification
- pnpm test tests/dispatch-tool-use-init.test.ts
- pnpm typecheck
- pnpm lint
- pnpm build
- pnpm test