### PR TITLE
fix: redirect entry points from missing dist/ to root files

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
+        "types": "./index.d.ts",
+        "default": "./index.js"
       }
     }
   },
-  "main": "./dist/index.mjs",
-  "types": "./dist/index.d.mts",
+  "main": "./index.js",
+  "types": "./index.d.ts",
   "bin": {
     "openclaw-lark": "bin/openclaw-lark.js"
   },


### PR DESCRIPTION
## Problem

The npm package `@larksuite/openclaw-lark@2026.6.10` is missing the `dist/` directory. The `package.json` entry points (`main`, `types`, `exports`) point to `./dist/index.mjs` and `./dist/index.d.mts`, which do not exist in the published tarball.

This causes `Plugin main entry not found` errors in OpenClaw when loading the plugin.

Related issue: #567

## Root Cause

The `files` field in `package.json` includes `dist/`, but `dist/` is never built (or not included) when publishing to npm. The compiled output exists at the root level as `index.js` and `index.d.ts`, but `package.json` does not reference them.

## Fix

Redirect `main`, `types`, and `exports.import` from `./dist/` paths to the root-level files that actually exist in the published package:

| Field | Before | After |
|-------|--------|-------|
| `main` | `./dist/index.mjs` | `./index.js` |
| `types` | `./dist/index.d.mts` | `./index.d.ts` |
| `exports.import.types` | `./dist/index.d.mts` | `./index.d.ts` |
| `exports.import.default` | `./dist/index.mjs` | `./index.js` |

## Verification

- `npm pack @larksuite/openclaw-lark@2026.6.10` confirms `index.js` and `index.d.ts` exist at package root
- After this change, `openclaw plugins doctor` reports no entry point errors

## Additional Context

Also related to #575 (CI should validate entry points). This fix ensures the package works even when `dist/` is not built before publishing.