### PR TITLE
ci: validate packed plugin entrypoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,8 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+      - name: Validate packed artifact
+        run: |
+          pnpm build
+          pnpm pack:check

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "scripts": {
     "build": "tsdown",
+    "pack:check": "mkdir -p .pack && rm -f .pack/*.tgz && pnpm pack --pack-destination .pack && node scripts/validate-pack.mjs .pack/*.tgz",
     "release": "node scripts/release.mjs",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/validate-pack.mjs
+++ b/scripts/validate-pack.mjs
@@ -1,0 +1,47 @@
+import { execFileSync } from 'node:child_process';
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+const tarball = process.argv[2];
+if (!tarball) fail('Usage: node scripts/validate-pack.mjs <tarball.tgz>');
+
+const listOutput = execFileSync('tar', ['-tf', tarball], { encoding: 'utf8' });
+const entries = new Set(
+  listOutput
+    .split('\n')
+    .map((entry) => entry.trim())
+    .filter(Boolean),
+);
+
+const packageJsonText = execFileSync('tar', ['-xOf', tarball, 'package/package.json'], { encoding: 'utf8' });
+const manifest = JSON.parse(packageJsonText);
+
+const declaredEntries = [];
+
+if (typeof manifest.main === 'string' && manifest.main.trim()) {
+  declaredEntries.push({ label: 'main', path: manifest.main.trim() });
+}
+
+const openclawExtensions = manifest?.openclaw?.extensions;
+if (Array.isArray(openclawExtensions)) {
+  for (const extensionPath of openclawExtensions) {
+    if (typeof extensionPath === 'string' && extensionPath.trim()) {
+      declaredEntries.push({ label: 'openclaw.extensions', path: extensionPath.trim() });
+    }
+  }
+}
+
+for (const entry of declaredEntries) {
+  const normalized = entry.path.replace(/^\.\//, '');
+  const tarPath = `package/${normalized}`;
+  if (!entries.has(tarPath)) {
+    fail(
+      `Packed tarball is missing declared ${entry.label} entry "${entry.path}" from package.json (${tarPath})`,
+    );
+  }
+}
+
+console.log(`Validated packed artifact ${tarball}`);


### PR DESCRIPTION
## Summary
Add a CI guard that validates the packed npm tarball contains the entrypoints declared in package.json, especially `main` and `openclaw.extensions`.

## Why
The published package can fail after release even when source CI is green if the tarball contents diverge from the manifest. This check catches that class of packaging regression before publish.

## Validation
- runs after build in CI
- packs the artifact with `pnpm pack`
- verifies the tarball contains every declared `main` and `openclaw.extensions` path

Refs: #524, #555
