### PR TITLE
fix(outbound): route create path into thread via receive_id_type=thread_id

### DIFF
--- a/src/messaging/outbound/deliver.ts
+++ b/src/messaging/outbound/deliver.ts
@@ -126,8 +126,9 @@ async function sendImMessage(params: {
   msgType: 'post' | 'interactive';
   replyToMessageId?: string;
   replyInThread?: boolean;
+  threadId?: string;
 }): Promise<FeishuSendResult> {
-  const { client, to, content, msgType, replyToMessageId, replyInThread } = params;
+  const { client, to, content, msgType, replyToMessageId, replyInThread, threadId } = params;
 
   // --- Reply path ---
   if (replyToMessageId) {
@@ -142,6 +143,27 @@ async function sendImMessage(params: {
       chatId: response?.data?.chat_id ?? '',
     };
     log.debug(`reply sent: messageId=${result.messageId}`);
+    return result;
+  }
+
+  // --- Create-in-thread path ---
+  // When `threadId` is provided without a reply anchor, route into the topic
+  // via `receive_id_type='thread_id'`. Without this branch, agent follow-up
+  // turns (e.g. spawn-completion notices, multi-message replies) inside a
+  // topic group fall back to chat-level and visually "leak" out of the topic.
+  if (threadId) {
+    log.info(`creating message in thread ${threadId} (msg_type=${msgType})`);
+    const response = await client.im.message.create({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      params: { receive_id_type: 'thread_id' as any },
+      data: { receive_id: threadId, msg_type: msgType, content },
+    });
+
+    const result: FeishuSendResult = {
+      messageId: response?.data?.message_id ?? '',
+      chatId: response?.data?.chat_id ?? '',
+    };
+    log.debug(`thread message created: messageId=${result.messageId}`);
     return result;
   }
 
@@ -284,7 +306,7 @@ export async function sendTextLark(params: SendTextLarkParams): Promise<FeishuSe
   if (card) {
     const version = card.schema === '2.0' ? 'v2' : 'v1';
     log.info(`detected ${version} card JSON in text (target=${to}), routing to sendCardLark`);
-    return sendCardLark({ cfg, to, card, replyToMessageId, replyInThread, accountId });
+    return sendCardLark({ cfg, to, card, replyToMessageId, replyInThread, accountId, threadId });
   }
 
   log.info(`sendTextLark: target=${to}, textLength=${text.length}`);
@@ -292,7 +314,7 @@ export async function sendTextLark(params: SendTextLarkParams): Promise<FeishuSe
   const prepared = await prepareTextForLark(cfg, text, to, accountId);
   const content = buildPostContent(prepared.text);
 
-  const result = await sendImMessage({ client, to, content, msgType: 'post', replyToMessageId, replyInThread });
+  const result = await sendImMessage({ client, to, content, msgType: 'post', replyToMessageId, replyInThread, threadId });
   recordSentinelsForChat(prepared.resolvedAccountId, to, threadId, prepared.sentinels);
   return result;
 }
@@ -325,6 +347,12 @@ export interface SendCardLarkParams {
   replyInThread?: boolean;
   /** Optional account identifier for multi-account setups. */
   accountId?: string;
+  /**
+   * Thread root id. When provided without `replyToMessageId`, the card is
+   * created with `receive_id_type='thread_id'` so it lands inside the topic
+   * instead of bubbling up to the chat root.
+   */
+  threadId?: string;
 }
 
 /**
@@ -363,7 +391,7 @@ export interface SendCardLarkParams {
  * ```
  */
 export async function sendCardLark(params: SendCardLarkParams): Promise<FeishuSendResult> {
-  const { cfg, to, card, replyToMessageId, replyInThread, accountId } = params;
+  const { cfg, to, card, replyToMessageId, replyInThread, accountId, threadId } = params;
 
   const version = card.schema === '2.0' ? 'v2' : 'v1';
   log.info(`sendCardLark: target=${to}, cardVersion=${version}`);
@@ -372,7 +400,7 @@ export async function sendCardLark(params: SendCardLarkParams): Promise<FeishuSe
   const content = JSON.stringify(card);
 
   try {
-    return await sendImMessage({ client, to, content, msgType: 'interactive', replyToMessageId, replyInThread });
+    return await sendImMessage({ client, to, content, msgType: 'interactive', replyToMessageId, replyInThread, threadId });
   } catch (err) {
     const detail = formatLarkError(err);
     log.error(`sendCardLark failed: ${detail}`);

--- a/src/messaging/outbound/send.ts
+++ b/src/messaging/outbound/send.ts
@@ -122,6 +122,11 @@ export interface SendFeishuCardParams {
   accountId?: string;
   /** When true, the reply appears in the thread instead of main chat. */
   replyInThread?: boolean;
+  /**
+   * Thread root id. When provided without `replyToMessageId`, the card is
+   * created with `receive_id_type='thread_id'` so it lands inside the topic.
+   */
+  threadId?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -263,12 +268,23 @@ export async function sendMessageFeishu(params: SendFeishuMessageParams): Promis
   }
 
   // Send as a new message.
-  const target = normalizeFeishuTarget(to);
-  if (!target) {
-    throw new Error(`[feishu-send] Invalid target: "${to}"`);
+  // When `threadId` is provided without `replyToMessageId`, route into the
+  // topic via `receive_id_type='thread_id'` so the message lands inside the
+  // thread instead of bubbling up to the chat root. See deliver.ts for the
+  // same routing on the unified path.
+  let receiveId: string;
+  let receiveIdType: string;
+  if (threadId) {
+    receiveId = threadId;
+    receiveIdType = 'thread_id';
+  } else {
+    const target = normalizeFeishuTarget(to);
+    if (!target) {
+      throw new Error(`[feishu-send] Invalid target: "${to}"`);
+    }
+    receiveId = target;
+    receiveIdType = resolveReceiveIdType(target);
   }
-
-  const receiveIdType = resolveReceiveIdType(target);
 
   const response = await client.im.message.create({
     params: {
@@ -276,7 +292,7 @@ export async function sendMessageFeishu(params: SendFeishuMessageParams): Promis
       receive_id_type: receiveIdType as any,
     },
     data: {
-      receive_id: target,
+      receive_id: receiveId,
       msg_type: 'post',
       content: contentPayload,
     },
@@ -300,7 +316,7 @@ export async function sendMessageFeishu(params: SendFeishuMessageParams): Promis
  * @returns The send result containing the new message ID.
  */
 export async function sendCardFeishu(params: SendFeishuCardParams): Promise<FeishuSendResult> {
-  const { cfg, to, card, replyToMessageId, accountId, replyInThread } = params;
+  const { cfg, to, card, replyToMessageId, accountId, replyInThread, threadId } = params;
 
   const client = LarkClient.fromCfg(cfg, accountId).sdk;
 
@@ -331,12 +347,20 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
     };
   }
 
-  const target = normalizeFeishuTarget(to);
-  if (!target) {
-    throw new Error(`[feishu-send] Invalid target: "${to}"`);
+  // See sendMessageFeishu for the same thread routing rationale.
+  let receiveId: string;
+  let receiveIdType: string;
+  if (threadId) {
+    receiveId = threadId;
+    receiveIdType = 'thread_id';
+  } else {
+    const target = normalizeFeishuTarget(to);
+    if (!target) {
+      throw new Error(`[feishu-send] Invalid target: "${to}"`);
+    }
+    receiveId = target;
+    receiveIdType = resolveReceiveIdType(target);
   }
-
-  const receiveIdType = resolveReceiveIdType(target);
 
   const response = await client.im.message.create({
     params: {
@@ -344,7 +368,7 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
       receive_id_type: receiveIdType as any,
     },
     data: {
-      receive_id: target,
+      receive_id: receiveId,
       msg_type: 'interactive',
       content: contentPayload,
     },


### PR DESCRIPTION
## Problem

When an outbound message in a topic-mode group has \`threadId\` but no \`replyToMessageId\`, the existing create path calls \`im.message.create\` with the chat-level \`receive_id_type\` (e.g. \`chat_id\`) and silently drops \`threadId\` — it's only used for sentinel keying. As a result, the message lands at the chat root instead of inside the topic.

Symptom in the user-facing chat: agents that respond with multiple messages in a topic group (first reply + follow-up status updates) have their first reply correctly threaded (via the \`reply\` path), but every subsequent message "leaks out" of the topic into the parent group chat. This breaks topic-session isolation that \`threadSession: true\` is supposed to enforce.

## Repro

1. Configure account with \`threadSession: true\` and an LLM that produces multi-message responses (e.g. tool use with status updates).
2. Send a message in a topic group.
3. Observe: first agent reply is correctly in the topic (via \`im.message.reply\` + \`reply_in_thread: true\`).
4. Subsequent messages from the same agent turn appear at the chat root, not inside the topic.

## Fix

When \`threadId\` is provided without \`replyToMessageId\`, route via \`receive_id_type='thread_id'\` and pass the thread root id as \`receive_id\`. The Lark SDK already accepts \`thread_id\` as a valid receive type (see \`receive_id_type: "open_id" | "user_id" | "union_id" | "email" | "chat_id" | "thread_id"\` in \`@larksuiteoapi/node-sdk\`).

Behavior is **unchanged** when:
- \`threadId\` is absent (existing chat-level routing)
- \`replyToMessageId\` is present (existing reply path with \`reply_in_thread\`)

## Affected call sites

- \`deliver.ts::sendImMessage\` — unified create path adds thread-routing branch
- \`deliver.ts::sendTextLark\` / \`sendCardLark\` — propagate \`threadId\` to \`sendImMessage\` and to detected-card-routing fallback
- \`send.ts::sendMessageFeishu\` / \`sendCardFeishu\` — legacy create paths get the same fix
- \`SendCardLarkParams\` / \`SendFeishuCardParams\` — \`threadId?\` field added

## Evidence

- \`pnpm build\` — clean build (\`dist/index.mjs 333.45 kB\`)
- \`pnpm test\` — **393 tests pass** (49 files), no regressions
- Patch deployed to dev environment downstream: agent follow-up turns in topic groups now stay inside the topic instead of leaking to chat root.

## Test plan

- [x] \`pnpm build\` clean
- [x] \`pnpm test\` 393/393 pass
- [x] Manual verification in dev: topic-group multi-message agent turn stays in topic
- [ ] (reviewer) Verify behavior unchanged for non-thread chats

🤖 AI-assisted PR — diagnosis + patch produced with Claude Code; verified against downstream production journal.