### PR TITLE
ci: fix prettier violation in abort-detect.ts

### DIFF
--- a/src/channel/abort-detect.ts
+++ b/src/channel/abort-detect.ts
@@ -183,7 +183,10 @@ const STOP_INTENT_PHRASES = [
 export function isConversationStopIntent(text: string): boolean {
   if (!text) return false;
   // Drop bot mention placeholders so "@Bot 中断对话" → "中断对话".
-  const normalized = text.replace(/@_user_\d+/g, '').trim().toLowerCase();
+  const normalized = text
+    .replace(/@_user_\d+/g, '')
+    .trim()
+    .toLowerCase();
   if (!normalized) return false;
   if (isLikelyAbortText(normalized)) return true;
   return STOP_INTENT_PHRASES.some((p) => normalized.includes(p));


### PR DESCRIPTION
## Summary

The `prettier --check` step in the CI lint job fails on `src/channel/abort-detect.ts`, which blocks the format check on every open PR (including #576). This reformats the offending method chain so the file is Prettier-compliant. No behavior change.

## Changes

- Reformat a method chain in `src/channel/abort-detect.ts` (`isConversationStopIntent`) to satisfy Prettier — line wrapping only, no logic change.

## Test Plan

- [x] `prettier --check src/**/*.ts` (the exact CI command, reproduced locally) passes after the change
- [x] verified the diff is whitespace-only (method-chain line wrap) — no semantic change
- [ ] unit suite not run: change is formatting-only with no logic change

## Related Issues

N/A — unblocks the CI format check on open PRs such as #576
