### PR TITLE
feat(feishu): support keyless private_key_jwt authentication

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,11 +41,18 @@
     "format:check": "prettier --check src/**/*.ts"
   },
   "dependencies": {
-    "@larksuiteoapi/node-sdk": "^1.64.0",
+    "@larksuiteoapi/node-sdk": "^1.71.1",
     "@sinclair/typebox": "0.34.49",
     "image-size": "^2.0.2",
     "undici-types": "^8.1.0",
     "zod": "^4.3.6"
+  },
+  "optionalDependencies": {
+    "@larksuite/lark-keyless-signer-darwin-arm64": "^1.0.0",
+    "@larksuite/lark-keyless-signer-darwin-x64": "^1.0.0",
+    "@larksuite/lark-keyless-signer-linux-arm64": "^1.0.0",
+    "@larksuite/lark-keyless-signer-linux-x64": "^1.0.0",
+    "@larksuite/lark-keyless-signer-win32-x64": "^1.0.0"
   },
   "peerDependencies": {
     "openclaw": ">=2026.5.4"
@@ -93,7 +100,14 @@
     "install": {
       "npmSpec": "@larksuite/openclaw-lark",
       "localPath": "extensions/feishu",
-      "defaultChoice": "npm"
+      "defaultChoice": "npm",
+      "requiredPlatformPackages": [
+        "@larksuite/lark-keyless-signer-darwin-arm64",
+        "@larksuite/lark-keyless-signer-darwin-x64",
+        "@larksuite/lark-keyless-signer-linux-arm64",
+        "@larksuite/lark-keyless-signer-linux-x64",
+        "@larksuite/lark-keyless-signer-win32-x64"
+      ]
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@larksuiteoapi/node-sdk':
-        specifier: ^1.64.0
-        version: 1.64.0
+        specifier: ^1.71.1
+        version: 1.71.1
       '@sinclair/typebox':
         specifier: 0.34.49
         version: 0.34.49
@@ -801,8 +801,8 @@ packages:
     peerDependencies:
       apache-arrow: '>=15.0.0 <=18.1.0'
 
-  '@larksuiteoapi/node-sdk@1.64.0':
-    resolution: {integrity: sha512-r3ae0lAi3ipH1g1geUo1fmb7DK5e0WAKrrrDi25yJCKBvxtiKLsR3ldss3OZnqyfP7yGHkjeN0BYuzyaWgxFoA==}
+  '@larksuiteoapi/node-sdk@1.71.1':
+    resolution: {integrity: sha512-Z4cZmgWvwiE7tCHqGm+t7DKvbpNRRTH2HqVwcYiOMAwbjIytXSoQqWytsOVu3p+d0fIvrtyIPZok5HOV/VNxxw==}
 
   '@line/bot-sdk@11.0.0':
     resolution: {integrity: sha512-3NZJjeFm2BikwVRgA8osIVbgKhuL0CzphQOdrB8okXIC40qMRE4RRfHFN3G8/qTb/34RtB95mD4J/KW5MD+b8g==}
@@ -2059,6 +2059,9 @@ packages:
   axios@1.13.6:
     resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
 
+  axios@1.18.1:
+    resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -2667,6 +2670,15 @@ packages:
 
   follow-redirects@1.15.11:
     resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -5709,9 +5721,9 @@ snapshots:
       '@lancedb/lancedb-win32-arm64-msvc': 0.27.2
       '@lancedb/lancedb-win32-x64-msvc': 0.27.2
 
-  '@larksuiteoapi/node-sdk@1.64.0':
+  '@larksuiteoapi/node-sdk@1.71.1':
     dependencies:
-      axios: 1.13.6
+      axios: 1.18.1
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -5721,6 +5733,7 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - debug
+      - supports-color
       - utf-8-validate
 
   '@line/bot-sdk@11.0.0':
@@ -7062,7 +7075,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   agent-base@7.1.4: {}
 
@@ -7152,6 +7164,16 @@ snapshots:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
+
+  axios@1.18.1:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   balanced-match@1.0.2: {}
 
@@ -7797,6 +7819,8 @@ snapshots:
 
   follow-redirects@1.15.11: {}
 
+  follow-redirects@1.16.0: {}
+
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -8076,7 +8100,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -8614,7 +8637,7 @@ snapshots:
       '@grammyjs/transformer-throttler': 1.2.1(grammy@1.42.0)
       '@homebridge/ciao': 1.3.6
       '@lancedb/lancedb': 0.27.2(apache-arrow@18.1.0)
-      '@larksuiteoapi/node-sdk': 1.64.0
+      '@larksuiteoapi/node-sdk': 1.71.1
       '@line/bot-sdk': 11.0.0
       '@lydell/node-pty': 1.2.0-beta.10
       '@mariozechner/pi-agent-core': 0.65.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)

--- a/skills/feishu-channel-rules/SKILL.md
+++ b/skills/feishu-channel-rules/SKILL.md
@@ -7,6 +7,23 @@ alwaysActive: true
 
 # Lark Output Rules
 
+## lark-cli Authentication Routing
+
+- If the user explicitly mentions `lark-cli` or `CLI` while asking to log in,
+  authorize, re-authorize, or grant scopes, this is a CLI authentication
+  request. Follow the installed `lark-shared` authentication workflow and use
+  `exec` to run the CLI flow.
+- Never replace an explicit CLI authentication request with
+  `feishu_oauth` or `feishu_oauth_batch_auth`. Those tools manage the
+  openclaw-lark plugin's own user token, not lark-cli's token store.
+- For recommended CLI scopes, run
+  `lark-cli auth login --recommend --no-wait --json`. For all CLI scopes, run
+  `lark-cli auth login --domain all --no-wait --json`.
+- Relay the exact verification URL and QR code returned by lark-cli. After the
+  user confirms authorization, resume with
+  `lark-cli auth login --device-code <device_code> --json`, then retry the
+  original CLI command.
+
 ## Writing Style
 
 - Short, conversational, low ceremony — talk like a coworker, not a manual

--- a/skills/feishu-troubleshoot/SKILL.md
+++ b/skills/feishu-troubleshoot/SKILL.md
@@ -52,7 +52,7 @@ description: |
   - 插件版本
 
 - **账号信息**：
-  - 凭证完整性（appId, appSecret 掩码）
+  - 凭证完整性（app_secret 显示 appId 与掩码；private_key_jwt 显示 appId 与 keyRef）
   - 账户启用状态
   - API 连通性测试
   - Bot 信息（名称和 openId）

--- a/src/channel/onboarding.ts
+++ b/src/channel/onboarding.ts
@@ -14,7 +14,7 @@ import type { ChannelSetupDmPolicy, ChannelSetupWizardAdapter } from 'openclaw/p
 import { DEFAULT_ACCOUNT_ID } from 'openclaw/plugin-sdk/account-id';
 import { formatDocsLink } from 'openclaw/plugin-sdk/setup';
 import type { FeishuConfig } from '../core/types';
-import { getLarkCredentials } from '../core/accounts';
+import { getLarkAccount } from '../core/accounts';
 import { probeFeishu } from './probe';
 import {
   parseAllowFromInput,
@@ -197,7 +197,7 @@ export const feishuOnboardingAdapter: ChannelSetupWizardAdapter = {
   // -----------------------------------------------------------------------
   getStatus: async ({ cfg }) => {
     const feishuCfg = cfg.channels?.feishu as FeishuConfig | undefined;
-    const configured = Boolean(getLarkCredentials(feishuCfg));
+    const configured = getLarkAccount(cfg).configured;
 
     // Attempt a live probe when credentials are present.
     let probeResult = null;
@@ -232,17 +232,20 @@ export const feishuOnboardingAdapter: ChannelSetupWizardAdapter = {
   // -----------------------------------------------------------------------
   configure: async ({ cfg, prompter }) => {
     const feishuCfg = cfg.channels?.feishu as FeishuConfig | undefined;
-    const resolved = getLarkCredentials(feishuCfg);
+    const account = getLarkAccount(cfg);
 
     let next = cfg;
 
     // Show credential help if nothing is configured yet.
-    if (!resolved) {
+    if (!account.configured) {
       await noteFeishuCredentialHelp(prompter);
     }
 
     // --- Credential acquisition ---
-    const creds = await acquireCredentials({ cfg: next, prompter, feishuCfg });
+    const creds =
+      account.configured && account.authMethod === 'private_key_jwt'
+        ? { cfg: next, appId: null, appSecret: null }
+        : await acquireCredentials({ cfg: next, prompter, feishuCfg });
     next = creds.cfg;
 
     // --- Persist and test credentials ---

--- a/src/channel/probe.ts
+++ b/src/channel/probe.ts
@@ -14,10 +14,11 @@ import type { FeishuProbeResult } from './types';
  * checks to verify credentials before committing them to config.
  */
 export async function probeFeishu(credentials?: LarkClientCredentials): Promise<FeishuProbeResult> {
-  if (!credentials?.appId || !credentials?.appSecret) {
+  const keyless = credentials?.authMethod === 'private_key_jwt' && Boolean(credentials.keyRef);
+  if (!credentials?.appId || (!credentials.appSecret && !keyless)) {
     return {
       ok: false,
-      error: 'missing credentials (appId, appSecret)',
+      error: 'missing credentials (appId and authentication method)',
     };
   }
 

--- a/src/commands/diagnose.ts
+++ b/src/commands/diagnose.ts
@@ -184,8 +184,10 @@ async function diagnoseAccount(account: LarkAccount): Promise<AccountDiagResult>
     name: '凭证完整性',
     status: account.configured ? 'pass' : 'fail',
     message: account.configured
-      ? `appId: ${account.appId}, appSecret: ${maskSecret(account.appSecret)}`
-      : '缺少 appId 或 appSecret',
+      ? account.authMethod === 'private_key_jwt'
+        ? `appId: ${account.appId}, authMethod: private_key_jwt, keyRef: ${account.keyRef}`
+        : `appId: ${account.appId}, appSecret: ${maskSecret(account.appSecret)}`
+      : '缺少完整的 app_secret 或 private_key_jwt 凭证',
   });
 
   // A2: Enabled
@@ -195,7 +197,7 @@ async function diagnoseAccount(account: LarkAccount): Promise<AccountDiagResult>
     message: account.enabled ? '已启用' : '已禁用',
   });
 
-  if (!account.configured || !account.appId || !account.appSecret) {
+  if (!account.configured || !account.appId) {
     checks.push({
       name: 'API 连通性',
       status: 'skip',
@@ -210,6 +212,8 @@ async function diagnoseAccount(account: LarkAccount): Promise<AccountDiagResult>
       accountId: account.accountId,
       appId: account.appId,
       appSecret: account.appSecret,
+      authMethod: account.authMethod,
+      keyRef: account.keyRef,
       brand: account.brand,
     });
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -320,7 +320,11 @@ async function checkBasicInfo(
     lines.push(t.legacyDisabled);
   }
 
-  lines.push(`${t.credentials}: appId: ${account.appId}, appSecret: ${maskSecret(account.appSecret, locale)}`);
+  lines.push(
+    account.authMethod === 'private_key_jwt'
+      ? `${t.credentials}: appId: ${account.appId}, authMethod: private_key_jwt, keyRef: ${account.keyRef}`
+      : `${t.credentials}: appId: ${account.appId}, appSecret: ${maskSecret(account.appSecret, locale)}`,
+  );
   lines.push(t.accountEnabled);
 
   // API 连通性
@@ -329,6 +333,8 @@ async function checkBasicInfo(
       accountId: account.accountId,
       appId: account.appId,
       appSecret: account.appSecret,
+      authMethod: account.authMethod,
+      keyRef: account.keyRef,
       brand: account.brand,
     });
 

--- a/src/core/accounts.ts
+++ b/src/core/accounts.ts
@@ -73,6 +73,12 @@ function toBrand(domain: string | undefined): LarkBrand {
   return (domain as LarkBrand) ?? 'feishu';
 }
 
+/** Whether a config fragment has a complete secret or keyless credential set. */
+function hasConfiguredCredentials(config: Partial<FeishuConfig>): boolean {
+  if (!config.appId) return false;
+  return Boolean(config.appSecret || (config.authMethod === 'private_key_jwt' && config.keyRef));
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -93,13 +99,13 @@ export function getLarkAccountIds(cfg: ClawdbotConfig): string[] {
 
   const accountIds = Object.keys(accountMap);
 
-  // 当 accounts 存在时，如果顶层也配置了 appId/appSecret（即默认机器人），
-  // 将 DEFAULT_ACCOUNT_ID 加入列表，确保顶层机器人不会被忽略。
+  // 当 accounts 存在时，如果顶层也配置了完整的 secret 或 keyless 凭证，
+  // 将 DEFAULT_ACCOUNT_ID 加入列表，确保顶层默认机器人不会被忽略。
   // 但如果 accountMap 已经包含 default，则不重复添加。
   const hasDefault = accountIds.some((id) => id.trim().toLowerCase() === DEFAULT_ACCOUNT_ID);
   if (!hasDefault) {
     const base = baseConfig(section);
-    if (base.appId && base.appSecret) {
+    if (hasConfiguredCredentials(base)) {
       return [DEFAULT_ACCOUNT_ID, ...accountIds];
     }
   }
@@ -146,21 +152,47 @@ export function getLarkAccount(cfg: ClawdbotConfig, accountId?: string | null): 
 
   const appId = merged.appId;
   const appSecret = merged.appSecret;
-  const configured = !!(appId && appSecret);
+  const authMethod = merged.authMethod;
+  const keyRef = merged.keyRef;
+  // An account is configured when it has an appId plus credentials for its auth
+  // method: an appSecret (default app_secret), or a keyRef when authMethod is
+  // private_key_jwt (keyless — the secret lives in the OS key facility).
+  const keylessConfigured = !!(appId && authMethod === 'private_key_jwt' && keyRef);
+  const secretConfigured = !!(appId && appSecret);
+  const configured = secretConfigured || keylessConfigured;
 
   // Respect explicit `enabled` when set; otherwise derive from `configured`.
   const enabled = !!(merged.enabled ?? configured);
 
   const brand: LarkBrand = toBrand(merged.domain);
 
-  if (configured) {
+  // Prefer the app-secret variant when both are present so existing secret-path
+  // behavior is unchanged; only fall to keyless when there is no appSecret.
+  if (secretConfigured) {
     return {
       accountId: requestedId,
       enabled,
       configured: true,
+      authMethod: authMethod === 'private_key_jwt' ? undefined : authMethod,
       name: merged.name ?? undefined,
       appId: appId!,
       appSecret: appSecret!,
+      encryptKey: merged.encryptKey ?? undefined,
+      verificationToken: merged.verificationToken ?? undefined,
+      brand,
+      config: merged,
+    };
+  }
+
+  if (keylessConfigured) {
+    return {
+      accountId: requestedId,
+      enabled,
+      configured: true,
+      authMethod: 'private_key_jwt',
+      name: merged.name ?? undefined,
+      appId: appId!,
+      keyRef: keyRef!,
       encryptKey: merged.encryptKey ?? undefined,
       verificationToken: merged.verificationToken ?? undefined,
       brand,
@@ -172,9 +204,11 @@ export function getLarkAccount(cfg: ClawdbotConfig, accountId?: string | null): 
     accountId: requestedId,
     enabled,
     configured: false,
+    authMethod,
     name: merged.name ?? undefined,
     appId: appId ?? undefined,
     appSecret: appSecret ?? undefined,
+    keyRef: keyRef ?? undefined,
     encryptKey: merged.encryptKey ?? undefined,
     verificationToken: merged.verificationToken ?? undefined,
     brand,

--- a/src/core/client-assertion-provider.ts
+++ b/src/core/client-assertion-provider.ts
@@ -1,0 +1,50 @@
+// Maps a Feishu account's keyless config (authMethod / keyRef) to a client
+// assertion provider backed by the lark-keyless-signer (core/keyless-signer).
+//
+// The node-sdk calls retrieveToken(aud) for every token exchange. The provider
+// delegates to the platform signer so no app secret or private-key material
+// enters this process.
+import { KeylessSigner, type KeylessSignerOptions } from './keyless-signer';
+
+export type AuthMethod = 'app_secret' | 'private_key_jwt';
+
+/** Minimal account shape this module reads; a subset of FeishuAccountConfig. */
+export interface AccountAuthConfig {
+  appId?: string;
+  authMethod?: AuthMethod;
+  keyRef?: string;
+}
+
+/** Effective auth method for an account; defaults to "app_secret". */
+export function resolveAuthMethod(account: AccountAuthConfig): AuthMethod {
+  return account.authMethod === 'private_key_jwt' ? 'private_key_jwt' : 'app_secret';
+}
+
+/** Whether the account is configured for keyless (private_key_jwt) auth. */
+export function isKeyless(account: AccountAuthConfig): boolean {
+  return resolveAuthMethod(account) === 'private_key_jwt';
+}
+
+/** Produces short-lived client assertions for the token endpoint. */
+export interface ClientAssertionProvider {
+  /** Mint a client_assertion for the SDK's requested token endpoint audience. */
+  retrieveToken(aud: string): Promise<{ value: string }>;
+}
+
+/**
+ * Build a client assertion provider for a configured keyless account, or return
+ * null when the account is not keyless or has no appId. Construction never
+ * resolves or starts the signer; provider verification and subprocess errors
+ * surface when the SDK requests an assertion. The platform optional dependency
+ * is resolved and rechecked for every call, and never falls back to app_secret.
+ */
+export function createClientAssertionProvider(
+  account: AccountAuthConfig,
+  opts: Pick<KeylessSignerOptions, 'binaryPath'> = {},
+): ClientAssertionProvider | null {
+  if (!isKeyless(account) || !account.appId) return null;
+  const signer = new KeylessSigner({ binaryPath: opts.binaryPath, keyRef: account.keyRef });
+  return {
+    retrieveToken: async (aud) => ({ value: await signer.signAssertion(account.appId!, aud) }),
+  };
+}

--- a/src/core/config-schema.ts
+++ b/src/core/config-schema.ts
@@ -160,6 +160,15 @@ export const FeishuGroupSchema = z.object({
 export const FeishuAccountConfigSchema = z.object({
   appId: z.string().optional(),
   appSecret: z.string().optional(),
+  // Authentication method for this account. "app_secret" (default) uses the
+  // long-lived app secret; "private_key_jwt" signs a short-lived client
+  // assertion with a non-exportable device key (keyless); see
+  // core/keyless-signer and core/client-assertion-provider.
+  authMethod: z.enum(['app_secret', 'private_key_jwt']).optional(),
+  // Device-key label the keyless signer uses to locate the key in the OS key
+  // facility (Keychain / TPM). Only meaningful when authMethod is
+  // "private_key_jwt".
+  keyRef: z.string().optional(),
   encryptKey: z.string().optional(),
   verificationToken: z.string().optional(),
   name: z.string().optional(),

--- a/src/core/device-flow.ts
+++ b/src/core/device-flow.ts
@@ -14,6 +14,7 @@
  */
 
 import type { LarkBrand } from './types';
+import type { ClientAssertionProvider } from './client-assertion-provider';
 import { larkLogger } from './lark-logger';
 
 const log = larkLogger('core/device-flow');
@@ -45,6 +46,26 @@ export type DeviceFlowResult =
   | { ok: false; error: DeviceFlowError; message: string };
 
 export type DeviceFlowError = 'authorization_pending' | 'slow_down' | 'access_denied' | 'expired_token';
+
+interface SecretClientAuthentication {
+  appId: string;
+  appSecret: string;
+  clientAssertionProvider?: never;
+}
+
+interface KeylessClientAuthentication {
+  appId: string;
+  appSecret?: never;
+  clientAssertionProvider: ClientAssertionProvider;
+}
+
+export type DeviceClientAuthentication = SecretClientAuthentication | KeylessClientAuthentication;
+
+const CLIENT_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
+
+function usesAppSecret(params: DeviceClientAuthentication): params is SecretClientAuthentication {
+  return typeof params.appSecret === 'string' && params.appSecret.length > 0;
+}
 
 // ---------------------------------------------------------------------------
 // Endpoint resolution
@@ -88,6 +109,14 @@ export function resolveOAuthEndpoints(brand: LarkBrand): {
   };
 }
 
+/**
+ * IAM client assertions use the bare Open API host as `aud`. This matches the
+ * deployed lark-cli/App Authentication JWT contract for TAT and OAuth flows.
+ */
+export function resolveClientAssertionAudience(brand: LarkBrand): string {
+  return new URL(resolveOAuthEndpoints(brand).token).host;
+}
+
 // ---------------------------------------------------------------------------
 // Step 1 – Device Authorization Request
 // ---------------------------------------------------------------------------
@@ -95,18 +124,20 @@ export function resolveOAuthEndpoints(brand: LarkBrand): {
 /**
  * Request a device authorisation code from the Feishu OAuth server.
  *
- * Uses Confidential Client authentication (HTTP Basic with appId:appSecret).
+ * Uses confidential-client authentication: HTTP Basic for app-secret accounts,
+ * or RFC 7523 private_key_jwt for keyless accounts.
  * The `offline_access` scope is automatically appended so that the token
  * response includes a refresh_token.
  */
-export async function requestDeviceAuthorization(params: {
-  appId: string;
-  appSecret: string;
-  brand: LarkBrand;
-  scope?: string;
-}): Promise<DeviceAuthResponse> {
-  const { appId, appSecret, brand } = params;
+export async function requestDeviceAuthorization(
+  params: DeviceClientAuthentication & {
+    brand: LarkBrand;
+    scope?: string;
+  },
+): Promise<DeviceAuthResponse> {
+  const { appId, brand } = params;
   const endpoints = resolveOAuthEndpoints(brand);
+  const assertionAudience = resolveClientAssertionAudience(brand);
 
   // Ensure offline_access is always requested.
   let scope = params.scope ?? '';
@@ -114,11 +145,19 @@ export async function requestDeviceAuthorization(params: {
     scope = scope ? `${scope} offline_access` : 'offline_access';
   }
 
-  const basicAuth = Buffer.from(`${appId}:${appSecret}`).toString('base64');
-
   const body = new URLSearchParams();
   body.set('client_id', appId);
   body.set('scope', scope);
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+  };
+  if (usesAppSecret(params)) {
+    headers.Authorization = `Basic ${Buffer.from(`${appId}:${params.appSecret}`).toString('base64')}`;
+  } else {
+    const assertion = await params.clientAssertionProvider.retrieveToken(assertionAudience);
+    body.set('client_assertion_type', CLIENT_ASSERTION_TYPE);
+    body.set('client_assertion', assertion.value);
+  }
 
   log.info(
     `requesting device authorization (scope="${scope}") url=${endpoints.deviceAuthorization} token_url=${endpoints.token}`,
@@ -126,21 +165,21 @@ export async function requestDeviceAuthorization(params: {
 
   const resp = await feishuFetch(endpoints.deviceAuthorization, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-      Authorization: `Basic ${basicAuth}`,
-    },
+    headers,
     body: body.toString(),
   });
 
   const text = await resp.text();
-  log.info(`response status=${resp.status} body=${text.slice(0, 500)}`);
+  // A successful RFC 8628 response contains device_code and user_code. Never
+  // write the raw body to logs; status and byte length are sufficient for
+  // transport diagnostics without leaking a still-live authorization grant.
+  log.info(`response status=${resp.status} bytes=${Buffer.byteLength(text, 'utf8')}`);
 
   let data: Record<string, unknown>;
   try {
     data = JSON.parse(text) as Record<string, unknown>;
   } catch {
-    throw new Error(`Device authorization failed: HTTP ${resp.status} – ${text.slice(0, 200)}`);
+    throw new Error(`Device authorization failed: HTTP ${resp.status} – response was not valid JSON`);
   }
 
   if (!resp.ok || data.error) {
@@ -189,21 +228,22 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
  *
  * Pass an `AbortSignal` to cancel polling from the outside.
  */
-export async function pollDeviceToken(params: {
-  appId: string;
-  appSecret: string;
-  brand: LarkBrand;
-  deviceCode: string;
-  interval: number;
-  expiresIn: number;
-  signal?: AbortSignal;
-}): Promise<DeviceFlowResult> {
+export async function pollDeviceToken(
+  params: DeviceClientAuthentication & {
+    brand: LarkBrand;
+    deviceCode: string;
+    interval: number;
+    expiresIn: number;
+    signal?: AbortSignal;
+  },
+): Promise<DeviceFlowResult> {
   const MAX_POLL_INTERVAL = 60; // slow_down 最大间隔 60 秒
   const MAX_POLL_ATTEMPTS = 200; // 安全上限（远超设备码有效期）
 
-  const { appId, appSecret, brand, deviceCode, expiresIn, signal } = params;
+  const { appId, brand, deviceCode, expiresIn, signal } = params;
   let interval = params.interval;
   const endpoints = resolveOAuthEndpoints(brand);
+  const assertionAudience = resolveClientAssertionAudience(brand);
   const deadline = Date.now() + expiresIn * 1000;
   let attempts = 0;
 
@@ -217,15 +257,22 @@ export async function pollDeviceToken(params: {
 
     let data: Record<string, unknown>;
     try {
+      const body = new URLSearchParams({
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        device_code: deviceCode,
+        client_id: appId,
+      });
+      if (usesAppSecret(params)) {
+        body.set('client_secret', params.appSecret);
+      } else {
+        const assertion = await params.clientAssertionProvider.retrieveToken(assertionAudience);
+        body.set('client_assertion_type', CLIENT_ASSERTION_TYPE);
+        body.set('client_assertion', assertion.value);
+      }
       const resp = await feishuFetch(endpoints.token, {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: new URLSearchParams({
-          grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
-          device_code: deviceCode,
-          client_id: appId,
-          client_secret: appSecret,
-        }).toString(),
+        body: body.toString(),
       });
       data = (await resp.json()) as Record<string, unknown>;
     } catch (err) {

--- a/src/core/keyless-signer.ts
+++ b/src/core/keyless-signer.ts
@@ -1,0 +1,424 @@
+// Keyless (private_key_jwt) signing for the Feishu plugin.
+//
+// The device private key is non-exportable and lives in the OS key facility
+// (macOS Keychain / Linux+Windows TPM). It never enters this Node process. All
+// signing is delegated to the `lark-keyless-signer` binary, invoked as a
+// one-shot subprocess over stdin/stdout JSON. This module is a thin wrapper
+// around that protocol — there is deliberately no private-key material, PEM, or
+// in-process crypto here.
+//
+// Protocol (IAM lark-keyless-signer): request carries `keyRef`; every response
+// is an envelope `{ ok, error?: { type, message } }`.
+//   pubkey           { keyRef }                 -> { ok, alg, jwk, spki }
+//   sign-attestation { keyRef, nonce }          -> { ok, attestation }
+//   sign-assertion   { keyRef, clientId, aud }  -> { ok, client_assertion_type, client_assertion }
+import { spawn } from 'node:child_process';
+import { lstatSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+/**
+ * Default device-key reference for openclaw-lark. onboard (attestation) and
+ * runtime (assertion) must use the same keyRef so both bind to one device key.
+ */
+export const DEFAULT_KEY_REF = 'openclaw-lark';
+
+/** Signer binary basename inside each per-platform package. */
+const BINARY_BASENAME = 'lark-keyless-signer';
+
+/** Platform packages are fixed code constants, never app config or environment input. */
+const SIGNER_PACKAGES: Readonly<Record<string, string>> = {
+  'darwin-arm64': '@larksuite/lark-keyless-signer-darwin-arm64',
+  'darwin-x64': '@larksuite/lark-keyless-signer-darwin-x64',
+  'linux-arm64': '@larksuite/lark-keyless-signer-linux-arm64',
+  'linux-x64': '@larksuite/lark-keyless-signer-linux-x64',
+  'win32-x64': '@larksuite/lark-keyless-signer-win32-x64',
+};
+
+const requireFromPlugin = createRequire(import.meta.url);
+
+interface SignerFileIdentity {
+  dev: number;
+  ino: number;
+  mode: number;
+  size: number;
+  mtimeMs: number;
+  ctimeMs: number;
+}
+
+export interface ResolvedKeylessSigner {
+  binaryPath: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  platform: NodeJS.Platform;
+  identity: SignerFileIdentity;
+}
+
+export class KeylessSignerError extends Error {
+  /** Error type from the signer envelope (e.g. invalid_request), if present. */
+  readonly type?: string;
+
+  constructor(message: string, type?: string) {
+    super(message);
+    this.name = 'KeylessSignerError';
+    this.type = type;
+  }
+}
+
+/** Windows packages ship an .exe; POSIX packages use the bare basename. */
+export function keylessSignerBinaryName(platform: NodeJS.Platform = process.platform): string {
+  return platform === 'win32' ? `${BINARY_BASENAME}.exe` : BINARY_BASENAME;
+}
+
+/** Return the fixed optional package for a supported platform/architecture pair. */
+export function keylessSignerPackageName(
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+): string | undefined {
+  return SIGNER_PACKAGES[`${platform}-${arch}`];
+}
+
+function minimalSignerEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    // The signer must see the receiving user's key store, never a build-time or
+    // plugin-owned HOME. Use the live process HOME with the OS home as fallback.
+    HOME: process.env.HOME?.trim() || homedir(),
+  };
+  const allowed = [
+    'LANG',
+    'LC_ALL',
+    'LC_CTYPE',
+    'TMPDIR',
+    'TMP',
+    'TEMP',
+    'SystemRoot',
+    'WINDIR',
+    'USERPROFILE',
+    'LOCALAPPDATA',
+    'APPDATA',
+  ];
+  for (const name of allowed) {
+    if (process.env[name] !== undefined) env[name] = process.env[name];
+  }
+  return env;
+}
+
+function inspectSignerBinary(binaryPath: string, platform: NodeJS.Platform): SignerFileIdentity {
+  let info;
+  try {
+    info = lstatSync(binaryPath);
+  } catch {
+    throw new KeylessSignerError(
+      `keyless signer binary is missing from its platform package: ${binaryPath}`,
+      'signer_unavailable',
+    );
+  }
+  if (!info.isFile()) {
+    throw new KeylessSignerError('keyless signer binary must be a regular file', 'unsafe_signer');
+  }
+  if (platform !== 'win32' && (info.mode & 0o111) === 0) {
+    throw new KeylessSignerError('keyless signer binary is not executable', 'unsafe_signer');
+  }
+  return {
+    dev: info.dev,
+    ino: info.ino,
+    mode: info.mode,
+    size: info.size,
+    mtimeMs: info.mtimeMs,
+    ctimeMs: info.ctimeMs,
+  };
+}
+
+function resolveInjectedSigner(binaryPath: string): ResolvedKeylessSigner {
+  const platform = process.platform;
+  return {
+    binaryPath,
+    cwd: dirname(binaryPath),
+    env: minimalSignerEnv(),
+    platform,
+    identity: inspectSignerBinary(binaryPath, platform),
+  };
+}
+
+/** Resolve and inspect the current host's signer optional dependency. */
+export function resolvePlatformKeylessSigner(
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+): ResolvedKeylessSigner {
+  const packageName = keylessSignerPackageName(platform, arch);
+  if (!packageName) {
+    throw new KeylessSignerError(`keyless signer does not support ${platform}-${arch}`, 'unsupported_platform');
+  }
+
+  let packageJsonPath: string;
+  try {
+    packageJsonPath = requireFromPlugin.resolve(`${packageName}/package.json`);
+  } catch {
+    throw new KeylessSignerError(
+      `keyless signer optional dependency ${packageName} is unavailable; reinstall ` +
+        '@larksuite/openclaw-lark from the configured registry',
+      'signer_unavailable',
+    );
+  }
+
+  const packageRoot = dirname(packageJsonPath);
+  const binaryPath = join(packageRoot, 'bin', keylessSignerBinaryName(platform));
+  return {
+    binaryPath,
+    cwd: packageRoot,
+    env: minimalSignerEnv(),
+    platform,
+    identity: inspectSignerBinary(binaryPath, platform),
+  };
+}
+
+/**
+ * Resolve the signer path for diagnostics. `explicit` is a unit-test seam;
+ * normal runtime calls always resolve the fixed optional dependency.
+ */
+export function resolveKeylessSignerPath(explicit?: string): string | undefined {
+  try {
+    return (explicit ? resolveInjectedSigner(explicit) : resolvePlatformKeylessSigner()).binaryPath;
+  } catch {
+    return undefined;
+  }
+}
+
+function assertSignerBinaryUnchanged(resolved: ResolvedKeylessSigner): void {
+  const current = inspectSignerBinary(resolved.binaryPath, resolved.platform);
+  const expected = resolved.identity;
+  if (
+    current.dev !== expected.dev ||
+    current.ino !== expected.ino ||
+    current.mode !== expected.mode ||
+    current.size !== expected.size ||
+    current.mtimeMs !== expected.mtimeMs ||
+    current.ctimeMs !== expected.ctimeMs
+  ) {
+    throw new KeylessSignerError('keyless signer binary changed between resolution and execution', 'signer_raced');
+  }
+}
+
+export interface PublicKeyResult {
+  /** Signing algorithm, e.g. RS256 (macOS) or ES256 (Linux/Windows). */
+  alg: string;
+  /** Public key as a JWK (for registration). */
+  jwk: Record<string, unknown>;
+  /** Public key as base64-encoded PKIX/SPKI DER. */
+  spki: string;
+}
+
+export interface KeylessSignerOptions {
+  /** Unit-test executable injection; production callers must leave unset. */
+  binaryPath?: string;
+  /** Device-key reference; defaults to DEFAULT_KEY_REF. */
+  keyRef?: string;
+  /** Unit-test resolver injection; production callers must leave unset. */
+  signerResolver?: () => ResolvedKeylessSigner;
+}
+
+type SignerOp = 'pubkey' | 'sign-attestation' | 'sign-assertion';
+
+interface SignerRequest {
+  op: SignerOp;
+  keyRef: string;
+  clientId?: string;
+  aud?: string;
+  nonce?: string;
+}
+
+interface SignerEnvelope {
+  ok?: boolean;
+  error?: { type?: string; message?: string };
+  alg?: string;
+  jwk?: Record<string, unknown>;
+  spki?: string;
+  attestation?: string;
+  client_assertion?: string;
+  client_assertion_type?: string;
+}
+
+export class KeylessSigner {
+  private readonly keyRef: string;
+  private readonly signerResolver: () => ResolvedKeylessSigner;
+
+  constructor(opts: KeylessSignerOptions = {}) {
+    this.keyRef = opts.keyRef?.trim() || DEFAULT_KEY_REF;
+    this.signerResolver =
+      opts.signerResolver ??
+      (opts.binaryPath ? () => resolveInjectedSigner(opts.binaryPath!) : () => resolvePlatformKeylessSigner());
+  }
+
+  /** Whether the signer package and executable are currently usable. */
+  static isAvailable(opts: KeylessSignerOptions = {}): boolean {
+    const resolver =
+      opts.signerResolver ??
+      (opts.binaryPath ? () => resolveInjectedSigner(opts.binaryPath!) : () => resolvePlatformKeylessSigner());
+    try {
+      const resolved = resolver();
+      assertSignerBinaryUnchanged(resolved);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Ensure the device key exists and return its public half (for registration). */
+  async getPublicKey(): Promise<PublicKeyResult> {
+    const res = await this.call({ op: 'pubkey', keyRef: this.keyRef });
+    const alg = res.alg;
+    if (
+      !alg ||
+      !['RS256', 'ES256'].includes(alg) ||
+      !res.jwk ||
+      typeof res.jwk !== 'object' ||
+      Array.isArray(res.jwk) ||
+      typeof res.spki !== 'string' ||
+      !res.spki
+    ) {
+      throw new KeylessSignerError('pubkey: signer returned no alg/jwk/spki');
+    }
+    const privateJwkMembers = ['d', 'p', 'q', 'dp', 'dq', 'qi', 'oth'];
+    if (privateJwkMembers.some((member) => member in res.jwk!)) {
+      throw new KeylessSignerError('pubkey: signer returned private JWK material');
+    }
+    return { alg, jwk: res.jwk, spki: res.spki };
+  }
+
+  /** Sign the onboard registration attestation binding the device key to the app. */
+  async signAttestation(nonce: string): Promise<string> {
+    if (!nonce.trim()) throw new KeylessSignerError('sign-attestation: nonce must be non-empty');
+    const res = await this.call({ op: 'sign-attestation', keyRef: this.keyRef, nonce });
+    if (typeof res.attestation !== 'string' || !res.attestation) {
+      throw new KeylessSignerError('sign-attestation: empty result');
+    }
+    return res.attestation;
+  }
+
+  /** Mint a short-lived RFC 7523 client_assertion for the token exchange. */
+  async signAssertion(clientId: string, aud: string): Promise<string> {
+    if (!clientId.trim() || !aud.trim()) {
+      throw new KeylessSignerError('sign-assertion: clientId and aud must be non-empty');
+    }
+    const res = await this.call({ op: 'sign-assertion', keyRef: this.keyRef, clientId, aud });
+    if (
+      res.client_assertion_type !== 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer' ||
+      typeof res.client_assertion !== 'string' ||
+      !res.client_assertion
+    ) {
+      throw new KeylessSignerError('sign-assertion: invalid assertion response');
+    }
+    return res.client_assertion;
+  }
+
+  private resolveForCall(): ResolvedKeylessSigner {
+    try {
+      // The package and executable are resolved anew for every operation, then
+      // the identity captured during inspection is checked again before spawn.
+      const resolved = this.signerResolver();
+      assertSignerBinaryUnchanged(resolved);
+      return resolved;
+    } catch (error) {
+      if (error instanceof KeylessSignerError) throw error;
+      throw new KeylessSignerError(
+        `keyless signer unavailable: ${error instanceof Error ? error.message : String(error)}`,
+        'signer_unavailable',
+      );
+    }
+  }
+
+  private call(req: SignerRequest): Promise<SignerEnvelope> {
+    const payload = JSON.stringify(req);
+    if (Buffer.byteLength(payload) > 64 * 1024) {
+      return Promise.reject(new KeylessSignerError('signer request exceeds 64 KiB'));
+    }
+    let executable: ResolvedKeylessSigner;
+    try {
+      executable = this.resolveForCall();
+    } catch (error) {
+      return Promise.reject(error);
+    }
+
+    return new Promise<SignerEnvelope>((resolve, reject) => {
+      const child = spawn(executable.binaryPath, [], {
+        cwd: executable.cwd,
+        env: executable.env,
+        shell: false,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
+      });
+      const stdout: Buffer[] = [];
+      const stderr: Buffer[] = [];
+      let stdoutBytes = 0;
+      let stderrBytes = 0;
+      let settled = false;
+
+      const finishError = (error: Error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        child.kill();
+        reject(error);
+      };
+      const timer = setTimeout(() => finishError(new KeylessSignerError('signer timed out after 10 seconds')), 10_000);
+
+      child.stdout.on('data', (chunk: Buffer) => {
+        stdoutBytes += chunk.length;
+        if (stdoutBytes > 1 << 20) {
+          finishError(new KeylessSignerError('signer stdout exceeds 1 MiB'));
+          return;
+        }
+        stdout.push(chunk);
+      });
+      child.stderr.on('data', (chunk: Buffer) => {
+        stderrBytes += chunk.length;
+        if (stderrBytes > 64 * 1024) {
+          finishError(new KeylessSignerError('signer stderr exceeds 64 KiB'));
+          return;
+        }
+        stderr.push(chunk);
+      });
+      child.on('error', (error) => finishError(new KeylessSignerError(`signer transport failed: ${error.message}`)));
+      child.stdin.on('error', () => {
+        // The close/error handler owns the transport result. Avoid an
+        // unhandled EPIPE if a malformed signer exits before reading stdin.
+      });
+      child.on('close', (code) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        const output = Buffer.concat(stdout).toString('utf8');
+        if (!output) {
+          reject(new KeylessSignerError(`signer transport failed (exit ${code ?? 'unknown'})`));
+          return;
+        }
+        let res: SignerEnvelope;
+        try {
+          res = JSON.parse(output) as SignerEnvelope;
+        } catch {
+          reject(new KeylessSignerError('signer produced non-JSON output'));
+          return;
+        }
+        if (!res || typeof res !== 'object' || Array.isArray(res)) {
+          reject(new KeylessSignerError('signer response must be a JSON object'));
+          return;
+        }
+        if (res.ok === false || res.error) {
+          if (typeof res.error?.type !== 'string' || typeof res.error.message !== 'string') {
+            reject(new KeylessSignerError('signer returned an invalid error envelope'));
+            return;
+          }
+          reject(new KeylessSignerError(res.error.message, res.error.type));
+          return;
+        }
+        if (res.ok !== true) {
+          reject(new KeylessSignerError('signer response is missing ok=true'));
+          return;
+        }
+        resolve(res);
+      });
+      child.stdin.end(payload);
+    });
+  }
+}

--- a/src/core/lark-client.ts
+++ b/src/core/lark-client.ts
@@ -21,6 +21,7 @@ import type { MessageDedup } from '../messaging/inbound/dedup';
 import { clearUserNameCache } from '../messaging/inbound/user-name-cache-store';
 import type { FeishuProbeResult, LarkAccount, LarkBrand } from './types';
 import { getLarkAccount } from './accounts';
+import { type ClientAssertionProvider, createClientAssertionProvider, isKeyless } from './client-assertion-provider';
 import { clearChatInfoCache, injectLarkClient } from './chat-info-cache';
 import { larkLogger } from './lark-logger';
 import { getLarkRuntime, setLarkRuntime } from './runtime-store';
@@ -64,6 +65,8 @@ export interface LarkClientCredentials {
   accountId?: string;
   appId?: string;
   appSecret?: string;
+  authMethod?: 'app_secret' | 'private_key_jwt';
+  keyRef?: string;
   brand?: LarkBrand;
 }
 
@@ -191,6 +194,8 @@ export class LarkClient {
     if (
       existing &&
       existing.account.appId === account.appId &&
+      existing.account.authMethod === account.authMethod &&
+      existing.account.keyRef === account.keyRef &&
       credentialsEqual(existing.account.appSecret, account.appSecret)
     ) {
       return existing;
@@ -218,10 +223,33 @@ export class LarkClient {
       config: {} as any,
     };
 
-    const account: LarkAccount =
-      credentials.appId && credentials.appSecret
-        ? { ...base, configured: true as const, appId: credentials.appId, appSecret: credentials.appSecret }
-        : { ...base, configured: false as const, appId: credentials.appId, appSecret: credentials.appSecret };
+    let account: LarkAccount;
+    if (credentials.appId && credentials.appSecret) {
+      // Preserve app-secret precedence when both credential forms are present.
+      account = {
+        ...base,
+        configured: true,
+        appId: credentials.appId,
+        appSecret: credentials.appSecret,
+      };
+    } else if (credentials.appId && credentials.authMethod === 'private_key_jwt' && credentials.keyRef) {
+      account = {
+        ...base,
+        configured: true,
+        authMethod: 'private_key_jwt',
+        appId: credentials.appId,
+        keyRef: credentials.keyRef,
+      };
+    } else {
+      account = {
+        ...base,
+        configured: false,
+        appId: credentials.appId,
+        appSecret: credentials.appSecret,
+        authMethod: credentials.authMethod,
+        keyRef: credentials.keyRef,
+      };
+    }
 
     return new LarkClient(account);
   }
@@ -253,10 +281,12 @@ export class LarkClient {
   /** Lazily-created Lark SDK client. */
   get sdk(): Lark.Client {
     if (!this._sdk) {
-      const { appId, appSecret } = this.requireCredentials();
+      const appId = this.requireAppId();
       this._sdk = new Lark.Client({
         appId,
-        appSecret,
+        ...(isKeyless(this.account)
+          ? { clientAssertionProvider: this.requireKeylessProvider() }
+          : { appSecret: this.requireAppSecret() }),
         appType: Lark.AppType.SelfBuild,
         domain: resolveBrand(this.account.brand),
       });
@@ -278,8 +308,8 @@ export class LarkClient {
       return this._lastProbeResult;
     }
 
-    if (!this.account.appId || !this.account.appSecret) {
-      return { ok: false, error: 'missing credentials (appId, appSecret)' };
+    if (!this.account.appId || (!isKeyless(this.account) && !this.account.appSecret)) {
+      return { ok: false, error: 'missing credentials (appId and authentication method)' };
     }
 
     try {
@@ -359,7 +389,7 @@ export class LarkClient {
     });
     dispatcher.register(handlers as any);
 
-    const { appId, appSecret } = this.requireCredentials();
+    const appId = this.requireAppId();
     // Close any existing WSClient before creating a new one to prevent
     // orphaned connections when startWS is called multiple times.
     if (this._wsClient) {
@@ -374,7 +404,9 @@ export class LarkClient {
 
     this._wsClient = new Lark.WSClient({
       appId,
-      appSecret,
+      ...(isKeyless(this.account)
+        ? { clientAssertionProvider: this.requireKeylessProvider() }
+        : { appSecret: this.requireAppSecret() }),
       domain: resolveBrand(this.account.brand),
       loggerLevel: Lark.LoggerLevel.info,
     });
@@ -429,14 +461,37 @@ export class LarkClient {
 
   // ---- Private helpers -------------------------------------------------------
 
-  /** Assert credentials exist or throw. */
-  private requireCredentials(): { appId: string; appSecret: string } {
+  /** Assert the application ID exists or throw. */
+  private requireAppId(): string {
     const appId = this.account.appId;
-    const appSecret = this.account.appSecret;
-    if (!appId || !appSecret) {
-      throw new Error(`LarkClient[${this.accountId}]: appId and appSecret are required`);
+    if (!appId) {
+      throw new Error(`LarkClient[${this.accountId}]: appId is required`);
     }
-    return { appId, appSecret };
+    return appId;
+  }
+
+  /** Assert the app-secret credential exists or throw. */
+  private requireAppSecret(): string {
+    const appSecret = this.account.appSecret;
+    if (!appSecret) {
+      throw new Error(`LarkClient[${this.accountId}]: appSecret is required`);
+    }
+    return appSecret;
+  }
+
+  /**
+   * Build the SDK client_assertion provider for a keyless account. Missing
+   * signer support is a configuration error: a keyless account must never
+   * silently fall back to app-secret authentication.
+   */
+  private requireKeylessProvider(): ClientAssertionProvider {
+    const provider = createClientAssertionProvider(this.account);
+    if (!provider) {
+      throw new Error(
+        `LarkClient[${this.accountId}]: invalid keyless account configuration; appId and keyRef are required`,
+      );
+    }
+    return provider;
   }
 
   /**

--- a/src/core/tool-client.ts
+++ b/src/core/tool-client.ts
@@ -32,6 +32,7 @@ import * as Lark from '@larksuiteoapi/node-sdk';
 import type { ClawdbotConfig } from 'openclaw/plugin-sdk';
 import type { ConfiguredLarkAccount } from './types';
 import { getEnabledLarkAccounts, getLarkAccount } from './accounts';
+import { createClientAssertionProvider } from './client-assertion-provider';
 import { LarkClient, getResolvedConfig } from './lark-client';
 import { getTicket } from './lark-ticket';
 import { callWithUAT } from './uat-client';
@@ -111,7 +112,7 @@ export type InvokeByPathOptions = InvokeOptions & {
 
 export class ToolClient {
   readonly config: ClawdbotConfig;
-  /** 当前解析的账号信息（appId、appSecret 保证存在）。 */
+  /** 当前解析的账号信息（appId 与所选认证凭据保证存在）。 */
   readonly account: ConfiguredLarkAccount;
 
   /** 当前请求的用户 open_id（来自 LarkTicket，可能为 undefined）。 */
@@ -365,13 +366,21 @@ export class ToolClient {
       }
     }
 
-    // 通过 callWithUAT 执行（自动 refresh + retry）
+    // 通过 callWithUAT 执行（自动 refresh + retry）。刷新 UAT 时复用账号的
+    // client authentication：secret 账号发 client_secret，keyless 账号签
+    // private_key_jwt，不在两种认证方式之间 fallback。
+    const clientAuthentication =
+      this.account.authMethod === 'private_key_jwt'
+        ? {
+            appId: this.account.appId,
+            clientAssertionProvider: createClientAssertionProvider(this.account)!,
+          }
+        : { appId: this.account.appId, appSecret: this.account.appSecret };
     try {
       return await callWithUAT(
         {
+          ...clientAuthentication,
           userOpenId,
-          appId: this.account.appId,
-          appSecret: this.account.appSecret,
           domain: this.account.brand,
         },
         (accessToken) => fn(this.sdk, Lark.withUserAccessToken(accessToken), accessToken),
@@ -486,7 +495,7 @@ export function createToolClient(config: ClawdbotConfig, accountIndex = 0): Tool
     const resolved = getLarkAccount(resolveConfig, ticket.accountId);
     if (!resolved.configured) {
       throw new Error(
-        `Feishu account "${ticket.accountId}" is not configured (missing appId or appSecret). ` +
+        `Feishu account "${ticket.accountId}" is not configured (missing appId or selected authentication credential). ` +
           `Please check channels.feishu.accounts.${ticket.accountId} in your config.`,
       );
     }
@@ -503,7 +512,7 @@ export function createToolClient(config: ClawdbotConfig, accountIndex = 0): Tool
     const accounts = getEnabledLarkAccounts(resolveConfig);
     if (accounts.length === 0) {
       throw new Error(
-        'No enabled Feishu accounts configured. ' + 'Please add appId and appSecret in config under channels.feishu',
+        'No enabled Feishu accounts configured. Add appId plus appSecret, or private_key_jwt plus keyRef, under channels.feishu.',
       );
     }
     if (accountIndex >= accounts.length) {
@@ -511,7 +520,7 @@ export function createToolClient(config: ClawdbotConfig, accountIndex = 0): Tool
     }
     const fallback = accounts[accountIndex];
     if (!fallback.configured) {
-      throw new Error(`Account at index ${accountIndex} is not fully configured (missing appId or appSecret)`);
+      throw new Error(`Account at index ${accountIndex} is missing appId or its selected authentication credential`);
     }
     account = fallback;
   }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -93,18 +93,46 @@ interface LarkAccountBase {
   config: FeishuConfig;
 }
 
-/** An account with both `appId` and `appSecret` present. */
-export type ConfiguredLarkAccount = LarkAccountBase & {
+/** Authentication method for a resolved account. */
+export type LarkAuthMethod = 'app_secret' | 'private_key_jwt';
+
+/**
+ * A configured account authenticated with the long-lived app secret: both
+ * `appId` and `appSecret` are present.
+ */
+export type ConfiguredSecretLarkAccount = LarkAccountBase & {
   configured: true;
+  authMethod?: 'app_secret';
   appId: string;
   appSecret: string;
+  keyRef?: undefined;
 };
 
-/** An account that is missing `appId` and/or `appSecret`. */
+/**
+ * A configured account authenticated keyless (private_key_jwt): `appId` and a
+ * `keyRef` (device-key label) are present, and there is no `appSecret`.
+ */
+export type ConfiguredKeylessLarkAccount = LarkAccountBase & {
+  configured: true;
+  authMethod: 'private_key_jwt';
+  appId: string;
+  keyRef: string;
+  appSecret?: undefined;
+};
+
+/**
+ * A configured account: either app-secret or keyless. `configured: true`
+ * guarantees `appId`; `appSecret` is present only on the app-secret variant.
+ */
+export type ConfiguredLarkAccount = ConfiguredSecretLarkAccount | ConfiguredKeylessLarkAccount;
+
+/** An account that is not configured (missing `appId`, or credentials for its auth method). */
 export type UnconfiguredLarkAccount = LarkAccountBase & {
   configured: false;
+  authMethod?: LarkAuthMethod;
   appId?: string;
   appSecret?: string;
+  keyRef?: string;
 };
 
 /** A resolved Lark account — either fully configured or not. */

--- a/src/core/uat-client.ts
+++ b/src/core/uat-client.ts
@@ -10,6 +10,7 @@
  */
 
 import type { LarkBrand } from './types';
+import type { DeviceClientAuthentication } from './device-flow';
 import {
   type StoredUAToken,
   getStoredToken,
@@ -18,7 +19,7 @@ import {
   setStoredToken,
   tokenStatus,
 } from './token-store';
-import { resolveOAuthEndpoints } from './device-flow';
+import { resolveClientAssertionAudience, resolveOAuthEndpoints } from './device-flow';
 import { larkLogger } from './lark-logger';
 
 const log = larkLogger('core/uat-client');
@@ -32,12 +33,12 @@ export { NeedAuthorizationError };
 // Types
 // ---------------------------------------------------------------------------
 
-export interface UATCallOptions {
+export type UATCallOptions = DeviceClientAuthentication & {
   userOpenId: string;
-  appId: string;
-  appSecret: string;
   domain: LarkBrand;
-}
+};
+
+const CLIENT_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
 
 export interface UATStatus {
   authorized: boolean;
@@ -75,18 +76,25 @@ async function doRefreshToken(opts: UATCallOptions, stored: StoredUAToken): Prom
   }
 
   const endpoints = resolveOAuthEndpoints(opts.domain);
-  const requestBody = new URLSearchParams({
-    grant_type: 'refresh_token',
-    refresh_token: stored.refreshToken,
-    client_id: opts.appId,
-    client_secret: opts.appSecret,
-  }).toString();
+  const assertionAudience = resolveClientAssertionAudience(opts.domain);
 
   const callEndpoint = async () => {
+    const requestBody = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: stored.refreshToken,
+      client_id: opts.appId,
+    });
+    if (opts.clientAssertionProvider) {
+      const assertion = await opts.clientAssertionProvider.retrieveToken(assertionAudience);
+      requestBody.set('client_assertion_type', CLIENT_ASSERTION_TYPE);
+      requestBody.set('client_assertion', assertion.value);
+    } else {
+      requestBody.set('client_secret', opts.appSecret);
+    }
     const resp = await feishuFetch(endpoints.token, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: requestBody,
+      body: requestBody.toString(),
     });
     return (await resp.json()) as Record<string, unknown>;
   };

--- a/src/tools/helpers.ts
+++ b/src/tools/helpers.ts
@@ -116,7 +116,7 @@ export function createClientGetter(config: ClawdbotConfig, accountIndex = 0): Cl
 
     if (accounts.length === 0) {
       throw new Error(
-        'No enabled Feishu accounts configured. ' + 'Please add appId and appSecret in config under channels.feishu',
+        'No enabled Feishu accounts configured. Add appId plus appSecret, or private_key_jwt plus keyRef, under channels.feishu.',
       );
     }
 
@@ -163,7 +163,7 @@ export function getFirstAccount(config: ClawdbotConfig): LarkAccount {
 
   if (accounts.length === 0) {
     throw new Error(
-      'No enabled Feishu accounts configured. ' + 'Please add appId and appSecret in config under channels.feishu',
+      'No enabled Feishu accounts configured. Add appId plus appSecret, or private_key_jwt plus keyRef, under channels.feishu.',
     );
   }
 

--- a/src/tools/oapi/task/attachment.ts
+++ b/src/tools/oapi/task/attachment.ts
@@ -7,14 +7,10 @@
  * Actions:
  * - upload: Upload task attachment (tenant identity)
  */
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import type { OpenClawPluginApi } from 'openclaw/plugin-sdk';
 import { Type } from '@sinclair/typebox';
 
 import { StringEnum, createToolContext, handleInvokeErrorWithAutoAuth, json, registerTool } from '../helpers';
-import { rawLarkRequest } from '../../../core/raw-request';
-
 
 // ---------------------------------------------------------------------------
 // Schema
@@ -96,36 +92,16 @@ export function registerFeishuTaskAttachmentTool(api: OpenClawPluginApi): void {
                     const file = new File([fileBuffer], p.name ?? 'attachment');
                     formData.append('file', file);
 
-                    const as = 'tenant';
-
-                    const tatRes = await rawLarkRequest<{
-                        tenant_access_token?: string;
-                        [k: string]: unknown;
-                    }>({
-                        brand: client.account.brand,
-                        path: '/open-apis/auth/v3/tenant_access_token/internal/',
-                        method: 'POST',
-                        body: {
-                            app_id: client.account.appId,
-                            app_secret: client.account.appSecret,
-                        },
-                    });
-                    const token = tatRes?.tenant_access_token;
-                    if (!token) {
-                        return json({
-                            error: 'Failed to get tenant_access_token.',
-                            response: tatRes,
-                        });
-                    }
-
-                    const res = await client.invokeByPath('feishu_task_attachment.upload', resolved.path, {
-                        method: 'POST',
-                        as,
-                        body: formData,
-                        headers: {
-                            'Authorization': `Bearer ${token}`,
-                        },
-                    });
+                    const res = await client.invoke(
+                        'feishu_task_attachment.upload',
+                        (sdk) =>
+                            sdk.request({
+                                method: 'POST',
+                                url: resolved.path,
+                                data: formData,
+                            }),
+                        { as: 'tenant' },
+                    );
                     return json(res);
                 } catch (err) {
                     return await handleInvokeErrorWithAutoAuth(err, cfg);

--- a/src/tools/oapi/task/task.ts
+++ b/src/tools/oapi/task/task.ts
@@ -29,7 +29,6 @@ import {
   registerTool,
 } from '../helpers';
 import type { PaginatedData, TaskCreateData } from '../sdk-types';
-import { rawLarkRequest } from '../../../core/raw-request';
 
 // ---------------------------------------------------------------------------
 // Schema
@@ -763,34 +762,19 @@ export function registerFeishuTaskTaskTool(api: OpenClawPluginApi): void {
                 });
               }
 
-              const tatRes = await rawLarkRequest(
-                {
-                  brand: client.account.brand,
-                  path: '/open-apis/auth/v3/tenant_access_token/internal/',
-                  method: 'POST',
-                  body: {
-                    app_id: client.sdk.appId,
-                    app_secret: client.sdk.appSecret,
-                  },
-                },
-              );;
-              const token = (tatRes as any)?.tenant_access_token ?? "";
-
-              const res = await client.invokeByPath(
+              const res = await client.invoke(
                 'feishu_task_task.append_steps',
-                '/open-apis/task/v2/agent_task_step_info/append_task_steps',
-                {
-                  method: 'POST',
-                  as: 'tenant',
-                  body: {
-                    task_guid: p.task_guid,
-                    idempotent_key: p.idempotent_key,
-                    task_steps: p.task_steps,
-                  },
-                  headers: {
-                    'authorization': `Bearer ${token}`,
-                  },
-                },
+                (sdk) =>
+                  sdk.request({
+                    method: 'POST',
+                    url: '/open-apis/task/v2/agent_task_step_info/append_task_steps',
+                    data: {
+                      task_guid: p.task_guid,
+                      idempotent_key: p.idempotent_key,
+                      task_steps: p.task_steps,
+                    },
+                  }),
+                { as: 'tenant' },
               );
               return json(res);
             }

--- a/src/tools/oapi/task/task_agent.ts
+++ b/src/tools/oapi/task/task_agent.ts
@@ -10,13 +10,10 @@
  *
 
  */
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import type { OpenClawPluginApi } from 'openclaw/plugin-sdk';
 import { Type } from '@sinclair/typebox';
 
 import { createToolContext, handleInvokeErrorWithAutoAuth, json, registerTool } from '../helpers';
-import { rawLarkRequest } from '../../../core/raw-request';
 
 // ---------------------------------------------------------------------------
 // Schema
@@ -76,52 +73,35 @@ export function registerFeishuTaskAgentTool(api: OpenClawPluginApi): void {
 
                     const client = toolClient();
 
-                    const tatRes = await rawLarkRequest(
-                        {
-                            brand: client.account.brand,
-                            path: '/open-apis/auth/v3/tenant_access_token/internal/',
-                            method: 'POST',
-                            body: {
-                                app_id: client.sdk.appId,
-                                app_secret: client.sdk.appSecret,
-                            },
-                        },
-                    );
-                    const token = (tatRes as any)?.tenant_access_token ?? "";
-
                     // Match openclaw-lark-task semantics:
                     // - register/update_profile use tenant identity (TAT)
-                    const as =
-                        normalizedAction === 'register' ||normalizedAction === 'update_profile'
-                            ? 'tenant'
-                            : 'user';
-
-
-
-
                     if (normalizedAction === 'update_profile') {
-                        const res = await client.invokeByPath('feishu_task_agent.update_profile', resolved.path, {
-                            method: 'POST',
-                            as,
-                            body: {
-                                profile_content: p.profile_content,
-                            },
-                            headers: {
-                                'authorization': `Bearer ${token}`,
-                            },
-                        });
+                        const res = await client.invoke(
+                            'feishu_task_agent.update_profile',
+                            (sdk) =>
+                                sdk.request({
+                                    method: 'POST',
+                                    url: resolved.path,
+                                    data: {
+                                        profile_content: p.profile_content,
+                                    },
+                                }),
+                            { as: 'tenant' },
+                        );
                         return json(res);
                     }
 
                     // register
                     if (normalizedAction === 'register') {
-                        const res = await client.invokeByPath('feishu_task_agent.register', resolved.path, {
-                            method: 'POST',
-                            as,
-                            headers: {
-                                'authorization': `Bearer ${token}`,
-                            },
-                        });
+                        const res = await client.invoke(
+                            'feishu_task_agent.register',
+                            (sdk) =>
+                                sdk.request({
+                                    method: 'POST',
+                                    url: resolved.path,
+                                }),
+                            { as: 'tenant' },
+                        );
                         return json(res);
                     }
                     return json({

--- a/src/tools/oauth-batch-auth.ts
+++ b/src/tools/oauth-batch-auth.ts
@@ -25,13 +25,16 @@ import { executeAuthorize } from './oauth';
 
 const log = larkLogger('tools/oauth-batch-auth');
 
+export const FEISHU_OAUTH_BATCH_AUTH_DESCRIPTION =
+  '飞书插件自身的批量授权工具，一次性授权 openclaw-lark 插件已开通的所有用户权限。' +
+  "仅在用户明确要求插件自身'授权所有权限'、'一次性授权'时使用。" +
+  '【严格排除】用户提到 lark-cli 或 CLI 时严禁调用；必须遵循 lark-shared 授权流程并通过 exec 执行 lark-cli auth login。' +
+  '插件自身的 keyless 用户授权使用 private_key_jwt，不要求配置 app secret。';
+
 const FeishuOAuthBatchAuthSchema = Type.Object(
   {},
   {
-    description:
-      '飞书批量授权工具。一次性授权应用已开通的所有用户权限（User Access Token scope）。' +
-      "【使用场景】用户明确要求'授权所有权限'、'一次性授权完成'时使用。" +
-      '【重要】禁止主动推荐此工具，仅在用户明确要求时使用。',
+    description: FEISHU_OAUTH_BATCH_AUTH_DESCRIPTION,
   },
 );
 
@@ -45,9 +48,7 @@ export function registerFeishuOAuthBatchAuthTool(api: OpenClawPluginApi): void {
     {
       name: 'feishu_oauth_batch_auth',
       label: 'Feishu: OAuth Batch Authorization',
-      description:
-        '飞书批量授权工具，一次性授权应用已开通的所有用户权限。' +
-        "仅在用户明确要求'授权所有权限'、'一次性授权'时使用。",
+      description: FEISHU_OAUTH_BATCH_AUTH_DESCRIPTION,
       parameters: FeishuOAuthBatchAuthSchema,
 
       async execute(_toolCallId: string, _params: unknown) {
@@ -63,10 +64,11 @@ export function registerFeishuOAuthBatchAuthTool(api: OpenClawPluginApi): void {
           const acct = getLarkAccount(cfg, ticket.accountId);
           if (!acct.configured) {
             return json({
-              error: `账号 ${ticket.accountId} 缺少 appId 或 appSecret 配置`,
+              error: `账号 ${ticket.accountId} 缺少 appId 或所选认证方式的完整凭据`,
             });
           }
           const account = acct; // Now we know it's ConfiguredLarkAccount
+
           const { appId } = account;
 
           // 1. 查询应用已开通的 user scope

--- a/src/tools/oauth.ts
+++ b/src/tools/oauth.ts
@@ -20,6 +20,7 @@ import type { ClawdbotConfig, OpenClawPluginApi } from 'openclaw/plugin-sdk';
 import { Type } from '@sinclair/typebox';
 import type { ConfiguredLarkAccount } from '../core/types';
 import { getLarkAccount } from '../core/accounts';
+import { createClientAssertionProvider } from '../core/client-assertion-provider';
 import { OwnerAccessDeniedError, assertOwnerAccessStrict } from '../core/owner-policy';
 import { LarkClient } from '../core/lark-client';
 import { getAppGrantedScopes } from '../core/app-scope-checker';
@@ -168,7 +169,7 @@ export function registerFeishuOAuthTool(api: OpenClawPluginApi): void {
         const acct = getLarkAccount(cfg, ticket.accountId);
         if (!acct.configured) {
           return json({
-            error: `账号 ${ticket.accountId} 缺少 appId 或 appSecret 配置`,
+            error: `账号 ${ticket.accountId} 缺少 appId 或所选认证方式的完整凭据`,
           });
         }
         const account = acct; // Now we know it's ConfiguredLarkAccount
@@ -273,7 +274,11 @@ export async function executeAuthorize(
     cfg,
     ticket,
   } = params;
-  const { appId, appSecret, brand, accountId } = account;
+  const { appId, brand, accountId } = account;
+  const clientAuthentication =
+    account.authMethod === 'private_key_jwt'
+      ? { appId, clientAssertionProvider: createClientAssertionProvider(account)! }
+      : { appId, appSecret: account.appSecret };
 
   // 0. Check if the user is the app owner (fail-close: 安全优先).
   const sdk = LarkClient.fromAccount(account).sdk;
@@ -431,8 +436,7 @@ export async function executeAuthorize(
 
   // 3. Request device authorisation.
   const deviceAuth = await requestDeviceAuthorization({
-    appId,
-    appSecret,
+    ...clientAuthentication,
     brand,
     scope: filteredScope,
   });
@@ -532,8 +536,7 @@ export async function executeAuthorize(
   let pendingFlowDelete = false;
   // Fire-and-forget – polling happens asynchronously.
   pollDeviceToken({
-    appId,
-    appSecret,
+    ...clientAuthentication,
     brand,
     deviceCode: deviceAuth.deviceCode,
     interval: deviceAuth.interval,

--- a/tests/accounts-merge.test.ts
+++ b/tests/accounts-merge.test.ts
@@ -86,6 +86,37 @@ describe('getLarkAccount – footer inheritance', () => {
   });
 });
 
+describe('getLarkAccountIds – top-level keyless default', () => {
+  it('includes default when named accounts coexist with top-level keyless credentials', () => {
+    const cfg = makeCfg({
+      appId: 'cli_keyless_default',
+      authMethod: 'private_key_jwt',
+      keyRef: 'openclaw-lark',
+      accounts: {
+        named: { appId: 'cli_named', appSecret: 'named_secret' },
+      },
+    });
+
+    expect(getLarkAccountIds(cfg)).toEqual(['default', 'named']);
+    const account = getLarkAccount(cfg, 'default');
+    expect(account.configured).toBe(true);
+    expect(account.authMethod).toBe('private_key_jwt');
+    expect(account.keyRef).toBe('openclaw-lark');
+  });
+
+  it('does not include an incomplete top-level keyless account', () => {
+    const cfg = makeCfg({
+      appId: 'cli_incomplete',
+      authMethod: 'private_key_jwt',
+      accounts: {
+        named: { appId: 'cli_named', appSecret: 'named_secret' },
+      },
+    });
+
+    expect(getLarkAccountIds(cfg)).toEqual(['named']);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Tests matching the user's real multi-account config structure
 // ---------------------------------------------------------------------------

--- a/tests/cli-auth-routing-contract.test.ts
+++ b/tests/cli-auth-routing-contract.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { FEISHU_OAUTH_BATCH_AUTH_DESCRIPTION } from '../src/tools/oauth-batch-auth';
+
+describe('lark-cli authorization routing contract', () => {
+  it('keeps explicit CLI requests away from the plugin batch OAuth tool', () => {
+    expect(FEISHU_OAUTH_BATCH_AUTH_DESCRIPTION).toContain('lark-cli');
+    expect(FEISHU_OAUTH_BATCH_AUTH_DESCRIPTION).toContain('严禁调用');
+    expect(FEISHU_OAUTH_BATCH_AUTH_DESCRIPTION).toContain('exec');
+  });
+
+  it('keeps plugin OAuth distinct and keyless-capable', () => {
+    expect(FEISHU_OAUTH_BATCH_AUTH_DESCRIPTION).toContain('插件自身的 keyless 用户授权');
+    expect(FEISHU_OAUTH_BATCH_AUTH_DESCRIPTION).toContain('不要求配置 app secret');
+  });
+
+  it('keeps the CLI routing rule in the always-active Feishu skill', () => {
+    const skill = readFileSync(join(process.cwd(), 'skills/feishu-channel-rules/SKILL.md'), 'utf8');
+
+    expect(skill).toContain('alwaysActive: true');
+    expect(skill).toContain('Never replace an explicit CLI authentication request');
+    expect(skill).toContain('lark-cli auth login --recommend --no-wait --json');
+    expect(skill).toContain('lark-cli auth login --domain all --no-wait --json');
+  });
+});

--- a/tests/client-assertion-provider.test.ts
+++ b/tests/client-assertion-provider.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { createClientAssertionProvider, isKeyless, resolveAuthMethod } from '../src/core/client-assertion-provider';
+import { FeishuAccountConfigSchema } from '../src/core/config-schema';
+
+describe('auth method resolution', () => {
+  it('defaults to app_secret', () => {
+    expect(resolveAuthMethod({})).toBe('app_secret');
+    expect(resolveAuthMethod({ authMethod: 'app_secret' })).toBe('app_secret');
+    expect(isKeyless({})).toBe(false);
+  });
+
+  it('detects keyless', () => {
+    expect(resolveAuthMethod({ authMethod: 'private_key_jwt' })).toBe('private_key_jwt');
+    expect(isKeyless({ authMethod: 'private_key_jwt' })).toBe(true);
+  });
+});
+
+describe('createClientAssertionProvider', () => {
+  it('returns null for an app_secret account', () => {
+    expect(createClientAssertionProvider({}, { binaryPath: '/nonexistent/lark-keyless-signer' })).toBeNull();
+  });
+
+  it('constructs lazily without probing the provider', () => {
+    expect(
+      createClientAssertionProvider({
+        appId: 'cli_keyless',
+        authMethod: 'private_key_jwt',
+        keyRef: 'openclaw-lark',
+      }),
+    ).not.toBeNull();
+  });
+
+  it('builds a provider for a keyless account when a binary path is given', () => {
+    // Construction must not throw even when the path is not a real binary;
+    // failures only surface when retrieveToken() is invoked.
+    const provider = createClientAssertionProvider(
+      {
+        appId: 'cli_keyless',
+        authMethod: 'private_key_jwt',
+        keyRef: 'openclaw-lark',
+      },
+      { binaryPath: '/nonexistent/lark-keyless-signer' },
+    );
+    expect(provider).not.toBeNull();
+    expect(typeof provider!.retrieveToken).toBe('function');
+  });
+
+  it('returns null for keyless config without an appId', () => {
+    expect(
+      createClientAssertionProvider(
+        { authMethod: 'private_key_jwt', keyRef: 'openclaw-lark' },
+        { binaryPath: '/nonexistent/lark-keyless-signer' },
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('keyless config schema', () => {
+  it('accepts authMethod and keyRef on an account', () => {
+    const r = FeishuAccountConfigSchema.safeParse({
+      authMethod: 'private_key_jwt',
+      keyRef: 'openclaw-lark',
+    });
+    expect(r.success).toBe(true);
+    expect(r.data!.authMethod).toBe('private_key_jwt');
+    expect(r.data!.keyRef).toBe('openclaw-lark');
+  });
+
+  it('rejects an unknown authMethod', () => {
+    const r = FeishuAccountConfigSchema.safeParse({ authMethod: 'oauth' });
+    expect(r.success).toBe(false);
+  });
+
+  it('defaults authMethod to undefined (app_secret at runtime)', () => {
+    const r = FeishuAccountConfigSchema.safeParse({});
+    expect(r.success).toBe(true);
+    expect(r.data!.authMethod).toBeUndefined();
+  });
+});

--- a/tests/device-flow-keyless.test.ts
+++ b/tests/device-flow-keyless.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ClientAssertionProvider } from '../src/core/client-assertion-provider';
+import { pollDeviceToken, requestDeviceAuthorization } from '../src/core/device-flow';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('OAuth device flow client authentication', () => {
+  it('uses a keyless client assertion for device authorization', async () => {
+    const retrieveToken = vi.fn(async (aud: string) => ({ value: `jwt:${aud}` }));
+    const provider: ClientAssertionProvider = { retrieveToken };
+    const fetchMock = vi.fn(
+      async (_input: string | URL | Request, _init?: RequestInit) =>
+        new Response(
+          JSON.stringify({
+            device_code: 'device-1',
+            user_code: 'user-1',
+            verification_uri: 'https://example.test/verify',
+            expires_in: 240,
+            interval: 5,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await requestDeviceAuthorization({
+      appId: 'cli_keyless',
+      clientAssertionProvider: provider,
+      brand: 'feishu',
+      scope: 'docs:document',
+    });
+
+    expect(retrieveToken).toHaveBeenCalledWith('open.feishu.cn');
+    const [, init] = fetchMock.mock.calls[0]!;
+    const body = new URLSearchParams(String(init?.body));
+    expect(body.get('client_id')).toBe('cli_keyless');
+    expect(body.get('client_assertion_type')).toBe('urn:ietf:params:oauth:client-assertion-type:jwt-bearer');
+    expect(body.get('client_assertion')).toBe('jwt:open.feishu.cn');
+    expect(body.has('client_secret')).toBe(false);
+    expect(new Headers(init?.headers).has('Authorization')).toBe(false);
+  });
+
+  it('does not log live device or user authorization codes', async () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              device_code: 'device-code-must-not-be-logged',
+              user_code: 'user-code-must-not-be-logged',
+              verification_uri: 'https://example.test/verify',
+              verification_uri_complete: 'https://example.test/verify?user_code=must-not-be-logged',
+              expires_in: 240,
+              interval: 5,
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          ),
+      ),
+    );
+
+    await requestDeviceAuthorization({
+      appId: 'cli_keyless',
+      clientAssertionProvider: { retrieveToken: async () => ({ value: 'assertion-must-not-be-logged' }) },
+      brand: 'feishu',
+    });
+
+    const logs = consoleLog.mock.calls.flat().map(String).join('\n');
+    expect(logs).not.toContain('device-code-must-not-be-logged');
+    expect(logs).not.toContain('user-code-must-not-be-logged');
+    expect(logs).not.toContain('assertion-must-not-be-logged');
+  });
+
+  it('mints a fresh keyless assertion for the token endpoint while polling', async () => {
+    const retrieveToken = vi.fn(async (aud: string) => ({ value: `jwt:${aud}` }));
+    const provider: ClientAssertionProvider = { retrieveToken };
+    const fetchMock = vi.fn(
+      async (_input: string | URL | Request, _init?: RequestInit) =>
+        new Response(
+          JSON.stringify({
+            access_token: 'uat-redacted',
+            refresh_token: 'refresh-redacted',
+            expires_in: 7200,
+            refresh_token_expires_in: 604800,
+            scope: 'docs:document',
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await pollDeviceToken({
+      appId: 'cli_keyless',
+      clientAssertionProvider: provider,
+      brand: 'feishu',
+      deviceCode: 'device-1',
+      interval: 0,
+      expiresIn: 10,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(retrieveToken).toHaveBeenCalledWith('open.feishu.cn');
+    const [, init] = fetchMock.mock.calls[0]!;
+    const body = new URLSearchParams(String(init?.body));
+    expect(body.get('client_assertion')).toBe('jwt:open.feishu.cn');
+    expect(body.has('client_secret')).toBe(false);
+  });
+
+  it('keeps HTTP Basic authentication for app-secret accounts', async () => {
+    const fetchMock = vi.fn(
+      async (_input: string | URL | Request, _init?: RequestInit) =>
+        new Response(
+          JSON.stringify({
+            device_code: 'device-1',
+            user_code: 'user-1',
+            verification_uri: 'https://example.test/verify',
+            expires_in: 240,
+            interval: 5,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await requestDeviceAuthorization({
+      appId: 'cli_secret',
+      appSecret: 'secret-redacted',
+      brand: 'feishu',
+    });
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect(new Headers(init?.headers).get('Authorization')).toMatch(/^Basic /);
+    const body = new URLSearchParams(String(init?.body));
+    expect(body.has('client_assertion')).toBe(false);
+  });
+});

--- a/tests/keyless-account-config.test.ts
+++ b/tests/keyless-account-config.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ClawdbotConfig } from 'openclaw/plugin-sdk';
+import { probeFeishu } from '../src/channel/probe';
+import { getLarkAccount, isConfigured } from '../src/core/accounts';
+import { LarkClient } from '../src/core/lark-client';
+
+function makeCfg(feishu: Record<string, unknown>): ClawdbotConfig {
+  return { channels: { feishu } } as unknown as ClawdbotConfig;
+}
+
+// ---------------------------------------------------------------------------
+// "configured" gate: keyless accounts count as configured; a bare appId does not
+// ---------------------------------------------------------------------------
+
+describe('getLarkAccount – keyless "configured" gate', () => {
+  it('treats appId + authMethod=private_key_jwt + keyRef (no secret) as configured', () => {
+    const cfg = makeCfg({
+      accounts: {
+        kl: { appId: 'cli_keyless', authMethod: 'private_key_jwt', keyRef: 'openclaw-lark' },
+      },
+    });
+
+    const account = getLarkAccount(cfg, 'kl');
+    expect(account.configured).toBe(true);
+    expect(account.enabled).toBe(true);
+    expect(account.appId).toBe('cli_keyless');
+    // Keyless accounts carry a keyRef and no appSecret.
+    if (isConfigured(account)) {
+      expect(account.authMethod).toBe('private_key_jwt');
+      expect(account.keyRef).toBe('openclaw-lark');
+      expect(account.appSecret).toBeUndefined();
+    }
+  });
+
+  it('does NOT treat a bare appId (no secret, not keyless) as configured', () => {
+    const cfg = makeCfg({ accounts: { bare: { appId: 'cli_bare' } } });
+    const account = getLarkAccount(cfg, 'bare');
+    expect(account.configured).toBe(false);
+  });
+
+  it('does NOT treat private_key_jwt without a keyRef as configured', () => {
+    const cfg = makeCfg({ accounts: { nokr: { appId: 'cli_x', authMethod: 'private_key_jwt' } } });
+    const account = getLarkAccount(cfg, 'nokr');
+    expect(account.configured).toBe(false);
+  });
+
+  it('keeps the app-secret account configured and unchanged (appSecret present, keyRef absent)', () => {
+    const cfg = makeCfg({ accounts: { s: { appId: 'cli_s', appSecret: 'sec' } } });
+    const account = getLarkAccount(cfg, 's');
+    expect(account.configured).toBe(true);
+    if (isConfigured(account)) {
+      expect(account.appSecret).toBe('sec');
+      expect(account.keyRef).toBeUndefined();
+    }
+  });
+
+  it('prefers the app-secret variant when both appSecret and keyRef are present', () => {
+    const cfg = makeCfg({
+      accounts: {
+        both: { appId: 'cli_b', appSecret: 'sec', authMethod: 'private_key_jwt', keyRef: 'openclaw-lark' },
+      },
+    });
+    const account = getLarkAccount(cfg, 'both');
+    expect(account.configured).toBe(true);
+    if (isConfigured(account)) {
+      expect(account.appSecret).toBe('sec');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Runtime: keyless injects a provider into both HTTP and WebSocket clients
+// ---------------------------------------------------------------------------
+
+describe('LarkClient – keyless runtime seam', () => {
+  afterEach(async () => {
+    await LarkClient.clearCache();
+  });
+
+  it('constructs and caches an HTTP SDK client without an appSecret', () => {
+    const cfg = makeCfg({
+      accounts: { kl: { appId: 'cli_keyless', authMethod: 'private_key_jwt', keyRef: 'openclaw-lark' } },
+    });
+    const client = LarkClient.fromCfg(cfg, 'kl');
+
+    const sdk = client.sdk;
+    expect(sdk).toBeTruthy();
+    expect(client.sdk).toBe(sdk);
+  });
+
+  it('probe reaches the SDK request path for a keyless account', async () => {
+    const cfg = makeCfg({
+      accounts: { kl2: { appId: 'cli_keyless2', authMethod: 'private_key_jwt', keyRef: 'openclaw-lark' } },
+    });
+    const client = LarkClient.fromCfg(cfg, 'kl2');
+    const request = vi.spyOn(client.sdk, 'request').mockResolvedValue({
+      code: 0,
+      data: { pingBotInfo: { botID: 'ou_keyless', botName: 'Keyless Bot' } },
+    });
+    const res = await client.probe();
+    expect(request).toHaveBeenCalledOnce();
+    expect(res.ok).toBe(true);
+    expect(res.appId).toBe('cli_keyless2');
+    expect(res.botOpenId).toBe('ou_keyless');
+  });
+
+  it('constructs a WebSocket client without an appSecret', async () => {
+    const cfg = makeCfg({
+      accounts: { kl3: { appId: 'cli_keyless3', authMethod: 'private_key_jwt', keyRef: 'openclaw-lark' } },
+    });
+    const client = LarkClient.fromCfg(cfg, 'kl3');
+    const controller = new AbortController();
+    controller.abort();
+
+    await client.startWS({ handlers: {}, autoProbe: false, abortSignal: controller.signal });
+    expect(client.wsConnected).toBe(false);
+  });
+
+  it('secret account still constructs the SDK client unchanged', () => {
+    const cfg = makeCfg({ accounts: { s: { appId: 'cli_s', appSecret: 'sec' } } });
+    const client = LarkClient.fromCfg(cfg, 's');
+    const sdk = client.sdk;
+    expect(sdk).toBeTruthy();
+    // A second access returns the same lazily-cached instance.
+    expect(client.sdk).toBe(sdk);
+  });
+});
+
+describe('probeFeishu – keyless credentials', () => {
+  it('accepts keyless credentials without requiring an appSecret', async () => {
+    const probe = vi.fn().mockResolvedValue({ ok: true, appId: 'cli_keyless' });
+    const factory = vi.spyOn(LarkClient, 'fromCredentials').mockReturnValue({ probe } as unknown as LarkClient);
+
+    try {
+      await expect(
+        probeFeishu({
+          appId: 'cli_keyless',
+          authMethod: 'private_key_jwt',
+          keyRef: 'openclaw-lark',
+        }),
+      ).resolves.toMatchObject({ ok: true, appId: 'cli_keyless' });
+      expect(factory).toHaveBeenCalledOnce();
+      expect(probe).toHaveBeenCalledOnce();
+    } finally {
+      factory.mockRestore();
+    }
+  });
+});

--- a/tests/keyless-signer-smoke.test.ts
+++ b/tests/keyless-signer-smoke.test.ts
@@ -1,0 +1,73 @@
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { KeylessSigner } from '../src/core/keyless-signer.ts';
+import { createClientAssertionProvider } from '../src/core/client-assertion-provider';
+
+// End-to-end smoke through an explicitly injected fake executable. Production
+// code never accepts a runtime path override and instead resolves the fixed
+// optional dependency for the current platform.
+const FAKE_SIGNER = `#!${process.execPath}
+let data = '';
+process.stdin.on('data', (c) => (data += c));
+process.stdin.on('end', () => {
+  const { op, keyRef, clientId, aud } = JSON.parse(data);
+  if (op === 'pubkey') {
+    process.stdout.write(JSON.stringify({ ok: true, alg: 'ES256', jwk: { kty: 'EC', crv: 'P-256' }, spki: Buffer.from('spki:' + keyRef).toString('base64') }));
+    return;
+  }
+  if (op === 'sign-assertion') {
+    process.stdout.write(JSON.stringify({ ok: true, client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer', client_assertion: ['jwt', clientId, aud, keyRef].join('.') }));
+    return;
+  }
+  process.stdout.write(JSON.stringify({ ok: false, error: { type: 'invalid_request', message: 'unknown op' } }));
+  process.exit(2);
+});
+`;
+
+describe.skipIf(process.platform === 'win32')('keyless signer subprocess smoke', () => {
+  let dir: string;
+  let bin: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'kl-smoke-'));
+    bin = join(dir, 'fake-signer.mjs');
+    writeFileSync(bin, FAKE_SIGNER);
+    chmodSync(bin, 0o755);
+  });
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('getPublicKey parses the subprocess envelope', async () => {
+    const { alg, jwk, spki } = await new KeylessSigner({
+      binaryPath: bin,
+      keyRef: 'openclaw-lark',
+    }).getPublicKey();
+    expect(alg).toBe('ES256');
+    expect(jwk.kty).toBe('EC');
+    expect(Buffer.from(spki, 'base64').toString()).toBe('spki:openclaw-lark');
+  });
+
+  it('signAssertion returns the subprocess result', async () => {
+    const assertion = await new KeylessSigner({ binaryPath: bin, keyRef: 'openclaw-lark' }).signAssertion(
+      'cli_app',
+      'open.feishu.cn',
+    );
+    expect(assertion).toBe('jwt.cli_app.open.feishu.cn.openclaw-lark');
+  });
+
+  it('createClientAssertionProvider.retrieveToken() drives the injected subprocess', async () => {
+    const provider = createClientAssertionProvider(
+      {
+        appId: 'cli_app',
+        authMethod: 'private_key_jwt',
+        keyRef: 'openclaw-lark',
+      },
+      { binaryPath: bin },
+    );
+    expect(provider).not.toBeNull();
+    const token = await provider!.retrieveToken('open.feishu.cn');
+    expect(token).toEqual({ value: 'jwt.cli_app.open.feishu.cn.openclaw-lark' });
+  });
+});

--- a/tests/keyless-signer.test.ts
+++ b/tests/keyless-signer.test.ts
@@ -1,0 +1,232 @@
+import { chmodSync, lstatSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_KEY_REF,
+  KeylessSigner,
+  type ResolvedKeylessSigner,
+  keylessSignerBinaryName,
+  keylessSignerPackageName,
+  resolveKeylessSignerPath,
+  resolvePlatformKeylessSigner,
+} from '../src/core/keyless-signer.ts';
+
+// A fake signer that speaks the IAM lark-keyless-signer protocol on stdin/stdout.
+// It lets us exercise the wrapper without the real (internal) binary. keyRef
+// "boom" forces an {ok:false,error} envelope so we can test error handling.
+const FAKE_SIGNER = `#!${process.execPath}
+let data = '';
+process.stdin.on('data', (c) => (data += c));
+process.stdin.on('end', () => {
+  if (process.argv.length !== 2) { process.stdout.write(JSON.stringify({ ok: false, error: { type: 'invalid_request', message: 'unexpected argv' } })); process.exit(2); }
+  let req;
+  try { req = JSON.parse(data); }
+  catch { process.stdout.write(JSON.stringify({ ok: false, error: { type: 'invalid_request', message: 'bad json' } })); process.exit(2); }
+  const { op, keyRef, clientId, aud, nonce } = req;
+  if (keyRef === 'boom') { process.stdout.write(JSON.stringify({ ok: false, error: { type: 'not_found', message: 'no such key' } })); process.exit(1); }
+  if (op === 'pubkey') { process.stdout.write(JSON.stringify({ ok: true, alg: 'RS256', jwk: { kty: 'RSA', n: 'x', e: 'AQAB' }, spki: Buffer.from('spki-' + keyRef).toString('base64') })); return; }
+  if (op === 'sign-attestation') { process.stdout.write(JSON.stringify({ ok: true, attestation: ['att', nonce, keyRef].join('.') })); return; }
+  if (op === 'sign-assertion') {
+    const clientAssertion = aud === 'report-env'
+      ? JSON.stringify({ home: process.env.HOME, nodeOptions: process.env.NODE_OPTIONS, path: process.env.PATH })
+      : ['assn', clientId, aud, keyRef].join('.');
+    process.stdout.write(JSON.stringify({ ok: true, client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer', client_assertion: clientAssertion }));
+    return;
+  }
+  process.stdout.write(JSON.stringify({ ok: false, error: { type: 'invalid_request', message: 'unknown op' } }));
+  process.exit(2);
+});
+`;
+
+function resolvedFakeSigner(binaryPath: string): ResolvedKeylessSigner {
+  const info = lstatSync(binaryPath);
+  return {
+    binaryPath,
+    cwd: dirname(binaryPath),
+    env: { HOME: process.env.HOME },
+    platform: process.platform,
+    identity: {
+      dev: info.dev,
+      ino: info.ino,
+      mode: info.mode,
+      size: info.size,
+      mtimeMs: info.mtimeMs,
+      ctimeMs: info.ctimeMs,
+    },
+  };
+}
+
+// Executing a shebang test fixture is a POSIX-only convenience; skip on Windows.
+describe.skipIf(process.platform === 'win32')('KeylessSigner against a fake signer', () => {
+  let dir: string;
+  let bin: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'kl-signer-'));
+    bin = join(dir, 'fake-signer.mjs');
+    writeFileSync(bin, FAKE_SIGNER);
+    chmodSync(bin, 0o755);
+  });
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('pubkey returns alg/jwk/spki', async () => {
+    const { alg, jwk, spki } = await new KeylessSigner({ binaryPath: bin }).getPublicKey();
+    expect(alg).toBe('RS256');
+    expect(jwk.kty).toBe('RSA');
+    expect(Buffer.from(spki, 'base64').toString()).toBe(`spki-${DEFAULT_KEY_REF}`);
+  });
+
+  it('sign-assertion sends keyRef/clientId/aud and returns client_assertion', async () => {
+    const signer = new KeylessSigner({ binaryPath: bin, keyRef: 'my-key' });
+    const assertion = await signer.signAssertion('cli_test', 'accounts.feishu.cn');
+    expect(assertion).toBe('assn.cli_test.accounts.feishu.cn.my-key');
+  });
+
+  it('sign-attestation sends keyRef/nonce and returns attestation', async () => {
+    const signer = new KeylessSigner({ binaryPath: bin, keyRef: 'my-key' });
+    expect(await signer.signAttestation('nonce123')).toBe('att.nonce123.my-key');
+  });
+
+  it('defaults keyRef to DEFAULT_KEY_REF', async () => {
+    const assertion = await new KeylessSigner({ binaryPath: bin }).signAssertion('cli_x', 'aud');
+    expect(assertion.endsWith(`.${DEFAULT_KEY_REF}`)).toBe(true);
+  });
+
+  it('rejects with the envelope error type/message on {ok:false}', async () => {
+    const signer = new KeylessSigner({ binaryPath: bin, keyRef: 'boom' });
+    await expect(signer.signAssertion('cli_test', 'aud')).rejects.toMatchObject({
+      name: 'KeylessSignerError',
+      type: 'not_found',
+      message: 'no such key',
+    });
+  });
+});
+
+describe('resolveKeylessSignerPath', () => {
+  it('uses the platform executable suffix', () => {
+    expect(keylessSignerBinaryName('win32')).toBe('lark-keyless-signer.exe');
+    expect(keylessSignerBinaryName('darwin')).toBe('lark-keyless-signer');
+    expect(keylessSignerBinaryName('linux')).toBe('lark-keyless-signer');
+  });
+
+  it('maps only supported platform packages', () => {
+    expect(keylessSignerPackageName('darwin', 'arm64')).toBe('@larksuite/lark-keyless-signer-darwin-arm64');
+    expect(keylessSignerPackageName('linux', 'x64')).toBe('@larksuite/lark-keyless-signer-linux-x64');
+    expect(keylessSignerPackageName('win32', 'x64')).toBe('@larksuite/lark-keyless-signer-win32-x64');
+    expect(keylessSignerPackageName('linux', 'riscv64')).toBeUndefined();
+  });
+
+  it('honors a valid explicit test path', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'kl-explicit-'));
+    const binaryPath = join(dir, 'lark-keyless-signer');
+    try {
+      writeFileSync(binaryPath, FAKE_SIGNER, { mode: 0o700 });
+      expect(resolveKeylessSignerPath(binaryPath)).toBe(binaryPath);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores the legacy runtime path override', () => {
+    const saved = process.env.LARK_KEYLESS_SIGNER_PATH;
+    process.env.LARK_KEYLESS_SIGNER_PATH = '/env/lark-keyless-signer';
+    try {
+      expect(resolveKeylessSignerPath()).not.toBe('/env/lark-keyless-signer');
+    } finally {
+      if (saved === undefined) delete process.env.LARK_KEYLESS_SIGNER_PATH;
+      else process.env.LARK_KEYLESS_SIGNER_PATH = saved;
+    }
+  });
+
+  it.skipIf(!resolveKeylessSignerPath())('resolves the current platform package and uses its root as cwd', () => {
+    const resolved = resolvePlatformKeylessSigner();
+    expect(resolved.binaryPath).toContain(`${keylessSignerPackageName()}/bin/${keylessSignerBinaryName()}`);
+    expect(resolved.cwd).toBe(dirname(dirname(resolved.binaryPath)));
+  });
+
+  it.skipIf(process.platform === 'win32')('passes only a minimal environment with the receiving HOME', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'kl-env-'));
+    const binaryPath = join(dir, 'lark-keyless-signer');
+    writeFileSync(binaryPath, FAKE_SIGNER, { mode: 0o700 });
+    const savedHome = process.env.HOME;
+    const savedNodeOptions = process.env.NODE_OPTIONS;
+    const savedPath = process.env.PATH;
+    process.env.HOME = '/tmp/receiving-user-home';
+    process.env.NODE_OPTIONS = '--require=/tmp/untrusted.js';
+    process.env.PATH = '/tmp/untrusted-bin';
+    try {
+      const assertion = await new KeylessSigner({ binaryPath }).signAssertion('cli_app', 'report-env');
+      expect(JSON.parse(assertion)).toEqual({ home: '/tmp/receiving-user-home' });
+    } finally {
+      if (savedHome === undefined) delete process.env.HOME;
+      else process.env.HOME = savedHome;
+      if (savedNodeOptions === undefined) delete process.env.NODE_OPTIONS;
+      else process.env.NODE_OPTIONS = savedNodeOptions;
+      if (savedPath === undefined) delete process.env.PATH;
+      else process.env.PATH = savedPath;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports availability consistently with optional-package resolution', () => {
+    const path = resolveKeylessSignerPath();
+    expect(KeylessSigner.isAvailable()).toBe(Boolean(path));
+    if (path) expect(path).toMatch(/[/\\]bin[/\\]lark-keyless-signer(?:\.exe)?$/);
+  });
+
+  it.skipIf(process.platform === 'win32')('re-resolves and rechecks the executable for every operation', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'kl-reresolve-'));
+    const binaryPath = join(dir, 'lark-keyless-signer');
+    writeFileSync(binaryPath, FAKE_SIGNER, { mode: 0o700 });
+    const signerResolver = vi.fn(() => resolvedFakeSigner(binaryPath));
+    const signer = new KeylessSigner({ keyRef: 'shared-key', signerResolver });
+    try {
+      await expect(signer.signAssertion('cli_app', 'aud-1')).resolves.toBe('assn.cli_app.aud-1.shared-key');
+      await expect(signer.signAssertion('cli_app', 'aud-2')).resolves.toBe('assn.cli_app.aud-2.shared-key');
+      expect(signerResolver).toHaveBeenCalledTimes(2);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(process.platform === 'win32')('rejects a non-executable regular file', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'kl-nonexec-'));
+    const binaryPath = join(dir, 'lark-keyless-signer');
+    writeFileSync(binaryPath, FAKE_SIGNER, { mode: 0o600 });
+    try {
+      await expect(new KeylessSigner({ binaryPath }).signAssertion('cli_app', 'aud')).rejects.toMatchObject({
+        type: 'unsafe_signer',
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a non-regular signer path', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'kl-not-regular-'));
+    try {
+      await expect(new KeylessSigner({ binaryPath: dir }).signAssertion('cli_app', 'aud')).rejects.toMatchObject({
+        type: 'unsafe_signer',
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed if the executable identity changes after resolution', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'kl-race-'));
+    const binaryPath = join(dir, 'lark-keyless-signer');
+    writeFileSync(binaryPath, FAKE_SIGNER, { mode: 0o700 });
+    const resolved = resolvedFakeSigner(binaryPath);
+    writeFileSync(binaryPath, `${FAKE_SIGNER}\n`, { mode: 0o700 });
+    try {
+      await expect(
+        new KeylessSigner({ signerResolver: () => resolved }).signAssertion('cli_app', 'aud'),
+      ).rejects.toMatchObject({ type: 'signer_raced' });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/task-keyless-tenant-request.test.ts
+++ b/tests/task-keyless-tenant-request.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  client: undefined as any,
+  tools: {} as Record<string, any>,
+}));
+
+vi.mock('../src/tools/oapi/helpers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/tools/oapi/helpers')>();
+  return {
+    ...actual,
+    createToolContext: () => ({
+      toolClient: () => state.client,
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    }),
+    registerTool: (_api: unknown, tool: { name: string }) => {
+      state.tools[tool.name] = tool;
+      return true;
+    },
+  };
+});
+
+import { registerFeishuTaskAttachmentTool } from '../src/tools/oapi/task/attachment';
+import { registerFeishuTaskTaskTool } from '../src/tools/oapi/task/task';
+import { registerFeishuTaskAgentTool } from '../src/tools/oapi/task/task_agent';
+
+describe('Task tenant requests use the SDK token chain', () => {
+  let invoke: ReturnType<typeof vi.fn>;
+  let request: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    state.tools = {};
+    request = vi.fn().mockResolvedValue({ code: 0, data: { ok: true } });
+    invoke = vi.fn(async (_action: string, fn: (sdk: unknown) => Promise<unknown>, _opts: unknown) => fn({ request }));
+    state.client = { invoke };
+
+    const api = { config: {}, logger: {}, registerTool: vi.fn() } as any;
+    registerFeishuTaskAttachmentTool(api);
+    registerFeishuTaskTaskTool(api);
+    registerFeishuTaskAgentTool(api);
+  });
+
+  it('uploads attachments through client.invoke and sdk.request', async () => {
+    await state.tools.feishu_task_attachment.execute('call-1', {
+      action: 'upload',
+      resource_id: 'task-1',
+      resource_type: 'task',
+      file: Buffer.from('hello').toString('base64'),
+      name: 'hello.txt',
+    });
+
+    expect(invoke).toHaveBeenCalledWith('feishu_task_attachment.upload', expect.any(Function), { as: 'tenant' });
+    expect(request).toHaveBeenCalledOnce();
+    const payload = request.mock.calls[0][0];
+    expect(payload).toMatchObject({
+      method: 'POST',
+      url: '/open-apis/task/v2/attachments/upload',
+    });
+    expect(payload.headers).toBeUndefined();
+    expect(payload.data).toBeInstanceOf(FormData);
+    expect(payload.data.get('resource_id')).toBe('task-1');
+  });
+
+  it('appends task steps through client.invoke and sdk.request', async () => {
+    await state.tools.feishu_task_task.execute('call-2', {
+      action: 'append_steps',
+      task_guid: 'task-guid',
+      idempotent_key: 'idem-1',
+      task_steps: [{ summary: 'step-1' }],
+    });
+
+    expect(invoke).toHaveBeenCalledWith('feishu_task_task.append_steps', expect.any(Function), { as: 'tenant' });
+    expect(request).toHaveBeenCalledWith({
+      method: 'POST',
+      url: '/open-apis/task/v2/agent_task_step_info/append_task_steps',
+      data: {
+        task_guid: 'task-guid',
+        idempotent_key: 'idem-1',
+        task_steps: [{ summary: 'step-1' }],
+      },
+    });
+  });
+
+  it('registers and updates a task agent through tenant SDK requests', async () => {
+    await state.tools.feishu_task_agent.execute('call-3', { action: 'register' });
+    await state.tools.feishu_task_agent.execute('call-4', {
+      action: 'update_profile',
+      profile_content: 'profile',
+    });
+
+    expect(invoke).toHaveBeenNthCalledWith(1, 'feishu_task_agent.register', expect.any(Function), { as: 'tenant' });
+    expect(invoke).toHaveBeenNthCalledWith(2, 'feishu_task_agent.update_profile', expect.any(Function), {
+      as: 'tenant',
+    });
+    expect(request).toHaveBeenNthCalledWith(1, {
+      method: 'POST',
+      url: '/open-apis/task/v2/agent/register_agent',
+    });
+    expect(request).toHaveBeenNthCalledWith(2, {
+      method: 'POST',
+      url: '/open-apis/task/v2/agent/update_agent_profile',
+      data: { profile_content: 'profile' },
+    });
+  });
+});

--- a/tests/uat-refresh-keyless.test.ts
+++ b/tests/uat-refresh-keyless.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ClientAssertionProvider } from '../src/core/client-assertion-provider';
+
+const mocks = vi.hoisted(() => ({
+  fetch: vi.fn(),
+  getStoredToken: vi.fn(),
+  removeStoredToken: vi.fn(),
+  setStoredToken: vi.fn(),
+  tokenStatus: vi.fn(),
+}));
+
+vi.mock('../src/core/feishu-fetch', () => ({ feishuFetch: mocks.fetch }));
+vi.mock('../src/core/token-store', () => ({
+  getStoredToken: mocks.getStoredToken,
+  maskToken: () => '***',
+  removeStoredToken: mocks.removeStoredToken,
+  setStoredToken: mocks.setStoredToken,
+  tokenStatus: mocks.tokenStatus,
+}));
+
+import { getValidAccessToken } from '../src/core/uat-client';
+
+describe('keyless UAT refresh', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getStoredToken.mockResolvedValue({
+      userOpenId: 'ou_user',
+      appId: 'cli_keyless',
+      accessToken: 'expired-access',
+      refreshToken: 'refresh-redacted',
+      expiresAt: Date.now() - 1,
+      refreshExpiresAt: Date.now() + 60_000,
+      scope: 'docs:document',
+      grantedAt: Date.now() - 10_000,
+    });
+    mocks.tokenStatus.mockReturnValue('needs_refresh');
+    mocks.fetch.mockResolvedValue({
+      json: async () => ({
+        code: 0,
+        access_token: 'new-access-redacted',
+        refresh_token: 'new-refresh-redacted',
+        expires_in: 7200,
+        refresh_token_expires_in: 604800,
+        scope: 'docs:document',
+      }),
+    });
+  });
+
+  it('authenticates refresh with private_key_jwt and never sends client_secret', async () => {
+    const retrieveToken = vi.fn(async (aud: string) => ({ value: `jwt:${aud}` }));
+    const clientAssertionProvider: ClientAssertionProvider = { retrieveToken };
+
+    await expect(
+      getValidAccessToken({
+        userOpenId: 'ou_user',
+        appId: 'cli_keyless',
+        clientAssertionProvider,
+        domain: 'feishu',
+      }),
+    ).resolves.toBe('new-access-redacted');
+
+    expect(retrieveToken).toHaveBeenCalledWith('open.feishu.cn');
+    const [, init] = mocks.fetch.mock.calls[0]! as [string, RequestInit];
+    const body = new URLSearchParams(String(init.body));
+    expect(body.get('client_assertion_type')).toBe('urn:ietf:params:oauth:client-assertion-type:jwt-bearer');
+    expect(body.get('client_assertion')).toBe('jwt:open.feishu.cn');
+    expect(body.has('client_secret')).toBe(false);
+    expect(mocks.setStoredToken).toHaveBeenCalledOnce();
+  });
+
+  it('keeps client_secret refresh authentication for secret accounts', async () => {
+    await expect(
+      getValidAccessToken({
+        userOpenId: 'ou_user',
+        appId: 'cli_secret',
+        appSecret: 'secret-redacted',
+        domain: 'feishu',
+      }),
+    ).resolves.toBe('new-access-redacted');
+
+    const [, init] = mocks.fetch.mock.calls[0]! as [string, RequestInit];
+    const body = new URLSearchParams(String(init.body));
+    expect(body.get('client_secret')).toBe('secret-redacted');
+    expect(body.has('client_assertion')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- add **private_key_jwt** account configuration through **authMethod** and **keyRef**, while preserving **app_secret** as the default and preferred path when both credential forms are present
- resolve the platform signer from fixed optional npm packages and invoke it through a bounded JSON subprocess protocol with path, symlink, ownership, permission, and race checks
- use short-lived client assertions for SDK clients, WebSocket clients, tenant token requests, OAuth device authorization, token polling, and user token refresh
- keep plugin OAuth authorization distinct from lark-cli authorization in tool descriptions and channel guidance
- add focused unit, contract, smoke, account-resolution, device-flow, refresh, and tenant-request tests

## Compatibility and security

- existing app-secret configurations keep their current behavior
- keyless accounts never silently fall back to app-secret authentication
- private-key material remains in the operating-system key facility and never enters the plugin process
- signer packages are platform-specific optional dependencies for macOS, Linux, and Windows

## Verification

- **pnpm test**: 61 test files passed; 492 tests passed, 1 skipped
- **pnpm typecheck**: passed
- **pnpm build**: passed
- **pnpm lint**: passed with 0 errors (25 existing warnings)

## Merge prerequisite

- the five **@larksuite/lark-keyless-signer-*** packages at **^1.0.0** are not yet available from the public npm registry
- until they are published, pnpm cannot generate a complete public lockfile and GitHub CI stops at **pnpm install --frozen-lockfile**
- after publication, regenerate **pnpm-lock.yaml** and rerun CI before merging