### PR TITLE
feat(ask-user-question): add checkbox select style for multi-select

### DIFF
--- a/src/tools/ask-user-question.ts
+++ b/src/tools/ask-user-question.ts
@@ -69,6 +69,7 @@ interface QuestionItem {
   header: string;
   options: Array<{ label: string; description: string }>;
   multiSelect: boolean;
+  selectStyle?: 'dropdown' | 'checkbox';
 }
 
 /** Lightweight context stored while awaiting user response (no Promise / timeout). */
@@ -186,6 +187,10 @@ function getInputFieldName(questionIndex: number): string {
 
 function getSelectFieldName(questionIndex: number): string {
   return `${SELECT_FIELD_NAME}_${questionIndex}`;
+}
+
+function getCheckerFieldName(questionIndex: number, optionIndex: number): string {
+  return `${SELECT_FIELD_NAME}_${questionIndex}_${optionIndex}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -308,8 +313,12 @@ export function handleAskUserAction(data: unknown, _cfg: ClawdbotConfig, account
       // Free-text input
       answer = readFormTextField(formValue, getInputFieldName(i));
     } else if (q.multiSelect) {
-      // Multi-select
-      const selected = readFormMultiSelect(formValue, getSelectFieldName(i));
+      // Multi-select — either a dropdown (multi_select_static) or a set of
+      // independent checker rows, depending on selectStyle.
+      const selected =
+        q.selectStyle === 'checkbox'
+          ? readFormCheckers(formValue, i, q.options)
+          : readFormMultiSelect(formValue, getSelectFieldName(i));
       if (selected.length > 0) {
         answer = selected.join(', ');
       }
@@ -519,6 +528,27 @@ function readFormMultiSelect(formValue: Record<string, unknown>, fieldName: stri
   return [];
 }
 
+/**
+ * Read the selected labels from a set of independent checker (checkbox)
+ * components — used when a multi-select question uses selectStyle 'checkbox'.
+ * Each option has its own boolean field (see getCheckerFieldName); Feishu may
+ * report the checked state as a boolean or a string.
+ */
+function readFormCheckers(
+  formValue: Record<string, unknown>,
+  questionIndex: number,
+  options: Array<{ label: string; description: string }>,
+): string[] {
+  const selected: string[] = [];
+  for (let optIndex = 0; optIndex < options.length; optIndex++) {
+    const raw = formValue[getCheckerFieldName(questionIndex, optIndex)];
+    if (raw === true || raw === 'true') {
+      selected.push(options[optIndex].label);
+    }
+  }
+  return selected;
+}
+
 // ---------------------------------------------------------------------------
 // Card Builders — unified form layout
 // ---------------------------------------------------------------------------
@@ -588,7 +618,23 @@ function buildQuestionFormElements(q: QuestionItem, questionIndex: number): Reco
     value: opt.label,
   }));
 
-  if (q.multiSelect) {
+  if (q.multiSelect && q.selectStyle === 'checkbox') {
+    // ---- Multi-select as independent checkbox rows ----
+    // Each option is its own checker so the user sees every selection at a
+    // glance before submitting (vs. the compact dropdown collapsed state).
+    // Note: checker requires a `value` field to pass Feishu's client-side
+    // interactive-component validation (otherwise code 200340).
+    elems.push(labelMd);
+    q.options.forEach((opt, optIndex) => {
+      elems.push({
+        tag: 'checker',
+        name: getCheckerFieldName(questionIndex, optIndex),
+        checked: false,
+        text: { tag: 'plain_text', content: opt.label },
+        value: { option: opt.label },
+      });
+    });
+  } else if (q.multiSelect) {
     // ---- Multi-select dropdown ----
     elems.push(
       buildLabeledRow(labelMd, {
@@ -914,6 +960,12 @@ const AskUserQuestionSchema = Type.Object({
       multiSelect: Type.Boolean({
         description: 'Whether multiple options can be selected (ignored when options is empty)',
       }),
+      selectStyle: Type.Optional(
+        Type.Union([Type.Literal('dropdown'), Type.Literal('checkbox')], {
+          description:
+            'For multi-select questions only: "dropdown" (default, compact multi-select dropdown) or "checkbox" (each option shown as a separate checkbox row, so the user can see all selected options at a glance before submitting). Ignored for single-select and free-text questions.',
+        }),
+      ),
     }),
     {
       description: 'Questions to ask the user (1-6 questions)',

--- a/tests/ask-user-question.test.ts
+++ b/tests/ask-user-question.test.ts
@@ -73,7 +73,7 @@ function createMockCfg() {
  */
 async function seedPendingQuestion(opts?: {
   questionId?: string;
-  questions?: Array<{ question: string; header: string; options: Array<{ label: string; description: string }>; multiSelect: boolean }>;
+  questions?: Array<{ question: string; header: string; options: Array<{ label: string; description: string }>; multiSelect: boolean; selectStyle?: 'dropdown' | 'checkbox' }>;
 }): Promise<string> {
   const cfg = createMockCfg();
   const questions = opts?.questions ?? [
@@ -349,6 +349,101 @@ describe('AskUserQuestion card callback', () => {
         (call: any) => call[0].card?.header?.template === 'green',
       );
       expect(answeredCall).toBeDefined();
+    });
+  });
+
+  describe('multi-select checkbox style', () => {
+    it('renders a checker per option when selectStyle is "checkbox"', async () => {
+      await seedPendingQuestion({
+        questions: [
+          {
+            question: '你喜欢哪些水果?',
+            header: '水果',
+            options: [
+              { label: '苹果', description: 'Apple' },
+              { label: '香蕉', description: 'Banana' },
+              { label: '橙子', description: 'Orange' },
+            ],
+            multiSelect: true,
+            selectStyle: 'checkbox',
+          },
+        ],
+      });
+
+      // The interactive form card is the one passed to createCardEntity.
+      const sentCard = mockCreateCardEntity.mock.calls[0][0].card;
+      const checkers = findDeep(sentCard, (el: any) => el?.tag === 'checker');
+
+      // One checker per option, no multi_select_static dropdown.
+      expect(checkers.length).toBe(3);
+      expect(findDeep(sentCard, (el: any) => el?.tag === 'multi_select_static').length).toBe(0);
+
+      // Each checker carries the per-option field name and a value (for 200340).
+      expect(checkers[0].name).toBe('selection_0_0');
+      expect(checkers[1].name).toBe('selection_0_1');
+      expect(checkers[2].name).toBe('selection_0_2');
+      expect(checkers[0].value).toEqual({ option: '苹果' });
+      expect(checkers[0].text.content).toBe('苹果');
+      expect(checkers[0].checked).toBe(false);
+    });
+
+    it('still renders multi_select_static dropdown by default (back-compat)', async () => {
+      await seedPendingQuestion({
+        questions: [
+          {
+            question: '你喜欢哪些水果?',
+            header: '水果',
+            options: [
+              { label: '苹果', description: '' },
+              { label: '香蕉', description: '' },
+            ],
+            multiSelect: true,
+            // selectStyle omitted → default dropdown
+          },
+        ],
+      });
+
+      const sentCard = mockCreateCardEntity.mock.calls[0][0].card;
+      expect(findDeep(sentCard, (el: any) => el?.tag === 'multi_select_static').length).toBe(1);
+      expect(findDeep(sentCard, (el: any) => el?.tag === 'checker').length).toBe(0);
+    });
+
+    it('parses checked checker fields into the answer (boolean and string true)', async () => {
+      const questionId = await seedPendingQuestion({
+        questions: [
+          {
+            question: '你喜欢哪些水果?',
+            header: '水果',
+            options: [
+              { label: '苹果', description: '' },
+              { label: '香蕉', description: '' },
+              { label: '橙子', description: '' },
+            ],
+            multiSelect: true,
+            selectStyle: 'checkbox',
+          },
+        ],
+      });
+
+      // 苹果 checked (boolean), 香蕉 unchecked (false), 橙子 checked (string 'true').
+      const event = createFormSubmitEvent(questionId, {
+        selection_0_0: true,
+        selection_0_1: false,
+        selection_0_2: 'true',
+      });
+      const result = handleAskUserAction(event, createMockCfg(), TEST_ACCOUNT_ID) as any;
+
+      // Submit succeeds (question is answered, not flagged unanswered).
+      expect(result.toast.type).toBe('success');
+
+      // The processing card should reflect the selected labels, comma-joined.
+      const answerEls = findDeep(result.card.data.body, (el: any) =>
+        el?.tag === 'markdown' && typeof el?.content === 'string' && el.content.includes('⏳'),
+      );
+      expect(answerEls.length).toBe(1);
+      expect(answerEls[0].content).toContain('苹果');
+      expect(answerEls[0].content).toContain('橙子');
+      expect(answerEls[0].content).not.toContain('香蕉');
     });
   });
 


### PR DESCRIPTION
## What

Adds an optional `selectStyle: 'dropdown' | 'checkbox'` field to multi-select questions in the `feishu_ask_user_question` tool. Defaults to `'dropdown'`, so existing behavior is **fully backward compatible**.

<img width="783" height="570" alt="698286ab-e0a9-49ec-9fd9-ae5e3f045331" src="https://github.com/user-attachments/assets/44b24549-d9b5-41b6-80bf-d059c77cd606" />

## Why

Multi-select questions currently render as a `multi_select_static` dropdown. When the dropdown is collapsed, it only shows the first selected option plus a `+N` badge — so the user **cannot review everything they've selected before submitting**. For questions like "pick which groups to summarize", this is confusing.

When `selectStyle: 'checkbox'` is set, each option renders as its own `checker` row, so all selections stay visible at a glance.

| dropdown (default, unchanged) | checkbox (new) |
|---|---|
| collapses to `first +N` | one checkbox row per option, all selections visible |

## Changes

- **schema**: add optional `selectStyle` union (`'dropdown'` \| `'checkbox'`); dropdown remains the default
- **render**: when `multiSelect && selectStyle === 'checkbox'`, emit one `checker` per option (each with a `value` so the card-action callback fires)
- **parse**: add `readFormCheckers` to read each option's boolean field on submit
- **tests**: cover checkbox rendering, dropdown back-compat, and checkbox parsing (boolean + string `true`)

## Backward compatibility

`selectStyle` is fully optional. When omitted (or `'dropdown'`), rendering and parsing are byte-for-byte the existing `multi_select_static` path. Single-select and free-text questions are unaffected.

## Testing

- `pnpm typecheck` — pass
- `pnpm lint` / `pnpm format:check` — pass (target file clean)
- `pnpm test` — all green (added 3 cases for the new style)
